### PR TITLE
Add abort session fallback with retry mechanism

### DIFF
--- a/frontend/src/components/message/PromptInput.tsx
+++ b/frontend/src/components/message/PromptInput.tsx
@@ -63,7 +63,7 @@ export function PromptInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const sendPrompt = useSendPrompt(opcodeUrl, directory)
   const sendShell = useSendShell(opcodeUrl, directory)
-  const abortSession = useAbortSession(opcodeUrl, directory)
+  const abortSession = useAbortSession(opcodeUrl, directory, sessionID)
   const { data: messages } = useMessages(opcodeUrl, sessionID, directory)
   const { data: config } = useConfig(opcodeUrl)
   const { preferences, updateSettings } = useSettings()

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -62,7 +62,7 @@ export function SessionDetail() {
     repoDirectory,
   );
   const { isConnected, isReconnecting } = useSSE(opcodeUrl, repoDirectory);
-  const abortSession = useAbortSession(opcodeUrl, repoDirectory);
+  const abortSession = useAbortSession(opcodeUrl, repoDirectory, sessionId);
   const updateSession = useUpdateSession(opcodeUrl, repoDirectory);
   const { open: openSettings } = useSettingsDialog();
 


### PR DESCRIPTION
- Immediately re-enable input when user clicks Stop
- Retry abort API call every 3 seconds in background (max 10 retries)
- Force-complete messages locally so UI is not blocked
- Stop retrying when server confirms abort via SSE