### PR TITLE
Add opencode-manager version to health endpoint

### DIFF
--- a/frontend/src/components/settings/OpenCodeConfigManager.tsx
+++ b/frontend/src/components/settings/OpenCodeConfigManager.tsx
@@ -305,7 +305,12 @@ export function OpenCodeConfigManager() {
                 )}
                 {health.opencodeVersion && (
                   <p className="text-xs text-muted-foreground">
-                    v{health.opencodeVersion}
+                    OpenCode v{health.opencodeVersion}
+                  </p>
+                )}
+                {health.opencodeManagerVersion && (
+                  <p className="text-xs text-muted-foreground">
+                    Manager v{health.opencodeManagerVersion}
                   </p>
                 )}
               </div>

--- a/frontend/src/hooks/useServerHealth.ts
+++ b/frontend/src/hooks/useServerHealth.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { settingsApi } from '@/api/settings'
+import { API_BASE_URL } from '@/config'
 import { useMutation } from '@tanstack/react-query'
 import { useQueryClient } from '@tanstack/react-query'
 
@@ -13,11 +14,13 @@ interface HealthResponse {
   opencodeVersion: string | null
   opencodeMinVersion: string
   opencodeVersionSupported: boolean
+  opencodeManagerVersion: string | null
   error?: string
 }
 
 async function fetchHealth(): Promise<HealthResponse> {
-  const response = await fetch('/api/health')
+  const apiBaseUrl = API_BASE_URL.replace(/\/$/, '')
+  const response = await fetch(`${apiBaseUrl}/api/health`)
   if (!response.ok) {
     throw new Error('Health check failed')
   }


### PR DESCRIPTION
Allows upgrade tooling to verify upgrades.

Also added to the server status panel, which may be more controversial, so happy to remove or move if-preferred (or feel free to do as you will with it post-merge!)