### PR TITLE
Bust docker cache for uv/opencode installs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,6 +47,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            TOOLS_CACHEBUST=${{ github.run_id }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,6 @@ RUN curl -fsSL https://bun.sh/install | bash && \
     chmod -R 755 /opt/bun && \
     ln -s /opt/bun/bin/bun /usr/local/bin/bun
 
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    mv /root/.local/bin/uv /usr/local/bin/uv && \
-    mv /root/.local/bin/uvx /usr/local/bin/uvx && \
-    chmod +x /usr/local/bin/uv /usr/local/bin/uvx
 
 WORKDIR /app
 
@@ -57,7 +53,14 @@ RUN pnpm --filter frontend build
 
 FROM base AS runner
 
-RUN curl -fsSL https://opencode.ai/install | bash && \
+ARG TOOLS_CACHEBUST=0
+
+RUN echo "tools cachebust=${TOOLS_CACHEBUST}" > /dev/null && \
+    curl -LsSf https://astral.sh/uv/install.sh | UV_NO_MODIFY_PATH=1 sh && \
+    mv /root/.local/bin/uv /usr/local/bin/uv && \
+    mv /root/.local/bin/uvx /usr/local/bin/uvx && \
+    chmod +x /usr/local/bin/uv /usr/local/bin/uvx && \
+    curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path && \
     mv /root/.opencode /opt/opencode && \
     chmod -R 755 /opt/opencode && \
     ln -s /opt/opencode/bin/opencode /usr/local/bin/opencode


### PR DESCRIPTION
The OpenCode & UV versions in the released image aren't being updated.
This is especially annoying for OpenCode, e.g. I have removed by custom implementation of Agent Skills now that it is native.

This is 1 way of handling that...does mean a less nicely-layered image, but avoids needing to manually maintain pinned versions.