### PR TITLE
chore: add .gitattributes to enforce line endings to prevent startup crash on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+
+*.sh text eol=lf
+*.bash text eol=lf
+
+Dockerfile text eol=lf
+docker-compose.yml text eol=lf


### PR DESCRIPTION
Add .gitattributes file to ensure consistent line endings across different operating systems. Configure LF endings for shell scripts (.sh, .bash) and Docker files (Dockerfile, docker-compose.yml) to prevent execution issues on Unix-like systems while setting auto text handling for all other files.

### Description

__Environment:__

- OS: Windows 10/11
- Docker: Desktop for Windows with WSL2
- Build context: WSL or native Windows

__Problem:__

When building and running the Docker container on Windows, the container crashes immediately with:

```javascript
exec /docker-entrypoint.sh: no such file or directory
```

However, when inspecting the container, the file clearly exists at `/docker-entrypoint.sh` with correct permissions (`-rwxr-xr-x`).

__Root Cause:__

The issue is caused by __Windows line endings (CRLF)__ in `scripts/docker-entrypoint.sh`. When Git clones the repository on Windows, it automatically converts LF (Unix) line endings to CRLF (Windows) by default.

When the Linux container tries to execute the script, the shebang becomes `#!/bin/bash\r` (with the carriage return character), which the kernel cannot find, causing the "no such file or directory" error.

__Diagnosis:__

You can verify this is the issue by checking for carriage returns:

```bash
# Inside the container
cat -v /docker-entrypoint.sh | head -1
# If you see: #!/bin/bash^M
# The ^M indicates a CRLF line ending
```
