### PR TITLE
fix(frontend): iOS clipboard paste handling for text and images

### DIFF
--- a/frontend/src/components/message/PromptInput.tsx
+++ b/frontend/src/components/message/PromptInput.tsx
@@ -420,6 +420,14 @@ export const PromptInput = forwardRef<PromptInputHandle, PromptInputProps>(funct
     const isSecureContext = window.isSecureContext || (window.location.protocol === 'http:' && window.location.hostname === 'localhost')
 
     if (isIOS && isSecureContext && navigator.clipboard && navigator.clipboard.read) {
+      try {
+        const text = await navigator.clipboard.readText()
+        if (text && text.trim()) {
+          return
+        }
+      } catch (err) {
+      }
+      
       event.preventDefault()
       try {
         const clipboardItems = await navigator.clipboard.read()


### PR DESCRIPTION
### Summary

Fixes clipboard paste behavior on iOS Safari by properly detecting text vs image content and allowing the browser to handle text paste natively.

### Problem

On iOS Safari/Chrome, the synchronous `event.clipboardData` API doesn't reliably expose image content. The async Clipboard API (`navigator.clipboard.read()`) is required for reading images, but calling `event.preventDefault()` unconditionally breaks normal text pasting.

### Solution

Implemented a two-phase paste detection for iOS:

1. __Text check first__: Attempt to read text via `navigator.clipboard.readText()`

   - If text exists → early `return` to let browser handle text paste natively
   - If no text or read fails → proceed to image handling

2. __Image handling__: Only `preventDefault()` and use async Clipboard API when clipboard doesn't contain text

### Changes

- `frontend/src/components/message/PromptInput.tsx`: Added iOS-specific paste detection logic that preserves native text paste behavior while enabling image paste via async Clipboard API

### Testing

- Verified text paste works on iOS Safari
- Verified image paste works on iOS Safari
- Verified existing paste behavior unchanged on desktop browsers
