### PR TITLE
Fix invisible code blocks in dark mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -334,10 +334,3 @@ body {
   }
 }
 
-:root:not(.dark) .hljs-dark {
-  display: none;
-}
-
-.dark .hljs:not(.hljs-dark) {
-  display: none;
-}


### PR DESCRIPTION
## Summary
- Fix invisible code blocks in dark mode

## Problem
Code blocks were rendering as empty black rectangles in dark mode. The CSS rule 
`.dark .hljs:not(.hljs-dark) { display: none }` was hiding all syntax-highlighted 
content because no elements ever have the `hljs-dark` class applied.

Before:
<img width="1245" height="357" alt="image" src="https://github.com/user-attachments/assets/f1edb95d-628b-4236-ad88-8b96ceec798c" />



## Solution
Remove the dead CSS rules that referenced the non-existent `hljs-dark` class. 

After:

dark mode: 
<img width="1246" height="356" alt="image" src="https://github.com/user-attachments/assets/96a8adc3-9ea7-42b4-9963-c2105a8c1bfd" />

light mode:
<img width="1248" height="568" alt="image" src="https://github.com/user-attachments/assets/0ec3a466-ccc6-4368-bfbc-84b4010b4173" />


## Test plan
- [x] Verify code blocks are visible in dark mode (was broken)
- [x] Verify code blocks render correctly in light mode
- [x] Toggle between themes and confirm syntax highlighting works