### PR TITLE
docs: update recommended NodeJS version in docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS base
+FROM node:24.13.0 AS base
 
 RUN apt-get update && apt-get install -y \
     git \

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -7,7 +7,7 @@ Guide for setting up a local development environment.
 - [pnpm](https://pnpm.io/installation) - Package manager (required for workspaces)
 - [Bun](https://bun.sh) - Backend runtime
 - [OpenCode TUI](https://opencode.ai) - `npm install -g @opencode/tui`
-- [Node.js 22+](https://nodejs.org/en/about/previous-releases)
+- [Node.js 24+](https://nodejs.org/en/about/previous-releases)
 
 ## Installation
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -62,7 +62,7 @@ For contributors who want to develop locally instead of using Docker.
 - [pnpm](https://pnpm.io/installation) - Package manager (required for workspaces)
 - [Bun](https://bun.sh) - Backend runtime
 - [OpenCode TUI](https://opencode.ai) - `npm install -g @opencode/tui`
-- [Node.js 22+](https://nodejs.org/en/about/previous-releases)
+- [Node.js 24+](https://nodejs.org/en/about/previous-releases)
 
 ### Setup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ OpenCode Manager provides a web-based interface for OpenCode AI agents, allowing
 - [pnpm](https://pnpm.io) - Package manager
 - [Bun](https://bun.sh) - Backend runtime
 - [OpenCode TUI](https://opencode.ai) - `npm i -g @opencode/tui`
-- [Node.js 22+](https://nodejs.org/en/about/previous-releases)
+- [Node.js 24+](https://nodejs.org/en/about/previous-releases)
 
 ## Next Steps
 


### PR DESCRIPTION
- update recommended version from 18+ to 24+
- link to the NodeJS Releases page
- update Dockerfile to use node:24.13.0 as base image