### PR TITLE
Improve git settings UI and credential management

### DIFF
--- a/frontend/src/components/settings/GitCredentialDialog.tsx
+++ b/frontend/src/components/settings/GitCredentialDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Loader2, Key, Lock, AlertTriangle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
@@ -50,7 +50,15 @@ export function GitCredentialDialog({ open, onOpenChange, onSave, credential, is
           token: credential.type === 'pat' ? '' : credential.token
         })
       } else {
-        setFormData({ name: '', host: '', type: 'pat', token: '', username: '', sshPrivateKey: '', passphrase: '' })
+        setFormData({
+          name: '',
+          host: 'github.com',
+          type: 'pat',
+          token: '',
+          username: '',
+          sshPrivateKey: '',
+          passphrase: ''
+        })
       }
     }
   }, [open, credential])
@@ -151,7 +159,13 @@ export function GitCredentialDialog({ open, onOpenChange, onSave, credential, is
                 <Button
                   type="button"
                   variant={formData.type === 'pat' ? 'default' : 'outline'}
-                  onClick={() => setFormData({ ...formData, type: 'pat', sshPrivateKey: '', passphrase: '' })}
+                  onClick={() => setFormData({
+                    ...formData,
+                    type: 'pat',
+                    host: formData.type === 'pat' ? formData.host : 'github.com',
+                    sshPrivateKey: '',
+                    passphrase: ''
+                  })}
                   disabled={isSaving}
                   className="flex-1"
                 >
@@ -161,7 +175,12 @@ export function GitCredentialDialog({ open, onOpenChange, onSave, credential, is
                 <Button
                   type="button"
                   variant={formData.type === 'ssh' ? 'default' : 'outline'}
-                  onClick={() => setFormData({ ...formData, type: 'ssh', token: '' })}
+                  onClick={() => setFormData({
+                    ...formData,
+                    type: 'ssh',
+                    host: formData.type === 'ssh' ? formData.host : 'git@github.com',
+                    token: ''
+                  })}
                   disabled={isSaving}
                   className="flex-1"
                 >
@@ -251,24 +270,24 @@ export function GitCredentialDialog({ open, onOpenChange, onSave, credential, is
                 </div>
 
                 {showPassphraseInput && (
-                 <div className="space-y-2">
-                  <Label htmlFor="cred-passphrase">Passphrase</Label>
-                  <Input
-                    id="cred-passphrase"
-                    type="password"
-                    placeholder="Enter passphrase for SSH key"
-                    value={formData.passphrase || ''}
-                    onChange={(e) => setFormData({ ...formData, passphrase: e.target.value })}
-                    disabled={isSaving}
-                    autoComplete="new-password"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    This passphrase will be required for each git operation
-                  </p>
-                </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="cred-passphrase">Passphrase</Label>
+                    <Input
+                      id="cred-passphrase"
+                      type="password"
+                      placeholder="Enter passphrase for SSH key"
+                      value={formData.passphrase || ''}
+                      onChange={(e) => setFormData({ ...formData, passphrase: e.target.value })}
+                      disabled={isSaving}
+                      autoComplete="new-password"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      This passphrase will be required for each git operation
+                    </p>
+                  </div>
                 )}
 
-                 <div className="space-y-2">
+                <div className="space-y-2">
                   <Label htmlFor="test-passphrase">Passphrase for Test (if protected)</Label>
                   <Input
                     id="test-passphrase"
@@ -304,25 +323,28 @@ export function GitCredentialDialog({ open, onOpenChange, onSave, credential, is
           </div>
         </form>
 
-        <div className="flex justify-end gap-2 pt-2 sm:pt-4 px-4 sm:px-6 pb-4 sm:pb-6 flex-shrink-0">
+        <DialogFooter className="p-3 sm:p-4 border-t gap-2">
           <Button
             type="button"
             variant="outline"
             onClick={() => onOpenChange(false)}
             disabled={isSaving}
+            className="flex-1 sm:flex-none"
           >
             Cancel
           </Button>
           <Button
-            type="submit"
+            type="button"
+            onClick={handleSubmit}
             disabled={isSaving || !formData.name.trim() || !formData.host.trim() ||
                      (formData.type === 'pat' && !formData.token?.trim()) ||
                      (formData.type === 'ssh' && !formData.sshPrivateKey?.trim())}
+            className="flex-1 sm:flex-none"
           >
             {isSaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
             {credential ? 'Update' : 'Add'}
           </Button>
-        </div>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/frontend/src/components/settings/GitSettings.tsx
+++ b/frontend/src/components/settings/GitSettings.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useSettings } from '@/hooks/useSettings'
-import { Loader2, Plus, Trash2, Save, ChevronDown, ChevronRight, User, Key, Pencil } from 'lucide-react'
+import { Loader2, Plus, Trash2, Save, User, Key, Pencil } from 'lucide-react'
 import { showToast } from '@/lib/toast'
 import { GitCredentialDialog } from './GitCredentialDialog'
 import { Label } from '@/components/ui/label'
@@ -16,8 +16,7 @@ export function GitSettings() {
   const [hasChanges, setHasChanges] = useState(false)
   const [isCredentialDialogOpen, setIsCredentialDialogOpen] = useState(false)
   const [editingCredentialIndex, setEditingCredentialIndex] = useState<number | null>(null)
-  const [identityExpanded, setIdentityExpanded] = useState(true)
-  const [credentialsExpanded, setCredentialsExpanded] = useState(true)
+
 
   useEffect(() => {
     if (preferences) {
@@ -27,12 +26,10 @@ export function GitSettings() {
     }
   }, [preferences])
 
-  const checkForChanges = (newCredentials: GitCredential[], newIdentity: GitIdentity) => {
-    const currentCreds = JSON.stringify(preferences?.gitCredentials || [])
-    const newCreds = JSON.stringify(newCredentials)
+  const checkForIdentityChanges = (newIdentity: GitIdentity) => {
     const currentIdentity = preferences?.gitIdentity || { name: '', email: '' }
     const identityChanged = currentIdentity.name !== newIdentity.name || currentIdentity.email !== newIdentity.email
-    setHasChanges(currentCreds !== newCreds || identityChanged)
+    setHasChanges(identityChanged)
   }
 
   const openAddCredentialDialog = () => {
@@ -68,19 +65,31 @@ export function GitSettings() {
     }
 
     setGitCredentials(newCredentials)
-    checkForChanges(newCredentials, gitIdentity)
+    
+    try {
+      await updateSettingsAsync({ gitCredentials: newCredentials, gitIdentity })
+      showToast.success('Credential saved')
+    } catch {
+      showToast.error('Failed to save credential')
+    }
   }
 
-  const removeCredential = (index: number) => {
+  const removeCredential = async (index: number) => {
     const newCredentials = gitCredentials.filter((_, i) => i !== index)
     setGitCredentials(newCredentials)
-    checkForChanges(newCredentials, gitIdentity)
+
+    try {
+      await updateSettingsAsync({ gitCredentials: newCredentials, gitIdentity })
+      showToast.success('Credential deleted')
+    } catch {
+      showToast.error('Failed to delete credential')
+    }
   }
 
   const updateIdentity = (field: keyof GitIdentity, value: string) => {
     const newIdentity = { ...gitIdentity, [field]: value }
     setGitIdentity(newIdentity)
-    checkForChanges(gitCredentials, newIdentity)
+    checkForIdentityChanges(newIdentity)
   }
 
   const saveAll = async () => {
@@ -132,171 +141,151 @@ export function GitSettings() {
         )}
       </div>
 
-      <div className="divide-y divide-border">
-        <div>
-          <button
-            className="w-full flex items-center gap-3 px-6 py-3 hover:bg-accent/30 transition-colors"
-            onClick={() => setIdentityExpanded(!identityExpanded)}
-          >
-            {identityExpanded ? (
-              <ChevronDown className="w-4 h-4 text-muted-foreground" />
-            ) : (
-              <ChevronRight className="w-4 h-4 text-muted-foreground" />
-            )}
-            <User className="w-4 h-4 text-muted-foreground" />
-            <span className="font-medium">Identity</span>
-            <span className="text-xs text-muted-foreground ml-auto">
-              {gitIdentity.name || gitIdentity.email ? `${gitIdentity.name || 'No name'} <${gitIdentity.email || 'No email'}>` : 'Not configured'}
-            </span>
-          </button>
+       <div className="divide-y divide-border space-y-4 pb-4">
+         <div>
+            <div className="flex items-center gap-3 px-6 py-3">
+              <User className="w-4 h-4 text-muted-foreground" />
+              <span className="font-medium">Identity</span>
+              <span className="text-xs text-muted-foreground ml-auto">
+                {gitIdentity.name || gitIdentity.email ? `${gitIdentity.name || 'No name'} <${gitIdentity.email || 'No email'}>` : 'Not configured'}
+              </span>
+            </div>
 
-          {identityExpanded && (
-            <div className="px-6 pb-4 pt-2 space-y-4 ml-7">
+            <div className="px-6 space-y-4 sm:ml-7">
               <p className="text-sm text-muted-foreground">
                 Author identity used for git commits. Leave empty to use system defaults.
               </p>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="git-name">Name</Label>
-                  <Input
-                    id="git-name"
-                    placeholder="Your Name"
-                    value={gitIdentity.name}
-                    onChange={(e) => updateIdentity('name', e.target.value)}
-                    disabled={isSaving}
-                    className="bg-background border-border text-foreground placeholder:text-muted-foreground"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="git-email">Email</Label>
-                  <Input
-                    id="git-email"
-                    type="email"
-                    placeholder="you@example.com"
-                    value={gitIdentity.email}
-                    onChange={(e) => updateIdentity('email', e.target.value)}
-                    disabled={isSaving}
-                    className="bg-background border-border text-foreground placeholder:text-muted-foreground"
-                  />
-                </div>
-              </div>
+             <div className="grid pb-4 grid-cols-1 sm:grid-cols-2 gap-4">
+               <div className="space-y-2">
+                 <Label htmlFor="git-name">Name</Label>
+                 <Input
+                   id="git-name"
+                   placeholder="Your Name"
+                   value={gitIdentity.name}
+                   onChange={(e) => updateIdentity('name', e.target.value)}
+                   disabled={isSaving}
+                   className="bg-background border-border text-foreground placeholder:text-muted-foreground"
+                 />
+               </div>
+               <div className="space-y-2">
+                 <Label htmlFor="git-email">Email</Label>
+                 <Input
+                   id="git-email"
+                   type="email"
+                   placeholder="you@example.com"
+                   value={gitIdentity.email}
+                   onChange={(e) => updateIdentity('email', e.target.value)}
+                   disabled={isSaving}
+                   className="bg-background border-border text-foreground placeholder:text-muted-foreground"
+                 />
+               </div>
+             </div>
+           </div>
+         </div>
+
+         <div>
+            <div className="flex items-center gap-3 px-6 py-3">
+              <Key className="w-4 h-4 text-muted-foreground" />
+              <span className="font-medium">Credentials</span>
+              <span className="text-xs text-muted-foreground ml-auto">
+                {gitCredentials.length} configured
+              </span>
             </div>
-          )}
-        </div>
 
-        <div>
-          <button
-            className="w-full flex items-center gap-3 px-6 py-3 hover:bg-accent/30 transition-colors"
-            onClick={() => setCredentialsExpanded(!credentialsExpanded)}
-          >
-            {credentialsExpanded ? (
-              <ChevronDown className="w-4 h-4 text-muted-foreground" />
-            ) : (
-              <ChevronRight className="w-4 h-4 text-muted-foreground" />
-            )}
-            <Key className="w-4 h-4 text-muted-foreground" />
-            <span className="font-medium">Credentials</span>
-            <span className="text-xs text-muted-foreground ml-auto">
-              {gitCredentials.length} configured
-            </span>
-          </button>
-
-          {credentialsExpanded && (
-            <div className="px-6 pb-4 pt-2 space-y-4 ml-7">
+            <div className="px-6 space-y-4 sm:ml-7">
               <div className="flex items-center justify-between">
                 <p className="text-sm text-muted-foreground">
                   Credentials for cloning private repositories
                 </p>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={openAddCredentialDialog}
-                  disabled={isSaving}
-                >
-                  <Plus className="h-4 w-4 mr-2" />
-                  Add
-                </Button>
-              </div>
+               <Button
+                 type="button"
+                 variant="outline"
+                 size="sm"
+                 onClick={openAddCredentialDialog}
+                 disabled={isSaving}
+               >
+                 <Plus className="h-4 w-4 mr-2" />
+                 Add
+               </Button>
+             </div>
 
-              {gitCredentials.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-border p-4 text-center">
-                  <p className="text-sm text-muted-foreground">
-                    No credentials configured. Click "Add" to add credentials.
-                  </p>
-                </div>
-              ) : (
-                <div className="border border-border rounded-lg overflow-hidden">
-                  <table className="w-full text-sm">
-                     <thead className="bg-muted/50">
-                      <tr>
-                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Name</th>
-                        <th className="px-3 py-2 text-left font-medium text-muted-foreground hidden sm:table-cell">Host</th>
-                        <th className="px-3 py-2 text-left font-medium text-muted-foreground hidden sm:table-cell">Type</th>
-                        <th className="px-3 py-2 text-right font-medium text-muted-foreground">Actions</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-border">
-                      {gitCredentials.map((cred, index) => (
-                        <tr key={index} className="hover:bg-accent/30 transition-colors">
+             {gitCredentials.length === 0 ? (
+               <div className="rounded-lg border border-dashed border-border p-4 text-center">
+                 <p className="text-sm text-muted-foreground">
+                   No credentials configured. Click "Add" to add credentials.
+                 </p>
+               </div>
+             ) : (
+               <div className="border border-border rounded-lg overflow-hidden">
+                 <table className="w-full text-sm">
+                    <thead className="bg-muted/50">
+                     <tr>
+                       <th className="px-3 py-2 text-left font-medium text-muted-foreground">Name</th>
+                       <th className="px-3 py-2 text-left font-medium text-muted-foreground hidden sm:table-cell">Host</th>
+                       <th className="px-3 py-2 text-left font-medium text-muted-foreground hidden sm:table-cell">Type</th>
+                       <th className="px-3 py-2 text-right font-medium text-muted-foreground">Actions</th>
+                     </tr>
+                   </thead>
+                   <tbody className="divide-y divide-border">
+                     {gitCredentials.map((cred, index) => (
+                       <tr key={index} className="hover:bg-accent/30 transition-colors">
+                         <td className="px-3 py-2">
+                           <div>
+                             <span className="font-medium">{cred.name || 'Unnamed'}</span>
+                             <div className="text-xs text-muted-foreground sm:hidden">{cred.host}</div>
+                           </div>
+                         </td>
+                         <td className="px-3 py-2 text-muted-foreground hidden sm:table-cell">
+                           {cred.host}
+                         </td>
+                         <td className="px-3 py-2 text-muted-foreground hidden sm:table-cell">
+                           <span className="text-xs px-1.5 py-0.5 rounded bg-muted">
+                             {cred.type === 'ssh' ? 'SSH' : 'PAT'}
+                           </span>
+                          </td>
                           <td className="px-3 py-2">
-                            <div>
-                              <span className="font-medium">{cred.name || 'Unnamed'}</span>
-                              <div className="text-xs text-muted-foreground sm:hidden">{cred.host}</div>
+                            <div className="flex items-center justify-end gap-1">
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 w-7 p-0"
+                                onClick={(e) => handleEditClick(e, index)}
+                                disabled={isSaving}
+                                title="Edit"
+                              >
+                                <Pencil className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                                onClick={(e) => handleDeleteClick(e, index)}
+                                disabled={isSaving}
+                                title="Delete"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
                             </div>
                           </td>
-                          <td className="px-3 py-2 text-muted-foreground hidden sm:table-cell">
-                            {cred.host}
-                          </td>
-                          <td className="px-3 py-2 text-muted-foreground hidden sm:table-cell">
-                            <span className="text-xs px-1.5 py-0.5 rounded bg-muted">
-                              {cred.type === 'ssh' ? 'SSH' : 'PAT'}
-                            </span>
-                          </td>
-                            <td className="px-3 py-2">
-                              <div className="flex items-center justify-end gap-1">
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="sm"
-                                  className="h-7 w-7 p-0"
-                                  onClick={(e) => handleEditClick(e, index)}
-                                  disabled={isSaving}
-                                  title="Edit"
-                                >
-                                  <Pencil className="h-3.5 w-3.5" />
-                                </Button>
-                               <Button
-                                 type="button"
-                                 variant="ghost"
-                                 size="sm"
-                                 className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                                 onClick={(e) => handleDeleteClick(e, index)}
-                                 disabled={isSaving}
-                                 title="Delete"
-                               >
-                                 <Trash2 className="h-3.5 w-3.5" />
-                               </Button>
-                             </div>
-                           </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
+                       </tr>
+                     ))}
+                   </tbody>
+                 </table>
+               </div>
+             )}
+           </div>
+         </div>
+       </div>
 
-      <GitCredentialDialog
-        open={isCredentialDialogOpen}
-        onOpenChange={setIsCredentialDialogOpen}
-        onSave={saveCredential}
-        credential={editingCredentialIndex !== null ? gitCredentials[editingCredentialIndex] : undefined}
-        isSaving={isSaving}
-      />
+       <GitCredentialDialog
+         open={isCredentialDialogOpen}
+         onOpenChange={setIsCredentialDialogOpen}
+         onSave={saveCredential}
+         credential={editingCredentialIndex !== null ? gitCredentials[editingCredentialIndex] : undefined}
+         isSaving={isSaving || isUpdating}
+       />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Remove collapsible accordion UI from git settings
- Implement immediate credential CRUD with toast feedback
- Add default hosts (github.com for PAT, git@github.com for SSH)
- Improve responsive layout in credential dialog with DialogFooter

## Changes
- GitCredentialDialog: Add default hosts, preserve host on type switch, use DialogFooter
- GitSettings: Remove accordion state, immediate credential save/delete with toasts