### PR TITLE
fix: handle missing cost.cache in provider models

### DIFF
--- a/frontend/src/api/providers.ts
+++ b/frontend/src/api/providers.ts
@@ -19,7 +19,7 @@ export interface OpenCodeModel {
   cost: {
     input: number;
     output: number;
-    cache: {
+    cache?: {
       read: number;
       write: number;
     };
@@ -171,8 +171,8 @@ async function getProvidersFromOpenCodeServer(): Promise<{ providers: Provider[]
             cost: {
               input: openCodeModel.cost.input,
               output: openCodeModel.cost.output,
-              cache_read: openCodeModel.cost.cache.read,
-              cache_write: openCodeModel.cost.cache.write,
+              cache_read: openCodeModel.cost.cache?.read ?? 0,
+              cache_write: openCodeModel.cost.cache?.write ?? 0,
             },
             limit: {
               context: openCodeModel.limit.context,


### PR DESCRIPTION
- Fix model selector showing no models when provider payload omits cost.cache

Closes #129