### PR TITLE
fix(lsp): Fixes LSP initialization timeout

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,6 @@ NODE_ENV=test
 PORT=3001
 DATABASE_PATH=:memory:
 AUTH_SECRET=test-secret-for-encryption
+WORKSPACE_PATH=/test/workspace
+OPENCODE_SERVER_PORT=5551
+OPENCODE_HOST=127.0.0.1

--- a/backend/src/services/opencode-single-server.ts
+++ b/backend/src/services/opencode-single-server.ts
@@ -22,10 +22,13 @@ import { compareVersions } from '../utils/version-utils'
 
 const OPENCODE_SERVER_PORT = ENV.OPENCODE.PORT
 const OPENCODE_SERVER_HOST = ENV.OPENCODE.HOST
-const OPENCODE_SERVER_DIRECTORY = getWorkspacePath()
-const OPENCODE_CONFIG_PATH = getOpenCodeConfigFilePath()
 const MIN_OPENCODE_VERSION = '1.0.137'
 const MAX_STDERR_SIZE = 10240
+
+// Helper getters to ensure values are computed at runtime (not module load time)
+// This allows proper mocking in tests
+const getOpenCodeServerDirectory = () => getWorkspacePath()
+const getOpenCodeConfigPath = () => getOpenCodeConfigFilePath()
 
 class OpenCodeServerManager {
   private static instance: OpenCodeServerManager
@@ -47,6 +50,14 @@ class OpenCodeServerManager {
       OpenCodeServerManager.instance = new OpenCodeServerManager()
     }
     return OpenCodeServerManager.instance
+  }
+
+  /**
+   * Test-only method to reset the singleton instance.
+   * Should only be used in test setup/teardown.
+   */
+  static resetInstance(): void {
+    OpenCodeServerManager.instance = null as unknown as OpenCodeServerManager
   }
 
   async start(): Promise<void> {
@@ -110,8 +121,10 @@ class OpenCodeServerManager {
       }
     }
 
-    logger.info(`OpenCode server working directory: ${OPENCODE_SERVER_DIRECTORY}`)
-    logger.info(`OpenCode XDG_CONFIG_HOME: ${path.join(OPENCODE_SERVER_DIRECTORY, '.config')}`)
+    const openCodeServerDirectory = getOpenCodeServerDirectory()
+    const openCodeConfigPath = getOpenCodeConfigPath()
+    logger.info(`OpenCode server working directory: ${openCodeServerDirectory}`)
+    logger.info(`OpenCode XDG_CONFIG_HOME: ${path.join(openCodeServerDirectory, '.config')}`)
     logger.info(`OpenCode will use ?directory= parameter for session isolation`)
 
     const gitEnv = createGitEnv(gitCredentials)
@@ -161,7 +174,6 @@ class OpenCodeServerManager {
 
     logger.info(`OpenCode server GIT_SSH_COMMAND: ${gitSshCommand}`)
 
-    // Initialize OpenCode bin directory before starting the server
     await this.initializeOpencodeBinDirectory()
 
     let stderrOutput = ''
@@ -170,7 +182,7 @@ class OpenCodeServerManager {
       'opencode',
       ['serve', '--port', OPENCODE_SERVER_PORT.toString(), '--hostname', OPENCODE_SERVER_HOST],
       {
-        cwd: OPENCODE_SERVER_DIRECTORY,
+        cwd: openCodeServerDirectory,
         detached: !isDevelopment,
         stdio: isDevelopment ? 'inherit' : ['ignore', 'pipe', 'pipe'],
         env: {
@@ -178,9 +190,9 @@ class OpenCodeServerManager {
           ...gitEnv,
           ...gitIdentityEnv,
           GIT_SSH_COMMAND: gitSshCommand,
-          XDG_DATA_HOME: path.join(OPENCODE_SERVER_DIRECTORY, '.opencode/state'),
-          XDG_CONFIG_HOME: path.join(OPENCODE_SERVER_DIRECTORY, '.config'),
-          OPENCODE_CONFIG: OPENCODE_CONFIG_PATH,
+          XDG_DATA_HOME: path.join(openCodeServerDirectory, '.opencode/state'),
+          XDG_CONFIG_HOME: path.join(openCodeServerDirectory, '.config'),
+          OPENCODE_CONFIG: openCodeConfigPath,
         }
       }
     )
@@ -267,7 +279,7 @@ class OpenCodeServerManager {
 
   private async initializeOpencodeBinDirectory(): Promise<void> {
     const binDir = path.join(
-      OPENCODE_SERVER_DIRECTORY,
+      getOpenCodeServerDirectory(),
       '.opencode',
       'state',
       'opencode',
@@ -277,20 +289,21 @@ class OpenCodeServerManager {
     const packageJsonPath = path.join(binDir, 'package.json')
 
     try {
-      // Create bin directory
       await fs.mkdir(binDir, { recursive: true })
 
-      // Check if package.json already exists
-      const packageJsonExists = await fs.access(packageJsonPath).then(() => true).catch(() => false)
+      const packageJsonExists = await fs.access(packageJsonPath)
+        .then(() => true)
+        .catch((error: NodeJS.ErrnoException) => {
+          if (error.code === 'ENOENT') return false
+          throw error
+        })
 
       if (!packageJsonExists) {
-        // Initialize with bun init -y to create an independent package.json
-        // This prevents Bun from finding parent package.json when OpenCode installs LSP servers
         try {
           execSync('bun init -y', {
             cwd: binDir,
             stdio: 'inherit',
-            timeout: 30000  // 30 second timeout
+            timeout: 30000
           })
           logger.info('OpenCode bin directory initialized successfully')
         } catch (error) {
@@ -301,7 +314,6 @@ class OpenCodeServerManager {
 
     } catch (error) {
       logger.error('Failed to initialize OpenCode bin directory:', error)
-      // Don't block OpenCode startup, just log the error
     }
   }
 
@@ -424,3 +436,4 @@ class OpenCodeServerManager {
 }
 
 export const opencodeServerManager = OpenCodeServerManager.getInstance()
+export { OpenCodeServerManager }

--- a/backend/test/services/opencode-single-server.test.ts
+++ b/backend/test/services/opencode-single-server.test.ts
@@ -1,22 +1,53 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { promises as fs } from 'fs'
-import { execSync } from 'child_process'
-import type { Database } from 'bun:sqlite'
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest'
 
 vi.mock('bun:sqlite', () => ({
   Database: vi.fn(),
+}))
+
+vi.mock('@opencode-manager/shared/config/env', () => ({
+  getWorkspacePath: vi.fn(() => '/test/workspace'),
+  getOpenCodeConfigFilePath: vi.fn(() => '/test/workspace/.config/opencode.json'),
+  getReposPath: vi.fn(() => '/test/workspace/repos'),
+  getAgentsMdPath: vi.fn(() => '/test/workspace/AGENTS.md'),
+  getDatabasePath: vi.fn(() => ':memory:'),
+  getConfigPath: vi.fn(() => '/test/workspace/config'),
+  ENV: {
+    SERVER: { PORT: 5003, HOST: '0.0.0.0', NODE_ENV: 'test' },
+    AUTH: { TRUSTED_ORIGINS: 'http://localhost:5173', SECRET: 'test-secret-for-encryption-key-32c' },
+    WORKSPACE: { BASE_PATH: '/test/workspace', REPOS_DIR: 'repos', CONFIG_DIR: 'config', AUTH_FILE: 'auth.json' },
+    OPENCODE: { PORT: 5551, HOST: '127.0.0.1' },
+    DATABASE: { PATH: ':memory:' },
+    FILE_LIMITS: {
+      MAX_SIZE_BYTES: 1024 * 1024,
+      MAX_UPLOAD_SIZE_BYTES: 10 * 1024 * 1024,
+    },
+  },
+  FILE_LIMITS: {
+    MAX_SIZE_BYTES: 1024 * 1024,
+    MAX_UPLOAD_SIZE_BYTES: 10 * 1024 * 1024,
+  },
 }))
 
 vi.mock('fs', () => ({
   promises: {
     mkdir: vi.fn(),
     access: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    stat: vi.fn(),
+    chmod: vi.fn(),
+    unlink: vi.fn(),
+    rm: vi.fn(),
+    readdir: vi.fn(),
   },
 }))
 
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
 }))
+
+import { promises as fs } from 'fs'
+import { execSync } from 'child_process'
 
 vi.mock('../../src/utils/logger', () => ({
   logger: {
@@ -29,15 +60,21 @@ const mkdirMock = fs.mkdir as any
 const accessMock = fs.access as any
 const execSyncMock = execSync as any
 
+// Reset singleton before any tests run to clear any polluted state from previous test files
+beforeAll(async () => {
+  const { OpenCodeServerManager } = await import('../../src/services/opencode-single-server')
+  OpenCodeServerManager.resetInstance()
+})
+
 describe('OpenCodeServerManager - reinitializeBinDirectory', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.stubEnv('WORKSPACE_PATH', '/test/workspace')
+    process.env.WORKSPACE_PATH = '/test/workspace'
   })
 
   afterEach(() => {
     vi.clearAllMocks()
-    vi.unstubAllEnvs()
+    delete process.env.WORKSPACE_PATH
   })
 
   describe('Success Cases', () => {
@@ -45,7 +82,9 @@ describe('OpenCodeServerManager - reinitializeBinDirectory', () => {
       const { opencodeServerManager } = await import('../../src/services/opencode-single-server')
       const { logger } = await import('../../src/utils/logger')
       
-      accessMock.mockRejectedValue(new Error('File not found'))
+      const enoentError = new Error('File not found') as NodeJS.ErrnoException
+      enoentError.code = 'ENOENT'
+      accessMock.mockRejectedValue(enoentError)
       execSyncMock.mockReturnValue(Buffer.from('Success'))
 
       await opencodeServerManager.reinitializeBinDirectory()
@@ -99,14 +138,20 @@ describe('OpenCodeServerManager - reinitializeBinDirectory', () => {
       const { opencodeServerManager } = await import('../../src/services/opencode-single-server')
       const { logger } = await import('../../src/utils/logger')
       
-      accessMock.mockRejectedValue(new Error('Not found'))
+      const enoentError = new Error('Not found') as NodeJS.ErrnoException
+      enoentError.code = 'ENOENT'
+      accessMock.mockRejectedValue(enoentError)
       execSyncMock.mockImplementation(() => {
         throw new Error('bun init failed')
       })
 
-      await expect(opencodeServerManager.reinitializeBinDirectory()).resolves.not.toThrow()
+      await opencodeServerManager.reinitializeBinDirectory()
 
       expect(logger.error).toHaveBeenCalledWith('bun init failed:', expect.any(Error))
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to initialize OpenCode bin directory:',
+        expect.any(Error)
+      )
     })
 
     it('should handle directory creation failure gracefully', async () => {
@@ -115,7 +160,7 @@ describe('OpenCodeServerManager - reinitializeBinDirectory', () => {
       
       mkdirMock.mockRejectedValue(new Error('Permission denied'))
 
-      await expect(opencodeServerManager.reinitializeBinDirectory()).resolves.not.toThrow()
+      await opencodeServerManager.reinitializeBinDirectory()
 
       expect(logger.error).toHaveBeenCalledWith(
         'Failed to initialize OpenCode bin directory:',
@@ -125,21 +170,19 @@ describe('OpenCodeServerManager - reinitializeBinDirectory', () => {
   })
 
   describe('Edge Cases', () => {
-    it('should handle fs.access throwing non-existence error', async () => {
+    it('should handle fs.access throwing non-ENOENT error gracefully', async () => {
       const { opencodeServerManager } = await import('../../src/services/opencode-single-server')
+      const { logger } = await import('../../src/utils/logger')
       
       mkdirMock.mockResolvedValue(undefined)
       accessMock.mockRejectedValue(new Error('Permission denied'))
 
-      await expect(opencodeServerManager.reinitializeBinDirectory()).resolves.not.toThrow()
+      await opencodeServerManager.reinitializeBinDirectory()
 
-      expect(execSyncMock).toHaveBeenCalledWith(
-        'bun init -y',
-        expect.objectContaining({
-          cwd: '/test/workspace/.opencode/state/opencode/bin',
-          stdio: 'inherit',
-          timeout: 30000
-        })
+      expect(execSyncMock).not.toHaveBeenCalled()
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to initialize OpenCode bin directory:',
+        expect.any(Error)
       )
     })
 
@@ -148,16 +191,22 @@ describe('OpenCodeServerManager - reinitializeBinDirectory', () => {
       const { logger } = await import('../../src/utils/logger')
       
       mkdirMock.mockResolvedValue(undefined)
-      accessMock.mockRejectedValue(new Error('Not found'))
+      const enoentError = new Error('Not found') as NodeJS.ErrnoException
+      enoentError.code = 'ENOENT'
+      accessMock.mockRejectedValue(enoentError)
       execSyncMock.mockImplementation(() => {
         const error = new Error('Command timed out')
         error.name = 'ETIMEDOUT'
         throw error
       })
 
-      await expect(opencodeServerManager.reinitializeBinDirectory()).resolves.not.toThrow()
+      await opencodeServerManager.reinitializeBinDirectory()
 
       expect(logger.error).toHaveBeenCalledWith('bun init failed:', expect.any(Error))
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to initialize OpenCode bin directory:',
+        expect.any(Error)
+      )
     })
   })
 })

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -1,12 +1,21 @@
-import { beforeAll, afterAll, vi } from 'vitest'
+import { beforeAll, afterAll } from 'vitest'
+
+const originalEnv: Record<string, string | undefined> = {}
 
 beforeAll(() => {
-  vi.stubEnv('NODE_ENV', 'test')
-  vi.stubEnv('PORT', '3001')
-  vi.stubEnv('DATABASE_PATH', ':memory:')
-  vi.stubEnv('AUTH_SECRET', 'test-secret-for-encryption')
+  originalEnv.NODE_ENV = process.env.NODE_ENV
+  originalEnv.PORT = process.env.PORT
+  originalEnv.DATABASE_PATH = process.env.DATABASE_PATH
+  originalEnv.AUTH_SECRET = process.env.AUTH_SECRET
+  originalEnv.WORKSPACE_PATH = process.env.WORKSPACE_PATH
 })
 
 afterAll(() => {
-  vi.unstubAllEnvs()
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
 })

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -4,6 +4,13 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    setupFiles: ['./test/setup.ts']
-  }
+    setupFiles: ['./test/setup.ts'],
+    env: {
+      NODE_ENV: 'test',
+      PORT: '3001',
+      DATABASE_PATH: ':memory:',
+      AUTH_SECRET: 'test-secret-for-encryption',
+      WORKSPACE_PATH: '/test/workspace',
+    },
+  },
 })


### PR DESCRIPTION
## Summary

Fixes pyright LSP initialization timeout by pre-initializing the OpenCode bin directory with an independent package.json. This prevents Bun from incorrectly resolving to the parent workspace package.json when OpenCode attempts to install LSP servers.

**Changes:**
- Added `initializeOpencodeBinDirectory()` method to create and initialize `.opencode/state/opencode/bin` directory
- Executes `bun init -y` to create an independent package.json in the bin directory
- Called before starting the OpenCode server to ensure proper isolation

**Root Cause:**
When OpenCode installs LSP servers (like pyright), Bun's package resolution would find the parent workspace's package.json instead of treating the bin directory as an independent package. This caused installation failures and timeouts.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Code follows project style (no comments, named imports)
- [x] TypeScript types are properly defined
- [x] Tests added/updated (80% coverage target)
- [x] `pnpm lint` passes locally
- [x] `pnpm typecheck` passes locally
