### PR TITLE
Fix global schedule creation with repo selector and repair broken mutations

### DIFF
--- a/frontend/src/components/schedules/ScheduleJobDialog.tsx
+++ b/frontend/src/components/schedules/ScheduleJobDialog.tsx
@@ -4,6 +4,8 @@ import type { CreateScheduleJobRequest, PromptTemplate, ScheduleJob } from '@ope
 import { getProvidersWithModels } from '@/api/providers'
 import { createOpenCodeClient } from '@/api/opencode'
 import { settingsApi } from '@/api/settings'
+import { listRepos } from '@/api/repos'
+import type { Repo } from '@/api/types'
 import { OPENCODE_API_ENDPOINT } from '@/config'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -26,6 +28,7 @@ import {
   type SchedulePreset,
   weekdayOptions,
 } from '@/components/schedules/schedule-utils'
+import { getRepoDisplayName } from '@/lib/utils'
 import { Check, Info, Loader2, Pencil, Plus, Sparkles, Trash2 } from 'lucide-react'
 import { usePromptTemplates, useDeletePromptTemplate } from '@/hooks/usePromptTemplates'
 import { PromptTemplateDialog } from './PromptTemplateDialog'
@@ -37,6 +40,9 @@ type ScheduleJobDialogProps = {
   job?: ScheduleJob
   isSaving: boolean
   onSubmit: (data: CreateScheduleJobRequest) => void
+  showRepoSelector?: boolean
+  repoId?: number
+  onRepoChange?: (repoId: number | undefined) => void
 }
 
 function InfoHint({ text }: { text: string }) {
@@ -51,7 +57,7 @@ function InfoHint({ text }: { text: string }) {
   )
 }
 
-export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit }: ScheduleJobDialogProps) {
+export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit, showRepoSelector, repoId: selectedRepoId, onRepoChange }: ScheduleJobDialogProps) {
   const [schedulePreset, setSchedulePreset] = useState<SchedulePreset>('interval')
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
@@ -111,6 +117,24 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit 
     enabled: open,
     staleTime: 5 * 60 * 1000,
   })
+
+  const { data: repos = [] } = useQuery<Repo[]>({
+    queryKey: ['repos'],
+    queryFn: listRepos,
+    enabled: open && !!showRepoSelector,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const repoOptions = useMemo<ComboboxOption[]>(() =>
+    repos
+      .filter((repo) => repo.cloneStatus === 'ready')
+      .map((repo) => ({
+        value: repo.id.toString(),
+        label: getRepoDisplayName(repo.repoUrl, repo.localPath, repo.sourcePath),
+        description: repo.localPath,
+      })),
+    [repos]
+  )
 
   const modelOptions = useMemo<ComboboxOption[]>(() => {
     const configuredModels: ComboboxOption[] = []
@@ -269,6 +293,18 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit 
 
           <TabsContent value="basics" className="mt-0 min-h-0 flex-1 overflow-y-auto pt-4 pb-5">
             <div className="space-y-4">
+              {showRepoSelector && !job && (
+                <div className="space-y-2">
+                  <Label>Repository</Label>
+                  <Combobox
+                    value={selectedRepoId?.toString() ?? ''}
+                    onChange={(value) => onRepoChange?.(value ? Number(value) : undefined)}
+                    options={repoOptions}
+                    placeholder="Select a repository"
+                    allowCustomValue={false}
+                  />
+                </div>
+              )}
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
                   <Label htmlFor="schedule-name">Name</Label>
@@ -637,7 +673,7 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit 
 
         <div className="mt-0 shrink-0 border-t border-border px-3 sm:px-6 py-4 flex flex-row gap-2 sm:justify-end">
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving} className="flex-1 sm:flex-none">Cancel</Button>
-          <Button onClick={handleSubmit} disabled={isSaving || !name.trim() || !prompt.trim() || isScheduleConfigInvalid} className="flex-1 sm:flex-none">
+          <Button onClick={handleSubmit} disabled={isSaving || !name.trim() || !prompt.trim() || isScheduleConfigInvalid || (!!showRepoSelector && !job && !selectedRepoId)} className="flex-1 sm:flex-none">
             {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
             {isSaving ? 'Saving...' : job ? 'Save changes' : 'Create schedule'}
           </Button>

--- a/frontend/src/hooks/useSchedules.ts
+++ b/frontend/src/hooks/useSchedules.ts
@@ -77,15 +77,17 @@ export function useCreateRepoSchedule(repoId: number | undefined) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (data: CreateScheduleJobRequest) => {
-      const response = await createRepoSchedule(repoId!, data)
+    mutationFn: async ({ repoId: callRepoId, data }: { repoId?: number; data: CreateScheduleJobRequest }) => {
+      const resolvedRepoId = callRepoId ?? repoId
+      const response = await createRepoSchedule(resolvedRepoId!, data)
       return response.job
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['repo-schedules', repoId] })
+    onSuccess: (__variables) => {
+      queryClient.invalidateQueries({ queryKey: ['repo-schedules', __variables.repoId ?? repoId] })
+      queryClient.invalidateQueries({ queryKey: ['all-schedules'] })
       showToast.success('Schedule created')
     },
-    onError: (error) => {
+    onError: (error: unknown) => {
       showToast.error(`Failed to create schedule: ${error instanceof Error ? error.message : String(error)}`)
     },
   })
@@ -95,16 +97,18 @@ export function useUpdateRepoSchedule(repoId: number | undefined) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ jobId, data }: { jobId: number; data: UpdateScheduleJobRequest }) => {
-      const response = await updateRepoSchedule(repoId!, jobId, data)
+    mutationFn: async ({ repoId: callRepoId, jobId, data }: { repoId?: number; jobId: number; data: UpdateScheduleJobRequest }) => {
+      const resolvedRepoId = callRepoId ?? repoId
+      const response = await updateRepoSchedule(resolvedRepoId!, jobId, data)
       return response.job
     },
-    onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['repo-schedules', repoId] })
-      queryClient.invalidateQueries({ queryKey: ['repo-schedule', repoId, variables.jobId] })
+    onSuccess: (__variables) => {
+      queryClient.invalidateQueries({ queryKey: ['repo-schedules', __variables.repoId ?? repoId] })
+      queryClient.invalidateQueries({ queryKey: ['repo-schedule', __variables.repoId ?? repoId, __variables.jobId] })
+      queryClient.invalidateQueries({ queryKey: ['all-schedules'] })
       showToast.success('Schedule updated')
     },
-    onError: (error) => {
+    onError: (error: unknown) => {
       showToast.error(`Failed to update schedule: ${error instanceof Error ? error.message : String(error)}`)
     },
   })
@@ -114,12 +118,16 @@ export function useDeleteRepoSchedule(repoId: number | undefined) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (jobId: number) => deleteRepoSchedule(repoId!, jobId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['repo-schedules', repoId] })
+    mutationFn: ({ repoId: callRepoId, jobId }: { repoId?: number; jobId: number }) => {
+      const resolvedRepoId = callRepoId ?? repoId
+      return deleteRepoSchedule(resolvedRepoId!, jobId)
+    },
+    onSuccess: (__variables) => {
+      queryClient.invalidateQueries({ queryKey: ['repo-schedules', __variables.repoId ?? repoId] })
+      queryClient.invalidateQueries({ queryKey: ['all-schedules'] })
       showToast.success('Schedule deleted')
     },
-    onError: (error) => {
+    onError: (error: unknown) => {
       showToast.error(`Failed to delete schedule: ${error instanceof Error ? error.message : String(error)}`)
     },
   })
@@ -129,18 +137,20 @@ export function useRunRepoSchedule(repoId: number | undefined) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (jobId: number) => {
-      const response = await runRepoSchedule(repoId!, jobId)
+    mutationFn: async ({ repoId: callRepoId, jobId }: { repoId?: number; jobId: number }) => {
+      const resolvedRepoId = callRepoId ?? repoId
+      const response = await runRepoSchedule(resolvedRepoId!, jobId)
       return response.run
     },
-    onSuccess: (run) => {
-      queryClient.invalidateQueries({ queryKey: ['repo-schedules', repoId] })
-      queryClient.invalidateQueries({ queryKey: ['repo-schedule-runs', repoId, run.jobId] })
-      queryClient.invalidateQueries({ queryKey: ['repo-schedule', repoId, run.jobId] })
-      queryClient.invalidateQueries({ queryKey: ['repo-schedule-run', repoId, run.jobId, run.id] })
+    onSuccess: (run, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['repo-schedules', variables.repoId ?? repoId] })
+      queryClient.invalidateQueries({ queryKey: ['repo-schedule-runs', variables.repoId ?? repoId, run.jobId] })
+      queryClient.invalidateQueries({ queryKey: ['repo-schedule', variables.repoId ?? repoId, run.jobId] })
+      queryClient.invalidateQueries({ queryKey: ['repo-schedule-run', variables.repoId ?? repoId, run.jobId, run.id] })
+      queryClient.invalidateQueries({ queryKey: ['all-schedules'] })
       showToast.success(run.status === 'running' ? 'Schedule started' : 'Schedule run completed')
     },
-    onError: (error) => {
+    onError: (error: unknown) => {
       showToast.error(`Failed to run schedule: ${error instanceof Error ? error.message : String(error)}`)
     },
   })

--- a/frontend/src/pages/GlobalSchedules.tsx
+++ b/frontend/src/pages/GlobalSchedules.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAllSchedules } from '@/hooks/useSchedules'
-import { useDeleteRepoSchedule, useRunRepoSchedule, useUpdateRepoSchedule } from '@/hooks/useSchedules'
+import { useDeleteRepoSchedule, useRunRepoSchedule, useUpdateRepoSchedule, useCreateRepoSchedule } from '@/hooks/useSchedules'
 import { ScheduleJobDialog } from '@/components/schedules'
 import type { CreateScheduleJobRequest } from '@opencode-manager/shared/types'
 import { toUpdateScheduleRequest, formatScheduleShortLabel, getJobStatusTone, formatTimestamp } from '@/components/schedules/schedule-utils'
@@ -24,7 +24,8 @@ export function GlobalSchedules() {
   const navigate = useNavigate()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingJob, setEditingJob] = useState<ScheduleJobWithRepo | null>(null)
-  const [deleteJobId, setDeleteJobId] = useState<number | null>(null)
+  const [deletingJob, setDeletingJob] = useState<ScheduleJobWithRepo | null>(null)
+  const [selectedRepoId, setSelectedRepoId] = useState<number | undefined>(undefined)
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
   const [scheduleModeFilter, setScheduleModeFilter] = useState<ScheduleModeFilter>('all')
   const [repoFilter, setRepoFilter] = useState<string>('all')
@@ -32,6 +33,7 @@ export function GlobalSchedules() {
 
   const { data: jobs = [], isLoading, error } = useAllSchedules()
 
+  const createMutation = useCreateRepoSchedule(undefined)
   const deleteMutation = useDeleteRepoSchedule(undefined)
   const runMutation = useRunRepoSchedule(undefined)
   const updateMutation = useUpdateRepoSchedule(undefined)
@@ -124,26 +126,26 @@ export function GlobalSchedules() {
   ], [])
 
   const handleDelete = () => {
-    if (deleteJobId === null) {
+    if (!deletingJob) {
       return
     }
 
-    deleteMutation.mutate(deleteJobId, {
-      onSuccess: () => {
-        setDeleteJobId(null)
-      },
-    })
+    deleteMutation.mutate(
+      { repoId: deletingJob.repoId, jobId: deletingJob.id },
+      { onSuccess: () => setDeletingJob(null) }
+    )
   }
 
   const handleToggleEnabled = (job: ScheduleJobWithRepo) => {
     updateMutation.mutate({
+      repoId: job.repoId,
       jobId: job.id,
       data: { enabled: !job.enabled },
     })
   }
 
   const handleRunNow = (job: ScheduleJobWithRepo) => {
-    runMutation.mutate(job.id)
+    runMutation.mutate({ repoId: job.repoId, jobId: job.id })
   }
 
   const handleEdit = (job: ScheduleJobWithRepo) => {
@@ -151,17 +153,24 @@ export function GlobalSchedules() {
     setDialogOpen(true)
   }
 
-  const handleCreate = () => {
-    setDialogOpen(false)
+  const handleCreate = (data: CreateScheduleJobRequest) => {
+    if (!selectedRepoId) return
+    createMutation.mutate(
+      { repoId: selectedRepoId, data },
+      {
+        onSuccess: () => {
+          setDialogOpen(false)
+          setSelectedRepoId(undefined)
+        },
+      }
+    )
   }
 
   const handleUpdate = (data: CreateScheduleJobRequest) => {
-    if (!editingJob) {
-      return
-    }
-
+    if (!editingJob) return
     updateMutation.mutate(
       {
+        repoId: editingJob.repoId,
         jobId: editingJob.id,
         data: toUpdateScheduleRequest(data),
       },
@@ -221,7 +230,7 @@ export function GlobalSchedules() {
           </Badge>
           <Header.Actions>
             <Button
-              onClick={() => { setEditingJob(null); setDialogOpen(true) }}
+              onClick={() => { setEditingJob(null); setSelectedRepoId(undefined); setDialogOpen(true) }}
               size="sm"
               className="hidden sm:flex"
             >
@@ -229,7 +238,7 @@ export function GlobalSchedules() {
               New Schedule
             </Button>
             <Button
-              onClick={() => { setEditingJob(null); setDialogOpen(true) }}
+              onClick={() => { setEditingJob(null); setSelectedRepoId(undefined); setDialogOpen(true) }}
               size="sm"
               className="sm:hidden"
             >
@@ -535,7 +544,7 @@ export function GlobalSchedules() {
                       className="h-8 w-8 p-0 text-destructive hover:text-destructive"
                       onClick={(e) => {
                         e.stopPropagation()
-                        setDeleteJobId(job.id)
+                        setDeletingJob(job)
                       }}
                     >
                       <Trash2 className="h-3.5 w-3.5" />
@@ -554,18 +563,22 @@ export function GlobalSchedules() {
           setDialogOpen(open)
           if (!open) {
             setEditingJob(null)
+            setSelectedRepoId(undefined)
           }
         }}
         job={editingJob ?? undefined}
-        isSaving={updateMutation.isPending}
+        isSaving={createMutation.isPending || updateMutation.isPending}
         onSubmit={editingJob ? handleUpdate : handleCreate}
+        showRepoSelector
+        repoId={selectedRepoId}
+        onRepoChange={setSelectedRepoId}
       />
 
       <DeleteDialog
-        open={deleteJobId !== null}
-        onOpenChange={(open) => !open && setDeleteJobId(null)}
+        open={deletingJob !== null}
+        onOpenChange={(open) => !open && setDeletingJob(null)}
         onConfirm={handleDelete}
-        onCancel={() => setDeleteJobId(null)}
+        onCancel={() => setDeletingJob(null)}
         title="Delete Schedule"
         description="This removes the job definition and all recorded run history for it."
         isDeleting={deleteMutation.isPending}

--- a/frontend/src/pages/Schedules.tsx
+++ b/frontend/src/pages/Schedules.tsx
@@ -103,7 +103,7 @@ export function Schedules() {
   const hasJobs = (jobs?.length ?? 0) > 0
 
   const handleCreate = (data: CreateScheduleJobRequest) => {
-    createMutation.mutate(data, {
+    createMutation.mutate({ data }, {
       onSuccess: (job) => {
         setSelectedJobId(job.id)
         setDialogOpen(false)
@@ -133,7 +133,7 @@ export function Schedules() {
       return
     }
 
-    deleteMutation.mutate(deleteJobId, {
+    deleteMutation.mutate({ jobId: deleteJobId }, {
       onSuccess: () => {
         if (selectedJobId === deleteJobId) {
           setSelectedJobId(null)
@@ -159,7 +159,7 @@ export function Schedules() {
       return
     }
 
-    runMutation.mutate(selectedJob.id, {
+    runMutation.mutate({ jobId: selectedJob.id }, {
       onSuccess: (run) => {
         setSelectedRunId(run.id)
       },


### PR DESCRIPTION
## Summary
- Fix "New Schedule" button on GlobalSchedules page — adds repo selector when creating schedules
- Fix all card action mutations (delete, run, toggle, edit) — pass each job's `repoId` instead of `undefined`
- Refactor mutation hooks to accept optional per-call `repoId` override for flexibility
- Add optional `showRepoSelector` prop to ScheduleJobDialog for conditional repo selection UI

## Why
The GlobalSchedules page had two critical bugs:
1. Creating schedules was non-functional — dialog opened but no repo selection existed and handleCreate was a no-op
2. All mutations received `repoId=undefined`, producing invalid API URLs like `/api/repos/undefined/schedules/...` returning 400 errors

## What Is Included
- **useSchedules.ts**: 4 mutation hooks accept optional per-call `repoId` with hook-level fallback, also invalidate `['all-schedules']` on success
- **GlobalSchedules.tsx**: Add create mutation, repo state, pass `job.repoId` to all mutations, rename `deleteJobId` to `deletingJob`
- **ScheduleJobDialog.tsx**: Add 3 optional props (`showRepoSelector`, `repoId`, `onRepoChange`) + repo Combobox + submit validation guard
- **Schedules.tsx**: Update mutation call sites to new object signatures (backward compatible)

## Type Of Change
- [x] Bug fix
- [x] Refactoring
- [x] New feature

## Checklist
- [x] Code follows project style
- [x] Types updated
- [x] pnpm lint passes