### PR TITLE
fix: reload/restart OpenCode server when changing default config

### DIFF
--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -444,6 +444,9 @@ export function createSettingsRoutes(db: Database, gitAuthService: GitAuthServic
       const userId = c.req.query('userId') || 'default'
       const configName = c.req.param('name')
 
+      const previousDefault = settingsService.getDefaultOpenCodeConfig(userId)
+      const previousContent = previousDefault?.content ?? null
+
       settingsService.saveLastKnownGoodConfig(userId)
 
       const existingConfig = settingsService.getOpenCodeConfigByName(configName, userId)
@@ -483,12 +486,43 @@ export function createSettingsRoutes(db: Database, gitAuthService: GitAuthServic
       await writeFileContent(configPath, contentToWrite)
       logger.info(`Wrote default config '${configName}' to: ${configPath}`)
 
+      const newContent = existingConfig.content as Record<string, unknown>
+      const agentsChanged = JSON.stringify(previousContent?.agent) !== JSON.stringify(newContent.agent)
+      const pluginsChanged = JSON.stringify(previousContent?.plugin) !== JSON.stringify(newContent.plugin)
+      const skillsChanged = JSON.stringify(previousContent?.skills) !== JSON.stringify(newContent.skills)
+      const providersChanged = JSON.stringify(previousContent?.provider) !== JSON.stringify(newContent.provider)
+
+      let reloaded = false
+      let restarted = false
+      let reloadError: string | undefined
+
+      if (agentsChanged) {
+        try {
+          logger.info('Agent configuration changed on set-default, restarting OpenCode server')
+          await opencodeServerManager.restart()
+          restarted = true
+        } catch (error) {
+          logger.warn('Failed to restart OpenCode after set-default:', error)
+          reloadError = error instanceof Error ? error.message : 'Unknown error'
+        }
+      } else if (pluginsChanged || skillsChanged || providersChanged) {
+        try {
+          logger.info('Runtime config sections changed on set-default, reloading OpenCode server')
+          await opencodeServerManager.reloadConfig()
+          reloaded = true
+        } catch (error) {
+          logger.warn('Failed to reload OpenCode after set-default:', error)
+          reloadError = error instanceof Error ? error.message : 'Unknown error'
+        }
+      }
+
+      const base = { ...config, reloaded, restarted, reloadError }
       if (patchResult.removedFields && patchResult.removedFields.length > 0) {
         logger.info(`Config applied with auto-removed fields: ${patchResult.removedFields.join(', ')}`)
-        return c.json({ ...config, removedFields: patchResult.removedFields })
+        return c.json({ ...base, removedFields: patchResult.removedFields })
       }
       
-      return c.json(config)
+      return c.json(base)
     } catch (error) {
       logger.error('Failed to set default OpenCode config:', error)
       return c.json({ error: 'Failed to set default OpenCode config' }, 500)

--- a/backend/test/routes/settings.test.ts
+++ b/backend/test/routes/settings.test.ts
@@ -9,6 +9,7 @@ const mockUpdateOpenCodeConfig = vi.fn()
 const mockDeleteOpenCodeConfig = vi.fn()
 const mockGetOpenCodeConfigByName = vi.fn()
 const mockSetDefaultOpenCodeConfig = vi.fn()
+const mockGetDefaultOpenCodeConfig = vi.fn()
 
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
@@ -53,6 +54,7 @@ vi.mock('../../src/services/settings', () => ({
     deleteOpenCodeConfig: mockDeleteOpenCodeConfig,
     getOpenCodeConfigByName: mockGetOpenCodeConfigByName,
     setDefaultOpenCodeConfig: mockSetDefaultOpenCodeConfig,
+    getDefaultOpenCodeConfig: mockGetDefaultOpenCodeConfig,
   })),
 }))
 
@@ -188,6 +190,7 @@ describe('Settings Routes - OpenCode Upgrade', () => {
     mockRelinkReposFromSessionDirectories.mockReset()
     mockWriteFileContent.mockReset()
     mockPatchOpenCodeConfig.mockReset()
+    mockGetDefaultOpenCodeConfig.mockReset()
     
     testDb = {} as any
     settingsApp = createSettingsRoutes(testDb, { getGitEnvironment: vi.fn().mockReturnValue({}) } as any)
@@ -215,6 +218,7 @@ describe('Settings Routes - OpenCode Upgrade', () => {
       duplicatePathCount: 0,
       errors: [],
     })
+    mockGetDefaultOpenCodeConfig.mockReturnValue(null)
   })
 
   describe('OpenCode config routes', () => {
@@ -408,6 +412,306 @@ describe('Settings Routes - OpenCode Upgrade', () => {
         '/tmp/test-workspace/.config/opencode.json',
         '{\n  "theme": "dark"\n}'
       )
+      expect(json.removedFields).toEqual(['command.review'])
+    })
+
+    it('should restart when agents changed on set-default', async () => {
+      mockGetDefaultOpenCodeConfig.mockReturnValue({
+        id: 1,
+        name: 'old-default',
+        content: { agent: { primary: { model: 'a' } } },
+        rawContent: '{"agent":{"primary":{"model":"a"}}}',
+        isValid: true,
+        isDefault: true,
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      mockGetOpenCodeConfigByName.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { agent: { primary: { model: 'b' } } },
+        rawContent: '{"agent":{"primary":{"model":"b"}}}',
+        isValid: true,
+        isDefault: false,
+        createdAt: 2,
+        updatedAt: 2,
+      })
+      mockPatchOpenCodeConfig.mockResolvedValueOnce({
+        success: true,
+        appliedConfig: { agent: { primary: { model: 'b' } } },
+      })
+      mockUpdateOpenCodeConfig.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { agent: { primary: { model: 'b' } } },
+        rawContent: '{"agent":{"primary":{"model":"b"}}}',
+        isValid: true,
+        isDefault: false,
+        createdAt: 2,
+        updatedAt: 3,
+      })
+      mockSetDefaultOpenCodeConfig.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { agent: { primary: { model: 'b' } } },
+        rawContent: '{"agent":{"primary":{"model":"b"}}}',
+        isValid: true,
+        isDefault: true,
+        createdAt: 2,
+        updatedAt: 4,
+      })
+
+      const req = new Request('http://localhost/opencode-configs/new-config/set-default', {
+        method: 'POST',
+      })
+      const res = await settingsApp.fetch(req)
+      const json = await res.json() as Record<string, unknown>
+
+      expect(res.status).toBe(200)
+      expect(mockRestart).toHaveBeenCalledTimes(1)
+      expect(mockReloadConfig).not.toHaveBeenCalled()
+      expect(json.restarted).toBe(true)
+      expect(json.reloaded).toBe(false)
+      expect(json.reloadError).toBeUndefined()
+    })
+
+    it('should reload when plugins/skills/providers changed on set-default', async () => {
+      mockGetDefaultOpenCodeConfig.mockReturnValue({
+        id: 1,
+        name: 'old-default',
+        content: { plugin: ['old'] },
+        rawContent: '{"plugin":["old"]}',
+        isValid: true,
+        isDefault: true,
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      mockGetOpenCodeConfigByName.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { plugin: ['old', 'new'] },
+        rawContent: '{"plugin":["old","new"]}',
+        isValid: true,
+        isDefault: false,
+        createdAt: 2,
+        updatedAt: 2,
+      })
+      mockPatchOpenCodeConfig.mockResolvedValueOnce({
+        success: true,
+        appliedConfig: { plugin: ['old', 'new'] },
+      })
+      mockUpdateOpenCodeConfig.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { plugin: ['old', 'new'] },
+        rawContent: '{"plugin":["old","new"]}',
+        isValid: true,
+        isDefault: false,
+        createdAt: 2,
+        updatedAt: 3,
+      })
+      mockSetDefaultOpenCodeConfig.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { plugin: ['old', 'new'] },
+        rawContent: '{"plugin":["old","new"]}',
+        isValid: true,
+        isDefault: true,
+        createdAt: 2,
+        updatedAt: 4,
+      })
+
+      const req = new Request('http://localhost/opencode-configs/new-config/set-default', {
+        method: 'POST',
+      })
+      const res = await settingsApp.fetch(req)
+      const json = await res.json() as Record<string, unknown>
+
+      expect(res.status).toBe(200)
+      expect(mockReloadConfig).toHaveBeenCalledTimes(1)
+      expect(mockRestart).not.toHaveBeenCalled()
+      expect(json.reloaded).toBe(true)
+      expect(json.restarted).toBe(false)
+    })
+
+    it('should not reload or restart when no runtime fields changed', async () => {
+      mockGetDefaultOpenCodeConfig.mockReturnValue({
+        id: 1,
+        name: 'old-default',
+        content: { theme: 'dark', agent: {} },
+        rawContent: '{"theme":"dark","agent":{}}',
+        isValid: true,
+        isDefault: true,
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      mockGetOpenCodeConfigByName.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { theme: 'light', agent: {} },
+        rawContent: '{"theme":"light","agent":{}}',
+        isValid: true,
+        isDefault: false,
+        createdAt: 2,
+        updatedAt: 2,
+      })
+      mockPatchOpenCodeConfig.mockResolvedValueOnce({
+        success: true,
+        appliedConfig: { theme: 'light', agent: {} },
+      })
+      mockUpdateOpenCodeConfig.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { theme: 'light', agent: {} },
+        rawContent: '{"theme":"light","agent":{}}',
+        isValid: true,
+        isDefault: false,
+        createdAt: 2,
+        updatedAt: 3,
+      })
+      mockSetDefaultOpenCodeConfig.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { theme: 'light', agent: {} },
+        rawContent: '{"theme":"light","agent":{}}',
+        isValid: true,
+        isDefault: true,
+        createdAt: 2,
+        updatedAt: 4,
+      })
+
+      const req = new Request('http://localhost/opencode-configs/new-config/set-default', {
+        method: 'POST',
+      })
+      const res = await settingsApp.fetch(req)
+      const json = await res.json() as Record<string, unknown>
+
+      expect(res.status).toBe(200)
+      expect(mockRestart).not.toHaveBeenCalled()
+      expect(mockReloadConfig).not.toHaveBeenCalled()
+      expect(json.restarted).toBe(false)
+      expect(json.reloaded).toBe(false)
+    })
+
+    it('should return reloadError in response when restart fails', async () => {
+      mockGetDefaultOpenCodeConfig.mockReturnValue({
+        id: 1,
+        name: 'old-default',
+        content: { agent: { primary: { model: 'a' } } },
+        rawContent: '{"agent":{"primary":{"model":"a"}}}',
+        isValid: true,
+        isDefault: true,
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      mockGetOpenCodeConfigByName.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { agent: { primary: { model: 'b' } } },
+        rawContent: '{"agent":{"primary":{"model":"b"}}}',
+        isValid: true,
+        isDefault: false,
+        createdAt: 2,
+        updatedAt: 2,
+      })
+      mockPatchOpenCodeConfig.mockResolvedValueOnce({
+        success: true,
+        appliedConfig: { agent: { primary: { model: 'b' } } },
+      })
+      mockUpdateOpenCodeConfig.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { agent: { primary: { model: 'b' } } },
+        rawContent: '{"agent":{"primary":{"model":"b"}}}',
+        isValid: true,
+        isDefault: false,
+        createdAt: 2,
+        updatedAt: 3,
+      })
+      mockSetDefaultOpenCodeConfig.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { agent: { primary: { model: 'b' } } },
+        rawContent: '{"agent":{"primary":{"model":"b"}}}',
+        isValid: true,
+        isDefault: true,
+        createdAt: 2,
+        updatedAt: 4,
+      })
+      mockRestart.mockRejectedValueOnce(new Error('boom'))
+
+      const req = new Request('http://localhost/opencode-configs/new-config/set-default', {
+        method: 'POST',
+      })
+      const res = await settingsApp.fetch(req)
+      const json = await res.json() as Record<string, unknown>
+
+      expect(res.status).toBe(200)
+      expect(mockRestart).toHaveBeenCalledTimes(1)
+      expect(json.reloadError).toBe('boom')
+      expect(json.restarted).toBe(false)
+      expect(json.id).toBeDefined()
+      expect(json.name).toBe('new-config')
+      expect(json.isDefault).toBe(true)
+    })
+
+    it('should preserve removedFields alongside new flags', async () => {
+      mockGetDefaultOpenCodeConfig.mockReturnValue({
+        id: 1,
+        name: 'old-default',
+        content: { plugin: ['old'] },
+        rawContent: '{"plugin":["old"]}',
+        isValid: true,
+        isDefault: true,
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      mockGetOpenCodeConfigByName.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { plugin: ['old', 'new'], command: { review: true } },
+        rawContent: '{"plugin":["old","new"],"command":{"review":true}}',
+        isValid: true,
+        isDefault: false,
+        createdAt: 2,
+        updatedAt: 2,
+      })
+      mockPatchOpenCodeConfig.mockResolvedValueOnce({
+        success: true,
+        appliedConfig: { plugin: ['old', 'new'] },
+        removedFields: ['command.review'],
+        details: [{ path: 'command.review', message: 'Invalid field' }],
+      })
+      mockUpdateOpenCodeConfig.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { plugin: ['old', 'new'] },
+        rawContent: '{"plugin":["old","new"]}',
+        isValid: true,
+        isDefault: false,
+        createdAt: 2,
+        updatedAt: 3,
+      })
+      mockSetDefaultOpenCodeConfig.mockReturnValue({
+        id: 2,
+        name: 'new-config',
+        content: { plugin: ['old', 'new'] },
+        rawContent: '{"plugin":["old","new"]}',
+        isValid: true,
+        isDefault: true,
+        createdAt: 2,
+        updatedAt: 4,
+      })
+
+      const req = new Request('http://localhost/opencode-configs/new-config/set-default', {
+        method: 'POST',
+      })
+      const res = await settingsApp.fetch(req)
+      const json = await res.json() as Record<string, unknown>
+
+      expect(res.status).toBe(200)
+      expect(mockReloadConfig).toHaveBeenCalledTimes(1)
+      expect(json.reloaded).toBe(true)
       expect(json.removedFields).toEqual(['command.review'])
     })
   })

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -94,7 +94,7 @@ export const settingsApi = {
   setDefaultOpenCodeConfig: async (
     configName: string,
     userId = DEFAULT_USER_ID
-  ): Promise<OpenCodeConfig> => {
+  ): Promise<OpenCodeConfig & { reloaded?: boolean; restarted?: boolean; reloadError?: string; removedFields?: string[] }> => {
     return fetchWrapper(
       `${API_BASE_URL}/api/settings/opencode-configs/${encodeURIComponent(configName)}/set-default`,
       {

--- a/frontend/src/components/settings/OpenCodeConfigManager.tsx
+++ b/frontend/src/components/settings/OpenCodeConfigManager.tsx
@@ -363,10 +363,23 @@ export function OpenCodeConfigManager() {
       setIsUpdating(true)
       const result = await settingsApi.setDefaultOpenCodeConfig(config.name)
       await fetchConfigs()
-      if (result.removedFields && result.removedFields.length > 0) {
-        showToast.info(`Default config updated after removing invalid fields: ${result.removedFields.join(', ')}`, { id: 'set-default' })
+      invalidateConfigCaches(queryClient)
+
+      if (result.reloadError) {
+        showToast.error(`Default set but server reload failed: ${result.reloadError}`, { id: 'set-default' })
+        return
+      }
+
+      const removedSuffix = result.removedFields && result.removedFields.length > 0
+        ? ` (removed invalid fields: ${result.removedFields.join(', ')})`
+        : ''
+
+      if (result.restarted) {
+        showToast.success(`Default config updated and server restarted${removedSuffix}`, { id: 'set-default' })
+      } else if (result.reloaded) {
+        showToast.success(`Default config updated and server reloaded${removedSuffix}`, { id: 'set-default' })
       } else {
-        showToast.success('Default config updated and applied', { id: 'set-default' })
+        showToast.success(`Default config updated${removedSuffix}`, { id: 'set-default' })
       }
     } catch (error) {
       console.error('Failed to set default config:', error)


### PR DESCRIPTION
## Summary

#### Changes
- **Modified** `backend/src/routes/settings.ts`: Detects which config sections (agents, plugins, skills, providers) changed when setting default config and triggers restart or reload accordingly
- **Modified** `backend/test/routes/settings.test.ts`: Added 5 new test cases covering restart, reload, no-change, error handling, and removedFields preservation scenarios
- **Modified** `frontend/src/api/settings.ts`: Extended return type with `reloaded`, `restarted`, `reloadError`, and `removedFields` fields
- **Modified** `frontend/src/components/settings/OpenCodeConfigManager.tsx`: Shows appropriate toast messages based on reload/restart status and error state

Agents changes trigger a full server restart; plugins/skills/providers changes trigger a reload. Errors are surfaced to the user via toast notifications.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Checklist

- [x] Code follows project style (no comments, named imports)
- [x] TypeScript types are properly defined
- [x] Tests added/updated (80% coverage target)
- [x] `pnpm lint` passes locally
- [x] `pnpm typecheck` passes locally