### PR TITLE
feat: add base branch support for worktree creation

### DIFF
--- a/backend/src/routes/repos.ts
+++ b/backend/src/routes/repos.ts
@@ -27,7 +27,7 @@ export function createRepoRoutes(database: Database, gitAuthService: GitAuthServ
   app.post('/', async (c) => {
     try {
       const body = await c.req.json()
-      const { repoUrl, localPath, branch, openCodeConfigName, useWorktree, skipSSHVerification, provider } = body
+      const { repoUrl, localPath, branch, openCodeConfigName, useWorktree, skipSSHVerification, provider, baseBranch } = body
 
       if (!repoUrl && !localPath) {
         return c.json({ error: 'Either repoUrl or localPath is required' }, 400)
@@ -48,9 +48,7 @@ export function createRepoRoutes(database: Database, gitAuthService: GitAuthServ
           database,
           gitAuthService,
           repoUrl!,
-          branch,
-          useWorktree,
-          skipSSHVerification
+          { branch, useWorktree, skipSSHVerification, baseBranch }
         )
       }
       

--- a/backend/src/services/repo.ts
+++ b/backend/src/services/repo.ts
@@ -576,14 +576,20 @@ export async function initLocalRepo(
   }
 }
 
+export interface CloneRepoOptions {
+  branch?: string
+  useWorktree?: boolean
+  skipSSHVerification?: boolean
+  baseBranch?: string
+}
+
 export async function cloneRepo(
   database: Database,
   gitAuthService: GitAuthService,
   repoUrl: string,
-  branch?: string,
-  useWorktree: boolean = false,
-  skipSSHVerification: boolean = false
+  options: CloneRepoOptions = {}
 ): Promise<Repo> {
+  const { branch, useWorktree = false, skipSSHVerification = false, baseBranch } = options
   const effectiveUrl = normalizeSSHUrl(repoUrl)
   const isSSH = isSSHUrl(effectiveUrl)
   const preserveSSH = isSSH
@@ -639,7 +645,7 @@ export async function cloneRepo(
        await executeCommand(['git', '-C', baseRepoPath, 'fetch', '--all'], { cwd: getReposPath(), env })
 
       
-       await createWorktreeSafely(baseRepoPath, worktreePath, branch, env)
+       await createWorktreeSafely(baseRepoPath, worktreePath, branch, env, baseBranch)
       
       const worktreeVerified = existsSync(worktreePath)
       
@@ -986,7 +992,7 @@ function normalizeRepoUrl(url: string, preserveSSH: boolean = false): { url: str
   }
 }
 
-async function createWorktreeSafely(baseRepoPath: string, worktreePath: string, branch: string, env: Record<string, string>): Promise<void> {
+async function createWorktreeSafely(baseRepoPath: string, worktreePath: string, branch: string, env: Record<string, string>, baseBranch?: string): Promise<void> {
   const currentBranch = await safeGetCurrentBranch(baseRepoPath, env)
   if (currentBranch === branch) {
     const defaultBranch = await executeCommand(['git', '-C', baseRepoPath, 'rev-parse', '--abbrev-ref', 'origin/HEAD'], { env })
@@ -1015,6 +1021,10 @@ async function createWorktreeSafely(baseRepoPath: string, worktreePath: string, 
   if (branchExists) {
     await executeCommand(['git', '-C', baseRepoPath, 'worktree', 'add', worktreePath, branch], { env })
   } else {
-    await executeCommand(['git', '-C', baseRepoPath, 'worktree', 'add', '-b', branch, worktreePath], { env })
+    const addArgs = ['git', '-C', baseRepoPath, 'worktree', 'add', '-b', branch, worktreePath]
+    if (baseBranch) {
+      addArgs.push(baseBranch)
+    }
+    await executeCommand(addArgs, { env })
   }
 }

--- a/frontend/src/api/repos.ts
+++ b/frontend/src/api/repos.ts
@@ -3,18 +3,21 @@ import { FetchError, fetchWrapper, fetchWrapperVoid, fetchWrapperBlob } from './
 import { API_BASE_URL } from '@/config'
 import type { DiscoverReposResponse } from '@opencode-manager/shared/types'
 
-export async function createRepo(
-  repoUrl?: string,
-  localPath?: string,
-  branch?: string,
-  openCodeConfigName?: string,
-  useWorktree?: boolean,
+export interface CreateRepoOptions {
+  repoUrl?: string
+  localPath?: string
+  branch?: string
+  openCodeConfigName?: string
+  useWorktree?: boolean
   skipSSHVerification?: boolean
-): Promise<Repo> {
+  baseBranch?: string
+}
+
+export async function createRepo(options: CreateRepoOptions = {}): Promise<Repo> {
   return fetchWrapper(`${API_BASE_URL}/api/repos`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ repoUrl, localPath, branch, openCodeConfigName, useWorktree, skipSSHVerification }),
+    body: JSON.stringify(options),
   })
 }
 

--- a/frontend/src/components/repo/AddRepoDialog.tsx
+++ b/frontend/src/components/repo/AddRepoDialog.tsx
@@ -37,7 +37,7 @@ export function AddRepoDialog({ open, onOpenChange }: AddRepoDialogProps) {
   const mutation = useMutation({
     mutationFn: async (): Promise<AddRepoResult> => {
       if (repoType === 'local') {
-        const repo = await createRepo(undefined, localPath, branch || undefined, undefined, false)
+        const repo = await createRepo({ localPath, branch: branch || undefined, useWorktree: false })
         return { mode: 'single', repo }
       }
 
@@ -46,7 +46,7 @@ export function AddRepoDialog({ open, onOpenChange }: AddRepoDialogProps) {
         return { mode: 'discover', ...result }
       }
 
-      const repo = await createRepo(repoUrl, undefined, branch || undefined, undefined, false, skipSSHVerification)
+      const repo = await createRepo({ repoUrl, branch: branch || undefined, useWorktree: false, skipSSHVerification })
       return { mode: 'single', repo }
     },
     onSuccess: (result) => {

--- a/frontend/src/components/repo/CreateWorktreeDialog.tsx
+++ b/frontend/src/components/repo/CreateWorktreeDialog.tsx
@@ -1,0 +1,204 @@
+import { useState, useEffect } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { AlertCircle, GitBranch, Loader2 } from 'lucide-react'
+import { createRepo, listBranches } from '@/api/repos'
+import { showToast } from '@/lib/toast'
+
+interface CreateWorktreeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  repoId: number
+  repoUrl?: string | null
+  defaultBaseBranch?: string
+  onCreated?: () => void
+}
+
+export function CreateWorktreeDialog({
+  open,
+  onOpenChange,
+  repoId,
+  repoUrl,
+  defaultBaseBranch,
+  onCreated,
+}: CreateWorktreeDialogProps) {
+  const queryClient = useQueryClient()
+  const [branchName, setBranchName] = useState('')
+  const [baseBranch, setBaseBranch] = useState<string>('')
+  const [error, setError] = useState<string | null>(null)
+
+  const canCreate = Boolean(repoUrl)
+
+  const { data: branchesData, isLoading: branchesLoading } = useQuery({
+    queryKey: ['branches', repoId],
+    queryFn: () => listBranches(repoId),
+    enabled: open && canCreate,
+    staleTime: 30000,
+  })
+
+  const localBranches = (branchesData?.branches ?? []).filter((b) => b.type === 'local')
+  const remoteBranches = (branchesData?.branches ?? [])
+    .filter((b) => b.type === 'remote')
+    .map((b) => ({ ...b, shortName: b.name.replace(/^remotes\/[^/]+\//, '') }))
+    .filter((b) => !localBranches.some((lb) => lb.name === b.shortName))
+
+  useEffect(() => {
+    if (!open) {
+      setBranchName('')
+      setBaseBranch('')
+      setError(null)
+      return
+    }
+    if (defaultBaseBranch) {
+      setBaseBranch(defaultBaseBranch)
+    }
+  }, [open, defaultBaseBranch])
+
+  const worktreeMutation = useMutation({
+    mutationFn: (payload: { branch: string; base: string }) =>
+      createRepo({
+        repoUrl: repoUrl || undefined,
+        branch: payload.branch,
+        useWorktree: true,
+        baseBranch: payload.base,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['repos'] })
+      queryClient.invalidateQueries({ queryKey: ['reposGitStatus'] })
+      showToast.success('Worktree created')
+      onCreated?.()
+      onOpenChange(false)
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : 'Failed to create worktree')
+    },
+  })
+
+  const handleCreate = () => {
+    const trimmed = branchName.trim()
+    if (!trimmed) {
+      setError('Branch name is required')
+      return
+    }
+    if (!baseBranch) {
+      setError('Base branch is required')
+      return
+    }
+    setError(null)
+    worktreeMutation.mutate({ branch: trimmed, base: baseBranch })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GitBranch className="w-4 h-4" />
+            Create Worktree
+          </DialogTitle>
+          <DialogDescription>
+            Create a separate workspace for a new branch. The worktree is managed as its own repo entry.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {!canCreate ? (
+            <div className="flex items-start gap-2 bg-yellow-500/10 border border-yellow-500/30 rounded p-3">
+              <AlertCircle className="w-4 h-4 text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0" />
+              <p className="text-sm text-yellow-700 dark:text-yellow-300">
+                Worktrees can only be created for repositories with a remote URL.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium">New branch name</label>
+                <Input
+                  placeholder="feature/my-branch"
+                  value={branchName}
+                  onChange={(e) => setBranchName(e.target.value)}
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !worktreeMutation.isPending) handleCreate()
+                  }}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium">Base branch</label>
+                <Select value={baseBranch} onValueChange={setBaseBranch} disabled={branchesLoading}>
+                  <SelectTrigger className="bg-background border-border text-foreground">
+                    <SelectValue placeholder={branchesLoading ? 'Loading branches...' : 'Select a base branch'} />
+                  </SelectTrigger>
+                  <SelectContent className="bg-popover border-border">
+                    {localBranches.length > 0 && (
+                      <>
+                        {localBranches.map((branch) => (
+                          <SelectItem key={`local-${branch.name}`} value={branch.name}>
+                            <div className="flex items-center gap-2">
+                              <GitBranch className="w-3.5 h-3.5" />
+                              <span>{branch.name}</span>
+                              {branch.current && (
+                                <span className="text-xs text-muted-foreground">(current)</span>
+                              )}
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </>
+                    )}
+                    {remoteBranches.map((branch) => (
+                      <SelectItem key={`remote-${branch.name}`} value={branch.shortName}>
+                        <div className="flex items-center gap-2">
+                          <GitBranch className="w-3.5 h-3.5 text-blue-500" />
+                          <span>{branch.shortName}</span>
+                          <span className="text-xs text-muted-foreground">(remote)</span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  The new branch will be created from this branch. Ignored if the branch name already exists locally or on the remote.
+                </p>
+              </div>
+            </>
+          )}
+
+          {error && (
+            <div className="flex items-start gap-2 bg-red-500/10 border border-red-500/30 rounded p-3">
+              <AlertCircle className="w-4 h-4 text-red-600 dark:text-red-400 mt-0.5 flex-shrink-0" />
+              <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            </div>
+          )}
+
+          <div className="flex gap-2 justify-end">
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              className="border-border hover:bg-accent"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!canCreate || !branchName.trim() || !baseBranch || worktreeMutation.isPending}
+              className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+            >
+              {worktreeMutation.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Creating...
+                </>
+              ) : (
+                'Create Worktree'
+              )}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/repo/RepoRowActions.tsx
+++ b/frontend/src/components/repo/RepoRowActions.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Loader2, GitBranch, Download, Trash2, MoreVertical } from 'lucide-react'
+import { Loader2, GitBranch, GitBranchPlus, Download, Trash2, MoreVertical } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { SourceControlPanel } from '@/components/source-control/SourceControlPanel'
 import { DownloadDialog } from '@/components/ui/download-dialog'
+import { CreateWorktreeDialog } from '@/components/repo/CreateWorktreeDialog'
 import { downloadRepo } from '@/api/repos'
 import { showToast } from '@/lib/toast'
 import { getRepoDisplayName } from '@/lib/utils'
@@ -47,6 +48,7 @@ export function RepoRowActions({
 }: RepoRowActionsProps) {
   const [showDownloadDialog, setShowDownloadDialog] = useState(false)
   const [showSourceControl, setShowSourceControl] = useState(false)
+  const [showWorktreeDialog, setShowWorktreeDialog] = useState(false)
 
   const repoName = getRepoDisplayName(repo.repoUrl, repo.localPath, repo.sourcePath)
   const branchToDisplay = gitStatus?.branch || repo.currentBranch || repo.branch
@@ -61,6 +63,13 @@ export function RepoRowActions({
     setShowDownloadDialog(open)
     onActionsOpenChange?.(open)
   }
+
+  const handleWorktreeDialogOpen = (open: boolean) => {
+    setShowWorktreeDialog(open)
+    onActionsOpenChange?.(open)
+  }
+
+  const canCreateWorktree = isReady && !repo.isWorktree && Boolean(repo.repoUrl)
 
   const handleDownload = async (options: { includeGit?: boolean; includePaths?: string[] }) => {
     try {
@@ -162,6 +171,18 @@ export function RepoRowActions({
           <GitBranch className="w-4 h-4" />
         </Button>
 
+        {canCreateWorktree && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => handleWorktreeDialogOpen(true)}
+            className="h-8 w-8 p-0"
+            title="Create Worktree"
+          >
+            <GitBranchPlus className="w-4 h-4" />
+          </Button>
+        )}
+
         <Button
           size="sm"
           variant="ghost"
@@ -204,6 +225,13 @@ export function RepoRowActions({
         description="This will create a ZIP archive of the entire repository."
         itemName={repoName}
         targetPath={repo.fullPath}
+      />
+      <CreateWorktreeDialog
+        open={showWorktreeDialog}
+        onOpenChange={handleWorktreeDialogOpen}
+        repoId={repo.id}
+        repoUrl={repo.repoUrl}
+        defaultBaseBranch={branchToDisplay}
       />
     </>
   )

--- a/frontend/src/components/source-control/BranchesTab.tsx
+++ b/frontend/src/components/source-control/BranchesTab.tsx
@@ -1,15 +1,15 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { listBranches, switchBranch, createRepo, GitAuthError } from '@/api/repos'
+import { listBranches, switchBranch, GitAuthError } from '@/api/repos'
 import { useGitStatus } from '@/api/git'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Checkbox } from '@/components/ui/checkbox'
-import { Loader2, GitBranch, Check, Plus, AlertCircle, ArrowUp, ArrowDown, Globe } from 'lucide-react'
+import { Loader2, GitBranch, GitBranchPlus, Check, Plus, AlertCircle, ArrowUp, ArrowDown, Globe } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { showToast } from '@/lib/toast'
 import { useGit } from '@/hooks/useGit'
 import { GIT_UI_COLORS } from '@/lib/git-status-styles'
+import { CreateWorktreeDialog } from '@/components/repo/CreateWorktreeDialog'
 
 interface BranchesTabProps {
   repoId: number
@@ -22,7 +22,7 @@ export function BranchesTab({ repoId, currentBranch, repoUrl, isRepoWorktree }: 
   const queryClient = useQueryClient()
   const [newBranchName, setNewBranchName] = useState('')
   const [isCreating, setIsCreating] = useState(false)
-  const [useWorktree, setUseWorktree] = useState(false)
+  const [worktreeDialogOpen, setWorktreeDialogOpen] = useState(false)
   const git = useGit(repoId)
 
   const { data: status } = useGitStatus(repoId)
@@ -52,34 +52,14 @@ export function BranchesTab({ repoId, currentBranch, repoUrl, isRepoWorktree }: 
     },
   })
 
-  const worktreeMutation = useMutation({
-    mutationFn: (branch: string) => createRepo(repoUrl || undefined, undefined, branch, undefined, true),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['repos'] })
-      queryClient.invalidateQueries({ queryKey: ['reposGitStatus'] })
-      setNewBranchName('')
-      setIsCreating(false)
-      setUseWorktree(false)
-      showToast.success('Branch workspace created')
-    },
-    onError: (error) => {
-      showToast.error(error instanceof Error ? error.message : 'Failed to create branch workspace')
-    },
-  })
-
   const handleCreateBranch = async () => {
     if (!newBranchName.trim()) return
 
     try {
-      if (useWorktree && repoUrl) {
-        await worktreeMutation.mutateAsync(newBranchName.trim())
-      } else {
-        await git.createBranch.mutateAsync(newBranchName.trim())
-        setNewBranchName('')
-        setIsCreating(false)
-        setUseWorktree(false)
-        refetch()
-      }
+      await git.createBranch.mutateAsync(newBranchName.trim())
+      setNewBranchName('')
+      setIsCreating(false)
+      refetch()
     } catch {
       // Error handled by mutation
     }
@@ -128,68 +108,69 @@ export function BranchesTab({ repoId, currentBranch, repoUrl, isRepoWorktree }: 
         </div>
 
         {isCreating ? (
-          <div className="space-y-2">
-            <div className="flex items-center gap-2">
-              <Input
-                placeholder="New branch name..."
-                value={newBranchName}
-                onChange={(e) => setNewBranchName(e.target.value)}
-                className="h-8 md:text-sm"
-                autoFocus
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') handleCreateBranch()
-                  if (e.key === 'Escape') {
-                    setIsCreating(false)
-                    setNewBranchName('')
-                    setUseWorktree(false)
-                  }
-                }}
-              />
-              <Button
-                size="sm"
-                className="h-8"
-                onClick={handleCreateBranch}
-                disabled={!newBranchName.trim() || git.createBranch.isPending || worktreeMutation.isPending}
-              >
-                {(git.createBranch.isPending || worktreeMutation.isPending) ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
-                  'Create'
-                )}
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-8"
-                onClick={() => {
+          <div className="flex items-center gap-2">
+            <Input
+              placeholder="New branch name..."
+              value={newBranchName}
+              onChange={(e) => setNewBranchName(e.target.value)}
+              className="h-8 md:text-sm"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleCreateBranch()
+                if (e.key === 'Escape') {
                   setIsCreating(false)
                   setNewBranchName('')
-                  setUseWorktree(false)
-                }}
-              >
-                Cancel
-              </Button>
-            </div>
-            {repoUrl && (
-              <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
-                <Checkbox
-                  checked={useWorktree}
-                  onCheckedChange={(checked) => setUseWorktree(checked === true)}
-                />
-                <span>Create as separate workspace</span>
-              </label>
-            )}
+                }
+              }}
+            />
+            <Button
+              size="sm"
+              className="h-8"
+              onClick={handleCreateBranch}
+              disabled={!newBranchName.trim() || git.createBranch.isPending}
+            >
+              {git.createBranch.isPending ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                'Create'
+              )}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-8"
+              onClick={() => {
+                setIsCreating(false)
+                setNewBranchName('')
+              }}
+            >
+              Cancel
+            </Button>
           </div>
         ) : (
-          <Button
-            size="sm"
-            variant="outline"
-            className="w-full h-8"
-            onClick={() => setIsCreating(true)}
-          >
-            <Plus className="w-4 h-4 mr-2" />
-            Create New Branch
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              className="flex-1 h-8"
+              onClick={() => setIsCreating(true)}
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              Create Branch
+            </Button>
+            {repoUrl && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="flex-1 h-8"
+                onClick={() => setWorktreeDialogOpen(true)}
+                title="Create as a separate worktree workspace"
+              >
+                <GitBranchPlus className="w-4 h-4 mr-2" />
+                Create Worktree
+              </Button>
+            )}
+          </div>
         )}
       </div>
 
@@ -249,6 +230,14 @@ export function BranchesTab({ repoId, currentBranch, repoUrl, isRepoWorktree }: 
           </div>
         )}
       </div>
+
+      <CreateWorktreeDialog
+        open={worktreeDialogOpen}
+        onOpenChange={setWorktreeDialogOpen}
+        repoId={repoId}
+        repoUrl={repoUrl}
+        defaultBaseBranch={activeBranch}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/RepoDetail.tsx
+++ b/frontend/src/pages/RepoDetail.tsx
@@ -8,6 +8,7 @@ import { Header } from "@/components/ui/header";
 import { SwitchConfigDialog } from "@/components/repo/SwitchConfigDialog";
 import { RepoMcpDialog } from "@/components/repo/RepoMcpDialog";
 import { RepoSkillsDialog } from "@/components/repo/RepoSkillsDialog";
+import { CreateWorktreeDialog } from "@/components/repo/CreateWorktreeDialog";
 import { SourceControlPanel } from "@/components/source-control";
 import { useCreateSession } from "@/hooks/useOpenCode";
 import { useRepoActivity } from "@/hooks/useRepoActivity";
@@ -17,7 +18,7 @@ import { useDialogParam } from "@/hooks/useDialogParam";
 import { OPENCODE_API_ENDPOINT } from "@/config";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Plug, FolderOpen, Plus, GitBranch, GitCommitHorizontal, ShieldOff, Brain, Loader2, CalendarClock, Sparkles } from "lucide-react";
+import { Plug, FolderOpen, Plus, GitBranch, GitBranchPlus, GitCommitHorizontal, ShieldOff, Brain, Loader2, CalendarClock, Sparkles } from "lucide-react";
 import { ResetPermissionsDialog } from "@/components/repo/ResetPermissionsDialog";
 import { PendingActionsGroup } from "@/components/notifications/PendingActionsGroup";
 import { invalidateConfigCaches } from "@/lib/queryInvalidation";
@@ -33,6 +34,7 @@ export function RepoDetail() {
   const [skillsDialogOpen, setSkillsDialogOpen] = useDialogParam('skills');
   const [sourceControlOpen, setSourceControlOpen] = useDialogParam('sourceControl');
   const [resetPermissionsOpen, setResetPermissionsOpen] = useDialogParam('resetPermissions');
+  const [worktreeDialogOpen, setWorktreeDialogOpen] = useDialogParam('createWorktree');
 
   const { data: repo, isLoading: repoLoading } = useQuery({
     queryKey: ["repo", repoId],
@@ -103,6 +105,7 @@ export function RepoDetail() {
   const displayName = branchToDisplay ? `${repoName} (${branchToDisplay})` : repoName;
   const currentBranch = repo.currentBranch || repo.branch || "main";
   const isWorktree = repo.isWorktree || false;
+  const canCreateWorktree = !isWorktree && Boolean(repo.repoUrl);
 
   return (
     <div
@@ -150,6 +153,18 @@ export function RepoDetail() {
           <GitCommitHorizontal className="w-4 h-4 sm:mr-2" />
           <span className="hidden sm:inline">Source</span>
         </Button>
+        {canCreateWorktree && (
+          <Button
+            variant="outline"
+            onClick={() => setWorktreeDialogOpen(true)}
+            size="sm"
+            className="hidden md:flex text-foreground border-border hover:bg-accent transition-all duration-200 hover:scale-105"
+            title="Create Worktree"
+          >
+            <GitBranchPlus className="w-4 h-4 sm:mr-2" />
+            <span className="hidden sm:inline">Worktree</span>
+          </Button>
+        )}
         <Button
           variant="outline"
           onClick={() => setFileBrowserOpen(true)}
@@ -268,6 +283,14 @@ export function RepoDetail() {
         onOpenChange={setResetPermissionsOpen}
         repoId={repoId}
         repoDirectory={repoDirectory}
+      />
+
+      <CreateWorktreeDialog
+        open={worktreeDialogOpen}
+        onOpenChange={setWorktreeDialogOpen}
+        repoId={repoId}
+        repoUrl={repo.repoUrl}
+        defaultBaseBranch={currentBranch}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `baseBranch` parameter to worktree creation for better branch control
- Create `CreateWorktreeDialog` component for dedicated worktree workflow
- Integrate worktree creation UI in repo list actions and detail page
- Update `BranchesTab` to use the new dialog with base branch selection

## Changes
- `backend/src/routes/repos.ts` - Added baseBranch parameter to route handler
- `backend/src/services/repo.ts` - Added CloneRepoOptions interface and baseBranch support
- `frontend/src/api/repos.ts` - Added CreateRepoOptions interface
- `frontend/src/components/repo/CreateWorktreeDialog.tsx` - New component
- `frontend/src/components/repo/RepoRowActions.tsx` - Added worktree action
- `frontend/src/components/repo/BranchesTab.tsx` - Updated to use CreateWorktreeDialog
- `frontend/src/pages/RepoDetail.tsx` - Added worktree creation button
- `frontend/src/components/repo/AddRepoDialog.tsx` - Updated to use new interface