### PR TITLE
feat(model): add favorites system for model selection

### DIFF
--- a/backend/src/routes/providers.ts
+++ b/backend/src/routes/providers.ts
@@ -1,11 +1,67 @@
 import { Hono } from 'hono'
 import { z } from 'zod'
+import path from 'path'
 import { AuthService } from '../services/auth'
 import { SetCredentialRequestSchema } from '../../../shared/src/schemas/auth'
 import { logger } from '../utils/logger'
 import { setOpenCodeAuth, deleteOpenCodeAuth } from '../services/proxy'
 import { opencodeServerManager } from '../services/opencode-single-server'
 import type { OpenCodeSupervisor } from '../services/opencode-supervisor'
+import { fileExists, readFileContent, writeFileContent } from '../services/file-operations'
+import { getWorkspacePath } from '@opencode-manager/shared/config/env'
+
+const ModelSelectionSchema = z.object({
+  providerID: z.string().min(1),
+  modelID: z.string().min(1),
+})
+
+const ModelStateSchema = z.object({
+  recent: z.array(ModelSelectionSchema).default([]),
+  favorite: z.array(ModelSelectionSchema).default([]),
+  variant: z.record(z.string(), z.string().optional()).default({}),
+})
+
+const UpdateModelStateSchema = z.object({
+  recent: ModelSelectionSchema.optional(),
+})
+
+type ModelSelection = z.infer<typeof ModelSelectionSchema>
+type ModelState = z.infer<typeof ModelStateSchema>
+
+const MAX_RECENT_MODELS = 10
+
+function getModelStatePath(): string {
+  return path.join(getWorkspacePath(), '.opencode', 'state', 'opencode', 'model.json')
+}
+
+async function readModelState(): Promise<ModelState> {
+  const modelStatePath = getModelStatePath()
+  if (!await fileExists(modelStatePath)) {
+    return { recent: [], favorite: [], variant: {} }
+  }
+
+  return ModelStateSchema.parse(JSON.parse(await readFileContent(modelStatePath)))
+}
+
+function uniqueModels(models: ModelSelection[]): ModelSelection[] {
+  const seen = new Set<string>()
+  return models.filter((model) => {
+    const key = `${model.providerID}/${model.modelID}`
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+    return true
+  })
+}
+
+async function addRecentModel(model: ModelSelection): Promise<ModelState> {
+  const state = await readModelState()
+  const recent = uniqueModels([model, ...state.recent]).slice(0, MAX_RECENT_MODELS)
+  const nextState = { ...state, recent }
+  await writeFileContent(getModelStatePath(), JSON.stringify(nextState, null, 2))
+  return nextState
+}
 
 async function reloadOpenCodeConfig(openCodeSupervisor?: OpenCodeSupervisor): Promise<void> {
   if (openCodeSupervisor) {
@@ -19,6 +75,32 @@ async function reloadOpenCodeConfig(openCodeSupervisor?: OpenCodeSupervisor): Pr
 export function createProvidersRoutes(openCodeSupervisor?: OpenCodeSupervisor) {
   const app = new Hono()
   const authService = new AuthService()
+
+  app.get('/model-state', async (c) => {
+    try {
+      return c.json(await readModelState())
+    } catch (error) {
+      logger.error('Failed to read OpenCode model state:', error)
+      return c.json({ recent: [], favorite: [], variant: {} })
+    }
+  })
+
+  app.post('/model-state', async (c) => {
+    try {
+      const body = await c.req.json()
+      const validated = UpdateModelStateSchema.parse(body)
+      if (!validated.recent) {
+        return c.json(await readModelState())
+      }
+      return c.json(await addRecentModel(validated.recent))
+    } catch (error) {
+      logger.error('Failed to update OpenCode model state:', error)
+      if (error instanceof z.ZodError) {
+        return c.json({ error: 'Invalid request data', details: error.issues }, 400)
+      }
+      return c.json({ error: 'Failed to update OpenCode model state' }, 500)
+    }
+  })
 
   app.get('/credentials', async (c) => {
     try {

--- a/backend/src/routes/providers.ts
+++ b/backend/src/routes/providers.ts
@@ -23,6 +23,7 @@ const ModelStateSchema = z.object({
 
 const UpdateModelStateSchema = z.object({
   recent: ModelSelectionSchema.optional(),
+  favorite: ModelSelectionSchema.optional(),
 })
 
 type ModelSelection = z.infer<typeof ModelSelectionSchema>
@@ -63,6 +64,17 @@ async function addRecentModel(model: ModelSelection): Promise<ModelState> {
   return nextState
 }
 
+async function toggleFavoriteModel(model: ModelSelection): Promise<ModelState> {
+  const state = await readModelState()
+  const exists = state.favorite.some((favorite) => favorite.providerID === model.providerID && favorite.modelID === model.modelID)
+  const favorite = exists
+    ? state.favorite.filter((favorite) => favorite.providerID !== model.providerID || favorite.modelID !== model.modelID)
+    : uniqueModels([model, ...state.favorite])
+  const nextState = { ...state, favorite }
+  await writeFileContent(getModelStatePath(), JSON.stringify(nextState, null, 2))
+  return nextState
+}
+
 async function reloadOpenCodeConfig(openCodeSupervisor?: OpenCodeSupervisor): Promise<void> {
   if (openCodeSupervisor) {
     await openCodeSupervisor.reloadConfig('settings_reload')
@@ -89,6 +101,9 @@ export function createProvidersRoutes(openCodeSupervisor?: OpenCodeSupervisor) {
     try {
       const body = await c.req.json()
       const validated = UpdateModelStateSchema.parse(body)
+      if (validated.favorite) {
+        return c.json(await toggleFavoriteModel(validated.favorite))
+      }
       if (!validated.recent) {
         return c.json(await readModelState())
       }

--- a/backend/src/services/opencode-single-server.ts
+++ b/backend/src/services/opencode-single-server.ts
@@ -287,6 +287,7 @@ class OpenCodeServerManager {
           ...gitIdentityEnv,
           GIT_SSH_COMMAND: gitSshCommand,
           XDG_DATA_HOME: path.join(openCodeServerDirectory, '.opencode/state'),
+          XDG_STATE_HOME: path.join(openCodeServerDirectory, '.opencode/state'),
           XDG_CONFIG_HOME: path.join(openCodeServerDirectory, '.config'),
           ...(OPENCODE_SERVER_PUBLIC_URL ? { OPENCODE_PUBLIC_URL: OPENCODE_SERVER_PUBLIC_URL } : {}),
           ...(OPENCODE_SERVER_PASSWORD

--- a/frontend/src/api/providers.ts
+++ b/frontend/src/api/providers.ts
@@ -168,9 +168,11 @@ export interface ProvidersResult {
   default: Record<string, string>;
 }
 
-async function getProvidersFromOpenCodeServer(): Promise<ProvidersResult> {
+async function getProvidersFromOpenCodeServer(directory?: string): Promise<ProvidersResult> {
   try {
-    const response = await fetchWrapper<OpenCodeProviderResponse>(`${API_BASE_URL}/api/opencode/provider`);
+    const response = await fetchWrapper<OpenCodeProviderResponse>(`${API_BASE_URL}/api/opencode/provider`, {
+      params: { directory },
+    });
 
     if (response?.all && Array.isArray(response.all)) {
       const connectedSet = new Set(response.connected || []);
@@ -231,8 +233,8 @@ async function getProvidersFromOpenCodeServer(): Promise<ProvidersResult> {
   return { providers: [], connected: [], default: {} };
 }
 
-export async function getProviders(): Promise<ProvidersResult> {
-  return await getProvidersFromOpenCodeServer();
+export async function getProviders(directory?: string): Promise<ProvidersResult> {
+  return await getProvidersFromOpenCodeServer(directory);
 }
 
 export async function getOpenCodeModelState(): Promise<OpenCodeModelState> {
@@ -244,6 +246,14 @@ export async function addOpenCodeRecentModel(model: ModelSelection): Promise<Ope
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ recent: model }),
+  });
+}
+
+export async function toggleOpenCodeFavoriteModel(model: ModelSelection): Promise<OpenCodeModelState> {
+  return await fetchWrapper<OpenCodeModelState>(`${API_BASE_URL}/api/providers/model-state`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ favorite: model }),
   });
 }
 
@@ -296,8 +306,8 @@ async function getConfiguredProviders(connectedIds: Set<string>): Promise<Provid
   }
 }
 
-export async function getProvidersWithModels(): Promise<ProviderWithModels[]> {
-  const { providers: builtinProviders, connected } = await getProviders();
+export async function getProvidersWithModels(directory?: string): Promise<ProviderWithModels[]> {
+  const { providers: builtinProviders, connected } = await getProviders(directory);
   const connectedIds = new Set(connected);
 
   const configuredProviders = await getConfiguredProviders(connectedIds);
@@ -339,8 +349,9 @@ export async function getProvidersWithModels(): Promise<ProviderWithModels[]> {
 export async function getModel(
   providerId: string,
   modelId: string,
+  directory?: string,
 ): Promise<Model | null> {
-  const providers = await getProvidersWithModels();
+  const providers = await getProvidersWithModels(directory);
   const provider = providers.find((p) => p.id === providerId);
   if (!provider) return null;
 

--- a/frontend/src/api/providers.ts
+++ b/frontend/src/api/providers.ts
@@ -115,6 +115,17 @@ export interface ProviderWithModels {
   isConnected: boolean;
 }
 
+export interface ModelSelection {
+  providerID: string;
+  modelID: string;
+}
+
+export interface OpenCodeModelState {
+  recent: ModelSelection[];
+  favorite: ModelSelection[];
+  variant: Record<string, string | undefined>;
+}
+
 interface ConfigProvider {
   npm?: string;
   name?: string;
@@ -151,7 +162,13 @@ interface OpenCodeProviderResponse {
   default: Record<string, string>;
 }
 
-async function getProvidersFromOpenCodeServer(): Promise<{ providers: Provider[]; connected: string[] }> {
+export interface ProvidersResult {
+  providers: Provider[];
+  connected: string[];
+  default: Record<string, string>;
+}
+
+async function getProvidersFromOpenCodeServer(): Promise<ProvidersResult> {
   try {
     const response = await fetchWrapper<OpenCodeProviderResponse>(`${API_BASE_URL}/api/opencode/provider`);
 
@@ -205,17 +222,29 @@ async function getProvidersFromOpenCodeServer(): Promise<{ providers: Provider[]
         };
       });
 
-      return { providers, connected: response.connected || [] };
+      return { providers, connected: response.connected || [], default: response.default || {} };
     }
   } catch {
     // Silently return empty providers on failure - graceful degradation
   }
 
-  return { providers: [], connected: [] };
+  return { providers: [], connected: [], default: {} };
 }
 
-export async function getProviders(): Promise<{ providers: Provider[]; connected: string[] }> {
+export async function getProviders(): Promise<ProvidersResult> {
   return await getProvidersFromOpenCodeServer();
+}
+
+export async function getOpenCodeModelState(): Promise<OpenCodeModelState> {
+  return await fetchWrapper<OpenCodeModelState>(`${API_BASE_URL}/api/providers/model-state`);
+}
+
+export async function addOpenCodeRecentModel(model: ModelSelection): Promise<OpenCodeModelState> {
+  return await fetchWrapper<OpenCodeModelState>(`${API_BASE_URL}/api/providers/model-state`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ recent: model }),
+  });
 }
 
 async function getConfiguredProviders(connectedIds: Set<string>): Promise<ProviderWithModels[]> {

--- a/frontend/src/components/message/PromptInput.tsx
+++ b/frontend/src/components/message/PromptInput.tsx
@@ -937,7 +937,7 @@ if (isIOS && isSecureContext && navigator.clipboard && navigator.clipboard.read)
   const client = useOpenCodeClient(opcodeUrl, directory)
   const { data: providersData } = useQuery({
     queryKey: ['opencode', 'providers', opcodeUrl, directory],
-    queryFn: () => getProviders(),
+    queryFn: () => getProviders(directory),
     enabled: !!client,
     staleTime: 30000,
   })

--- a/frontend/src/components/model/ModelQuickSelect.tsx
+++ b/frontend/src/components/model/ModelQuickSelect.tsx
@@ -1,16 +1,14 @@
 import { useCallback, useMemo } from 'react'
-import { Check, ChevronRight, Clock, Sparkles } from 'lucide-react'
+import { Check, ChevronRight, Star } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { useModelSelection } from '@/hooks/useModelSelection'
 import { useVariants } from '@/hooks/useVariants'
-import { formatModelName, getProviders } from '@/api/providers'
+import { formatModelName, formatProviderName, getProviders } from '@/api/providers'
 import { useQuery } from '@tanstack/react-query'
 import { useOpenCodeClient } from '@/hooks/useOpenCode'
 
@@ -29,22 +27,27 @@ export function ModelQuickSelect({
   disabled,
   children,
 }: ModelQuickSelectProps) {
-  const { modelString, recentModels, favoriteModels, setModel } = useModelSelection(opcodeUrl, directory)
+  const { model, modelString, recentModels, favoriteModels, setModel, toggleFavorite } = useModelSelection(opcodeUrl, directory)
   const { availableVariants, currentVariant, setVariant, clearVariant, hasVariants } = useVariants(opcodeUrl, directory)
   const client = useOpenCodeClient(opcodeUrl, directory)
 
    const { data: providersData } = useQuery({
      queryKey: ['opencode', 'providers', opcodeUrl, directory],
-     queryFn: () => getProviders(),
+     queryFn: () => getProviders(directory),
      enabled: !!client,
      staleTime: 30000,
    })
 
    const getDisplayName = useCallback((providerID: string, modelID: string) => {
      const modelData = providersData?.providers
-       .find(provider => provider.id === providerID)
-       ?.models?.[modelID]
+        .find(provider => provider.id === providerID)
+        ?.models?.[modelID]
      return modelData ? formatModelName(modelData) : modelID
+   }, [providersData])
+
+   const getProviderName = useCallback((providerID: string) => {
+     const provider = providersData?.providers.find(provider => provider.id === providerID)
+     return provider ? formatProviderName(provider) : providerID
    }, [providersData])
 
    const favoriteModelsWithNames = useMemo(() => {
@@ -52,11 +55,12 @@ export function ModelQuickSelect({
        .filter(favorite => `${favorite.providerID}/${favorite.modelID}` !== modelString)
        .slice(0, 5)
        .map(favorite => ({
-         ...favorite,
-         displayName: getDisplayName(favorite.providerID, favorite.modelID),
-         key: `${favorite.providerID}/${favorite.modelID}`,
-       }))
-   }, [favoriteModels, getDisplayName, modelString])
+          ...favorite,
+          displayName: getDisplayName(favorite.providerID, favorite.modelID),
+          providerName: getProviderName(favorite.providerID),
+          key: `${favorite.providerID}/${favorite.modelID}`,
+        }))
+    }, [favoriteModels, getDisplayName, getProviderName, modelString])
 
    const recentModelsWithNames = useMemo(() => {
      return recentModels
@@ -66,11 +70,21 @@ export function ModelQuickSelect({
        })
        .slice(0, 5)
        .map(recent => ({
-         ...recent,
-         displayName: getDisplayName(recent.providerID, recent.modelID),
-         key: `${recent.providerID}/${recent.modelID}`,
-       }))
-   }, [recentModels, favoriteModels, getDisplayName, modelString])
+          ...recent,
+          displayName: getDisplayName(recent.providerID, recent.modelID),
+          providerName: getProviderName(recent.providerID),
+          key: `${recent.providerID}/${recent.modelID}`,
+        }))
+    }, [recentModels, favoriteModels, getDisplayName, getProviderName, modelString])
+
+  const duplicateDisplayNames = useMemo(() => {
+    const counts = [...favoriteModelsWithNames, ...recentModelsWithNames].reduce<Record<string, number>>((acc, item) => {
+      acc[item.displayName] = (acc[item.displayName] || 0) + 1
+      return acc
+    }, {})
+
+    return new Set(Object.entries(counts).filter(([, count]) => count > 1).map(([name]) => name))
+  }, [favoriteModelsWithNames, recentModelsWithNames])
 
   const handleVariantSelect = (variant: string | undefined) => {
     if (variant === undefined) {
@@ -84,6 +98,14 @@ export function ModelQuickSelect({
     setModel({ providerID, modelID })
   }
 
+  const handleCurrentFavoriteToggle = () => {
+    if (!model) return
+    toggleFavorite(model)
+  }
+
+  const isCurrentFavorite = model
+    ? favoriteModels.some((favorite) => favorite.providerID === model.providerID && favorite.modelID === model.modelID)
+    : false
   const hasFavorites = favoriteModelsWithNames.length > 0
   const hasRecents = recentModelsWithNames.length > 0
 
@@ -93,12 +115,18 @@ export function ModelQuickSelect({
         {children}
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-56">
+        {model && (
+          <DropdownMenuItem
+            onClick={handleCurrentFavoriteToggle}
+            className="flex items-center justify-between"
+          >
+            <span>{isCurrentFavorite ? 'Remove from favorites' : 'Add to favorites'}</span>
+            <Star className={`h-4 w-4 ${isCurrentFavorite ? 'fill-yellow-400 text-yellow-400' : ''}`} />
+          </DropdownMenuItem>
+        )}
+
         {hasVariants && (
           <>
-            <DropdownMenuLabel className="flex items-center gap-1.5">
-              <Sparkles className="h-3 w-3" />
-              Thinking Effort
-            </DropdownMenuLabel>
             <DropdownMenuItem
               onClick={() => handleVariantSelect(undefined)}
               className="flex items-center justify-between"
@@ -116,47 +144,44 @@ export function ModelQuickSelect({
                 {currentVariant === variant && <Check className="h-4 w-4" />}
               </DropdownMenuItem>
             ))}
-            {(hasFavorites || hasRecents) && <DropdownMenuSeparator />}
           </>
         )}
 
         {hasFavorites && (
           <>
-            <DropdownMenuLabel className="flex items-center gap-1.5">
-              <Sparkles className="h-3 w-3" />
-              Favorite Models
-            </DropdownMenuLabel>
             {favoriteModelsWithNames.map((favorite) => (
               <DropdownMenuItem
                 key={favorite.key}
                 onClick={() => handleModelSelect(favorite.providerID, favorite.modelID)}
                 className="flex items-center justify-between"
               >
-                <span className="truncate">{favorite.displayName}</span>
+                <span className="truncate">
+                  {duplicateDisplayNames.has(favorite.displayName)
+                    ? `${favorite.providerName}/${favorite.displayName}`
+                    : favorite.displayName}
+                </span>
                 {modelString === favorite.key && <Check className="h-4 w-4" />}
               </DropdownMenuItem>
             ))}
-            {hasRecents && <DropdownMenuSeparator />}
           </>
         )}
 
         {hasRecents && (
           <>
-            <DropdownMenuLabel className="flex items-center gap-1.5">
-              <Clock className="h-3 w-3" />
-              Recent Models
-            </DropdownMenuLabel>
             {recentModelsWithNames.map((recent) => (
               <DropdownMenuItem
                 key={recent.key}
                 onClick={() => handleModelSelect(recent.providerID, recent.modelID)}
                 className="flex items-center justify-between"
               >
-                <span className="truncate">{recent.displayName}</span>
+                <span className="truncate">
+                  {duplicateDisplayNames.has(recent.displayName)
+                    ? `${recent.providerName}/${recent.displayName}`
+                    : recent.displayName}
+                </span>
                 {modelString === recent.key && <Check className="h-4 w-4" />}
               </DropdownMenuItem>
             ))}
-            <DropdownMenuSeparator />
           </>
         )}
 

--- a/frontend/src/components/model/ModelQuickSelect.tsx
+++ b/frontend/src/components/model/ModelQuickSelect.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Check, ChevronRight, Clock, Sparkles } from 'lucide-react'
 import {
   DropdownMenu,
@@ -29,7 +29,7 @@ export function ModelQuickSelect({
   disabled,
   children,
 }: ModelQuickSelectProps) {
-  const { modelString, recentModels, setModel } = useModelSelection(opcodeUrl, directory)
+  const { modelString, recentModels, favoriteModels, setModel } = useModelSelection(opcodeUrl, directory)
   const { availableVariants, currentVariant, setVariant, clearVariant, hasVariants } = useVariants(opcodeUrl, directory)
   const client = useOpenCodeClient(opcodeUrl, directory)
 
@@ -40,33 +40,37 @@ export function ModelQuickSelect({
      staleTime: 30000,
    })
 
+   const getDisplayName = useCallback((providerID: string, modelID: string) => {
+     const modelData = providersData?.providers
+       .find(provider => provider.id === providerID)
+       ?.models?.[modelID]
+     return modelData ? formatModelName(modelData) : modelID
+   }, [providersData])
+
+   const favoriteModelsWithNames = useMemo(() => {
+     return favoriteModels
+       .filter(favorite => `${favorite.providerID}/${favorite.modelID}` !== modelString)
+       .slice(0, 5)
+       .map(favorite => ({
+         ...favorite,
+         displayName: getDisplayName(favorite.providerID, favorite.modelID),
+         key: `${favorite.providerID}/${favorite.modelID}`,
+       }))
+   }, [favoriteModels, getDisplayName, modelString])
+
    const recentModelsWithNames = useMemo(() => {
-     if (!providersData?.providers || providersData.providers.length === 0 || recentModels.length === 0) return []
-     
      return recentModels
        .filter(recent => {
          const key = `${recent.providerID}/${recent.modelID}`
-         return key !== modelString
+         return key !== modelString && !favoriteModels.some(favorite => favorite.providerID === recent.providerID && favorite.modelID === recent.modelID)
        })
        .slice(0, 5)
-       .map(recent => {
-         let displayName = recent.modelID
-         for (const provider of providersData.providers) {
-          if (provider.id === recent.providerID && provider.models) {
-            const modelData = provider.models[recent.modelID]
-            if (modelData) {
-              displayName = formatModelName(modelData)
-              break
-            }
-          }
-        }
-        return {
-          ...recent,
-          displayName,
-          key: `${recent.providerID}/${recent.modelID}`,
-        }
-      })
-  }, [recentModels, providersData, modelString])
+       .map(recent => ({
+         ...recent,
+         displayName: getDisplayName(recent.providerID, recent.modelID),
+         key: `${recent.providerID}/${recent.modelID}`,
+       }))
+   }, [recentModels, favoriteModels, getDisplayName, modelString])
 
   const handleVariantSelect = (variant: string | undefined) => {
     if (variant === undefined) {
@@ -80,6 +84,7 @@ export function ModelQuickSelect({
     setModel({ providerID, modelID })
   }
 
+  const hasFavorites = favoriteModelsWithNames.length > 0
   const hasRecents = recentModelsWithNames.length > 0
 
   return (
@@ -109,6 +114,26 @@ export function ModelQuickSelect({
               >
                 <span className="capitalize text-orange-500 text-center">{variant}</span>
                 {currentVariant === variant && <Check className="h-4 w-4" />}
+              </DropdownMenuItem>
+            ))}
+            {(hasFavorites || hasRecents) && <DropdownMenuSeparator />}
+          </>
+        )}
+
+        {hasFavorites && (
+          <>
+            <DropdownMenuLabel className="flex items-center gap-1.5">
+              <Sparkles className="h-3 w-3" />
+              Favorite Models
+            </DropdownMenuLabel>
+            {favoriteModelsWithNames.map((favorite) => (
+              <DropdownMenuItem
+                key={favorite.key}
+                onClick={() => handleModelSelect(favorite.providerID, favorite.modelID)}
+                className="flex items-center justify-between"
+              >
+                <span className="truncate">{favorite.displayName}</span>
+                {modelString === favorite.key && <Check className="h-4 w-4" />}
               </DropdownMenuItem>
             ))}
             {hasRecents && <DropdownMenuSeparator />}

--- a/frontend/src/components/model/ModelSelectDialog.tsx
+++ b/frontend/src/components/model/ModelSelectDialog.tsx
@@ -69,14 +69,18 @@ interface ModelCardProps {
   provider: ProviderWithModels;
   modelKey: string;
   isSelected: boolean;
+  isFavorite: boolean;
   onSelect: (providerId: string, modelId: string) => void;
+  onToggleFavorite: (providerId: string, modelId: string) => void;
 }
 
 const ModelCard = memo(function ModelCard({ 
   model, 
   provider, 
   isSelected, 
-  onSelect 
+  isFavorite,
+  onSelect,
+  onToggleFavorite,
 }: ModelCardProps) {
   const capabilities = useMemo(() => {
     const caps = [];
@@ -113,9 +117,21 @@ const ModelCard = memo(function ModelCard({
             {formatProviderName(provider)}
           </p>
         </div>
-        {isSelected && (
-          <Check className="h-4 w-4 text-blue-500 flex-shrink-0 ml-2" />
-        )}
+        <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleFavorite(provider.id, model.key || model.id);
+            }}
+            aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
+          >
+            <Star className={`h-4 w-4 ${isFavorite ? "fill-yellow-400 text-yellow-400" : "text-muted-foreground"}`} />
+          </Button>
+          {isSelected && <Check className="h-4 w-4 text-blue-500" />}
+        </div>
       </div>
 
       <div className="text-xs text-muted-foreground mb-2 sm:mb-3 font-mono truncate">
@@ -165,7 +181,9 @@ const ModelCard = memo(function ModelCard({
 interface ModelGridProps {
   models: FlatModel[];
   currentModel: string;
+  favoriteModelKeys: Set<string>;
   onSelect: (providerId: string, modelId: string) => void;
+  onToggleFavorite: (providerId: string, modelId: string) => void;
   loading: boolean;
   favoriteModels?: FlatModel[];
   recentModels?: FlatModel[];
@@ -175,7 +193,9 @@ interface ModelGridProps {
 const ModelGrid = memo(function ModelGrid({ 
   models, 
   currentModel, 
+  favoriteModelKeys,
   onSelect, 
+  onToggleFavorite,
   loading,
   favoriteModels = [],
   recentModels = [],
@@ -213,7 +233,9 @@ const ModelGrid = memo(function ModelGrid({
                 provider={provider}
                 modelKey={modelKey}
                 isSelected={currentModel === modelKey}
+                isFavorite={favoriteModelKeys.has(modelKey)}
                 onSelect={onSelect}
+                onToggleFavorite={onToggleFavorite}
               />
             ))}
           </div>
@@ -234,7 +256,9 @@ const ModelGrid = memo(function ModelGrid({
                 provider={provider}
                 modelKey={modelKey}
                 isSelected={currentModel === modelKey}
+                isFavorite={favoriteModelKeys.has(modelKey)}
                 onSelect={onSelect}
+                onToggleFavorite={onToggleFavorite}
               />
             ))}
           </div>
@@ -256,7 +280,9 @@ const ModelGrid = memo(function ModelGrid({
                 provider={provider}
                 modelKey={modelKey}
                 isSelected={currentModel === modelKey}
+                isFavorite={favoriteModelKeys.has(modelKey)}
                 onSelect={onSelect}
+                onToggleFavorite={onToggleFavorite}
               />
             ))}
           </div>
@@ -318,12 +344,12 @@ export function ModelSelectDialog({
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedProvider, setSelectedProvider] = useState<string>("");
 
-  const { modelString, setModel, recentModels, favoriteModels } = useModelSelection(opcodeUrl, directory);
+  const { modelString, setModel, toggleFavorite, recentModels, favoriteModels } = useModelSelection(opcodeUrl, directory);
   const currentModel = modelString || "";
 
   const { data: allProviders = [], isLoading: loading } = useQuery({
     queryKey: ["providers-with-models", opcodeUrl, directory],
-    queryFn: () => getProvidersWithModels(),
+    queryFn: () => getProvidersWithModels(directory),
     enabled: open,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
@@ -358,6 +384,10 @@ export function ModelSelectDialog({
       .filter((fm): fm is FlatModel => fm !== undefined)
       .slice(0, 6);
   }, [favoriteModels, flatModels]);
+
+  const favoriteModelKeys = useMemo(() => {
+    return new Set(favoriteModels.map((favorite) => `${favorite.providerID}/${favorite.modelID}`));
+  }, [favoriteModels]);
 
   const recentFlatModels = useMemo((): FlatModel[] => {
     return recentModels
@@ -412,6 +442,10 @@ export function ModelSelectDialog({
     onOpenChange(false);
   }, [setModel, onOpenChange]);
 
+  const handleFavoriteToggle = useCallback((providerId: string, modelId: string) => {
+    toggleFavorite({ providerID: providerId, modelID: modelId });
+  }, [toggleFavorite]);
+
   const searchResetKey = selectedProvider;
 
   return (
@@ -456,7 +490,9 @@ export function ModelSelectDialog({
                 key={selectedProvider || "all"}
                 models={filteredModels}
                 currentModel={currentModel}
+                favoriteModelKeys={favoriteModelKeys}
                 onSelect={handleModelSelect}
+                onToggleFavorite={handleFavoriteToggle}
                 loading={loading}
                 favoriteModels={favoriteFlatModels}
                 recentModels={recentFlatModels}

--- a/frontend/src/components/model/ModelSelectDialog.tsx
+++ b/frontend/src/components/model/ModelSelectDialog.tsx
@@ -9,14 +9,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Loader2, Search, Check, Star } from "lucide-react";
+import { Clock, Loader2, Search, Check, Star } from "lucide-react";
 import {
   getProvidersWithModels,
   formatModelName,
   formatProviderName,
 } from "@/api/providers";
 import { useModelSelection } from "@/hooks/useModelSelection";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import type { Model, ProviderWithModels } from "@/api/providers";
 
 interface ModelSelectDialogProps {
@@ -167,6 +167,7 @@ interface ModelGridProps {
   currentModel: string;
   onSelect: (providerId: string, modelId: string) => void;
   loading: boolean;
+  favoriteModels?: FlatModel[];
   recentModels?: FlatModel[];
   showRecent?: boolean;
 }
@@ -176,6 +177,7 @@ const ModelGrid = memo(function ModelGrid({
   currentModel, 
   onSelect, 
   loading,
+  favoriteModels = [],
   recentModels = [],
   showRecent = false,
 }: ModelGridProps) {
@@ -187,7 +189,7 @@ const ModelGrid = memo(function ModelGrid({
     );
   }
 
-  if (models.length === 0 && recentModels.length === 0) {
+  if (models.length === 0 && (!showRecent || (favoriteModels.length === 0 && recentModels.length === 0))) {
     return (
       <div className="text-center py-12 text-zinc-500">
         No models found
@@ -197,10 +199,31 @@ const ModelGrid = memo(function ModelGrid({
 
   return (
     <div className="space-y-6">
-      {showRecent && recentModels.length > 0 && (
+      {showRecent && favoriteModels.length > 0 && (
         <div>
           <h3 className="text-sm font-semibold text-muted-foreground mb-3 flex items-center gap-1.5">
             <Star className="h-3.5 w-3.5" />
+            Favorite Models
+          </h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-4">
+            {favoriteModels.map(({ model, provider, modelKey }) => (
+              <ModelCard
+                key={`favorite-${modelKey}`}
+                model={model}
+                provider={provider}
+                modelKey={modelKey}
+                isSelected={currentModel === modelKey}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {showRecent && recentModels.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-muted-foreground mb-3 flex items-center gap-1.5">
+            <Clock className="h-3.5 w-3.5" />
             Recent Models
           </h3>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-4">
@@ -220,7 +243,7 @@ const ModelGrid = memo(function ModelGrid({
 
       {models.length > 0 && (
         <div>
-          {showRecent && recentModels.length > 0 && (
+          {showRecent && (favoriteModels.length > 0 || recentModels.length > 0) && (
             <h3 className="text-sm font-semibold text-muted-foreground mb-3">
               All Models
             </h3>
@@ -295,20 +318,23 @@ export function ModelSelectDialog({
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedProvider, setSelectedProvider] = useState<string>("");
 
-  const { modelString, setModel, recentModels } = useModelSelection(opcodeUrl, directory);
+  const { modelString, setModel, recentModels, favoriteModels } = useModelSelection(opcodeUrl, directory);
   const currentModel = modelString || "";
 
   const { data: allProviders = [], isLoading: loading } = useQuery({
-    queryKey: ["providers-with-models"],
+    queryKey: ["providers-with-models", opcodeUrl, directory],
     queryFn: () => getProvidersWithModels(),
     enabled: open,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
+    placeholderData: keepPreviousData,
   });
 
   const connectedProviders = useMemo(() => {
     return allProviders.filter(p => p.isConnected);
   }, [allProviders]);
+
+  const selectableProviders = connectedProviders.length > 0 ? connectedProviders : allProviders;
 
   useEffect(() => {
     if (open) {
@@ -317,24 +343,29 @@ export function ModelSelectDialog({
   }, [open]);
 
   const flatModels = useMemo((): FlatModel[] => {
-    return connectedProviders.flatMap((provider) =>
+    return selectableProviders.flatMap((provider) =>
       provider.models.map((model) => ({
         model,
         provider,
         modelKey: `${provider.id}/${model.key || model.id}`,
       }))
     );
-  }, [connectedProviders]);
+  }, [selectableProviders]);
+
+  const favoriteFlatModels = useMemo((): FlatModel[] => {
+    return favoriteModels
+      .map((favorite) => flatModels.find((fm) => fm.modelKey === `${favorite.providerID}/${favorite.modelID}`))
+      .filter((fm): fm is FlatModel => fm !== undefined)
+      .slice(0, 6);
+  }, [favoriteModels, flatModels]);
 
   const recentFlatModels = useMemo((): FlatModel[] => {
     return recentModels
-      .map((recent) => {
-        const modelKey = `${recent.providerID}/${recent.modelID}`;
-        return flatModels.find((fm) => fm.modelKey === modelKey);
-      })
+      .filter((recent) => !favoriteModels.some((favorite) => favorite.providerID === recent.providerID && favorite.modelID === recent.modelID))
+      .map((recent) => flatModels.find((fm) => fm.modelKey === `${recent.providerID}/${recent.modelID}`))
       .filter((fm): fm is FlatModel => fm !== undefined)
       .slice(0, 6);
-  }, [recentModels, flatModels]);
+  }, [recentModels, favoriteModels, flatModels]);
 
   const filteredModels = useMemo(() => {
     const search = searchQuery.toLowerCase();
@@ -351,13 +382,20 @@ export function ModelSelectDialog({
         item.provider.name.toLowerCase().includes(search)
       );
     }
+
+    if (!selectedProvider && !search) {
+      filtered = filtered.filter((item) =>
+        !favoriteFlatModels.some((favorite) => favorite.modelKey === item.modelKey) &&
+        !recentFlatModels.some((recent) => recent.modelKey === item.modelKey)
+      );
+    }
     
     return filtered;
-  }, [flatModels, selectedProvider, searchQuery]);
+  }, [flatModels, favoriteFlatModels, recentFlatModels, selectedProvider, searchQuery]);
 
   const selectedProviderData = useMemo(
-    () => connectedProviders.find(p => p.id === selectedProvider),
-    [connectedProviders, selectedProvider]
+    () => selectableProviders.find(p => p.id === selectedProvider),
+    [selectableProviders, selectedProvider]
   );
 
   const handleProviderSelect = useCallback((providerId: string) => {
@@ -387,7 +425,7 @@ export function ModelSelectDialog({
 
         <div className="flex flex-1 overflow-hidden">
           <ProviderSidebar
-            providers={connectedProviders}
+            providers={selectableProviders}
             selectedProvider={selectedProvider}
             onSelect={handleProviderSelect}
           />
@@ -399,7 +437,7 @@ export function ModelSelectDialog({
                   <SelectValue placeholder="Select a provider..." />
                 </SelectTrigger>
                 <SelectContent>
-                  {connectedProviders.map((provider) => (
+                  {selectableProviders.map((provider) => (
                     <SelectItem key={provider.id} value={provider.id}>
                       {formatProviderName(provider)} ({provider.models.length})
                     </SelectItem>
@@ -420,6 +458,7 @@ export function ModelSelectDialog({
                 currentModel={currentModel}
                 onSelect={handleModelSelect}
                 loading={loading}
+                favoriteModels={favoriteFlatModels}
                 recentModels={recentFlatModels}
                 showRecent={!selectedProvider && !searchQuery}
               />

--- a/frontend/src/hooks/useAssistantSessionLauncher.test.tsx
+++ b/frontend/src/hooks/useAssistantSessionLauncher.test.tsx
@@ -7,6 +7,7 @@ import { initializeAssistantMode } from '@/api/repos'
 const mocks = vi.hoisted(() => ({
   listSessions: vi.fn(),
   createSession: vi.fn(),
+  sendPrompt: vi.fn(),
   initializeAssistantMode: vi.fn(),
 }))
 
@@ -18,6 +19,7 @@ vi.mock('@/api/opencode', () => ({
   OpenCodeClient: vi.fn(() => ({
     listSessions: mocks.listSessions,
     createSession: mocks.createSession,
+    sendPrompt: mocks.sendPrompt,
   })),
 }))
 
@@ -68,6 +70,14 @@ describe('useAssistantSessionLauncher', () => {
     })
 
     expect(mocks.createSession).toHaveBeenCalledWith({ title: 'Assistant' })
+    expect(mocks.sendPrompt).toHaveBeenCalledWith('created', {
+      parts: [
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('Welcome to OpenCode Manager!'),
+        }),
+      ],
+    })
     expect(onNavigate).toHaveBeenCalledWith('created')
   })
 })

--- a/frontend/src/hooks/useAssistantSessionLauncher.ts
+++ b/frontend/src/hooks/useAssistantSessionLauncher.ts
@@ -36,6 +36,27 @@ export function useAssistantSessionLauncher({
       onNavigate(newest.id)
     } else {
       const session = await client.createSession({ title: 'Assistant' })
+      await client.sendPrompt(session.id, {
+        parts: [
+          {
+            type: 'text',
+            text: `Welcome to OpenCode Manager! I'm your assistant and I'm here to help you work with your code.
+
+To get started, let's set up your assistant:
+
+**1. Name your assistant**
+What would you like to call me? This name will help personalize our interactions.
+
+**2. Configure AGENTS.md**
+This file contains instructions that define my behavior, persona, and preferences. You can customize it to match your workflow. Take a moment to review and edit it - you can always adjust it later.
+
+**3. Set up your v file (optional)**
+The v file stores conversation state and context between sessions. This helps me maintain memory of our work together.
+
+Take your time exploring and customizing these settings. Let me know when you're ready to start coding, or if you have any questions about getting set up!`,
+          },
+        ],
+      })
       onNavigate(session.id)
     }
   }, [repoId, opcodeUrl, onNavigate])

--- a/frontend/src/hooks/useModelSelection.ts
+++ b/frontend/src/hooks/useModelSelection.ts
@@ -3,7 +3,7 @@ import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tansta
 import { useConfig } from './useOpenCode'
 import { useOpenCodeClient } from './useOpenCode'
 import { useModelStore, type ModelSelection } from '@/stores/modelStore'
-import { addOpenCodeRecentModel, getOpenCodeModelState, getProviders } from '@/api/providers'
+import { addOpenCodeRecentModel, getOpenCodeModelState, getProviders, toggleOpenCodeFavoriteModel } from '@/api/providers'
 
 interface UseModelSelectionResult {
   model: ModelSelection | null
@@ -11,6 +11,7 @@ interface UseModelSelectionResult {
   recentModels: ModelSelection[]
   favoriteModels: ModelSelection[]
   setModel: (model: ModelSelection) => void
+  toggleFavorite: (model: ModelSelection) => void
   isModelStateLoading: boolean
 }
 
@@ -26,7 +27,7 @@ export function useModelSelection(
   
   const { data: providersData } = useQuery({
     queryKey: ['opencode', 'providers', opcodeUrl, directory],
-    queryFn: () => getProviders(),
+    queryFn: () => getProviders(directory),
     enabled: !!client,
     staleTime: 30000,
   })
@@ -37,6 +38,7 @@ export function useModelSelection(
     favoriteModels,
     setModel: setStoreModel,
     syncModelState,
+    toggleFavorite: toggleStoreFavorite,
     validateAndSyncModel, 
     getModelString 
   } = useModelStore()
@@ -51,6 +53,15 @@ export function useModelSelection(
 
   const updateRecentModel = useMutation({
     mutationFn: addOpenCodeRecentModel,
+    onSuccess: (state) => {
+      syncModelState(state)
+      queryClient.setQueryData([...modelStateQueryKey, opcodeUrl, directory], state)
+      queryClient.invalidateQueries({ queryKey: [...modelStateQueryKey, opcodeUrl, directory] })
+    },
+  })
+
+  const updateFavoriteModel = useMutation({
+    mutationFn: toggleOpenCodeFavoriteModel,
     onSuccess: (state) => {
       syncModelState(state)
       queryClient.setQueryData([...modelStateQueryKey, opcodeUrl, directory], state)
@@ -80,12 +91,18 @@ export function useModelSelection(
     updateRecentModel.mutate(nextModel)
   }
 
+  const toggleFavorite = (nextModel: ModelSelection) => {
+    toggleStoreFavorite(nextModel)
+    updateFavoriteModel.mutate(nextModel)
+  }
+
   return {
     model,
     modelString: getModelString(),
     recentModels,
     favoriteModels,
     setModel,
+    toggleFavorite,
     isModelStateLoading,
   }
 }

--- a/frontend/src/hooks/useModelSelection.ts
+++ b/frontend/src/hooks/useModelSelection.ts
@@ -1,16 +1,20 @@
 import { useEffect } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useConfig } from './useOpenCode'
 import { useOpenCodeClient } from './useOpenCode'
 import { useModelStore, type ModelSelection } from '@/stores/modelStore'
-import { getProviders } from '@/api/providers'
+import { addOpenCodeRecentModel, getOpenCodeModelState, getProviders } from '@/api/providers'
 
 interface UseModelSelectionResult {
   model: ModelSelection | null
   modelString: string | null
   recentModels: ModelSelection[]
+  favoriteModels: ModelSelection[]
   setModel: (model: ModelSelection) => void
+  isModelStateLoading: boolean
 }
+
+const modelStateQueryKey = ['opencode', 'model-state']
 
 export function useModelSelection(
   opcodeUrl: string | null | undefined,
@@ -18,6 +22,7 @@ export function useModelSelection(
 ): UseModelSelectionResult {
   const { data: config } = useConfig(opcodeUrl, directory)
   const client = useOpenCodeClient(opcodeUrl, directory)
+  const queryClient = useQueryClient()
   
   const { data: providersData } = useQuery({
     queryKey: ['opencode', 'providers', opcodeUrl, directory],
@@ -29,19 +34,58 @@ export function useModelSelection(
   const { 
     model, 
     recentModels, 
-    setModel, 
+    favoriteModels,
+    setModel: setStoreModel,
+    syncModelState,
     validateAndSyncModel, 
     getModelString 
   } = useModelStore()
 
+  const { data: modelState, isLoading: isModelStateLoading } = useQuery({
+    queryKey: [...modelStateQueryKey, opcodeUrl, directory],
+    queryFn: () => getOpenCodeModelState(),
+    enabled: !!client,
+    staleTime: 30000,
+    placeholderData: keepPreviousData,
+  })
+
+  const updateRecentModel = useMutation({
+    mutationFn: addOpenCodeRecentModel,
+    onSuccess: (state) => {
+      syncModelState(state)
+      queryClient.setQueryData([...modelStateQueryKey, opcodeUrl, directory], state)
+      queryClient.invalidateQueries({ queryKey: [...modelStateQueryKey, opcodeUrl, directory] })
+    },
+  })
+
+  const defaultModelString = providersData?.providers
+    .map((provider) => {
+      const modelID = providersData.default[provider.id] || Object.keys(provider.models || {})[0]
+      return modelID ? `${provider.id}/${modelID}` : null
+    })
+    .find((value): value is string => Boolean(value))
+
   useEffect(() => {
-    validateAndSyncModel(config?.model, providersData?.providers)
-  }, [config?.model, providersData, validateAndSyncModel])
+    validateAndSyncModel(config?.model || defaultModelString, providersData?.providers)
+  }, [config?.model, defaultModelString, providersData, validateAndSyncModel])
+
+  useEffect(() => {
+    if (modelState) {
+      syncModelState(modelState)
+    }
+  }, [modelState, syncModelState])
+
+  const setModel = (nextModel: ModelSelection) => {
+    setStoreModel(nextModel)
+    updateRecentModel.mutate(nextModel)
+  }
 
   return {
     model,
     modelString: getModelString(),
     recentModels,
+    favoriteModels,
     setModel,
+    isModelStateLoading,
   }
 }

--- a/frontend/src/hooks/useVariants.ts
+++ b/frontend/src/hooks/useVariants.ts
@@ -24,7 +24,7 @@ export function useVariants(
 
    const { data: providersData, isLoading } = useQuery({
      queryKey: ['opencode', 'providers', opcodeUrl, directory],
-     queryFn: () => getProviders(),
+     queryFn: () => getProviders(directory),
      enabled: !!client && !!model,
      staleTime: 30000,
    })

--- a/frontend/src/stores/modelStore.ts
+++ b/frontend/src/stores/modelStore.ts
@@ -10,10 +10,12 @@ export interface ModelSelection {
 interface ModelStore {
   model: ModelSelection | null
   recentModels: ModelSelection[]
+  favoriteModels: ModelSelection[]
   variants: Record<string, string | undefined>
   lastConfigModel: string | undefined
 
   setModel: (model: ModelSelection) => void
+  syncModelState: (state: { recent: ModelSelection[], favorite: ModelSelection[], variant: Record<string, string | undefined> }) => void
   syncFromConfig: (configModel: string | undefined, force?: boolean) => void
   validateAndSyncModel: (configModel: string | undefined, providers?: Provider[]) => void
   getModelString: () => string | null
@@ -36,6 +38,7 @@ export const useModelStore = create<ModelStore>()(
     (set, get) => ({
       model: null,
       recentModels: [],
+      favoriteModels: [],
       variants: {},
       lastConfigModel: undefined,
 
@@ -53,6 +56,17 @@ export const useModelStore = create<ModelStore>()(
             recentModels: newRecent,
           }
         })
+      },
+
+      syncModelState: (modelState) => {
+        set((state) => ({
+          recentModels: modelState.recent,
+          favoriteModels: modelState.favorite,
+          variants: {
+            ...modelState.variant,
+            ...state.variants,
+          },
+        }))
       },
 
       syncFromConfig: (configModel: string | undefined, force = false) => {
@@ -94,9 +108,14 @@ export const useModelStore = create<ModelStore>()(
         const currentModelExists = state.model ? modelExists(state.model) : false
 
         const cleanedRecentModels = state.recentModels.filter(modelExists)
+        const cleanedFavoriteModels = state.favoriteModels.filter(modelExists)
 
         if (cleanedRecentModels.length !== state.recentModels.length) {
           set({ recentModels: cleanedRecentModels })
+        }
+
+        if (cleanedFavoriteModels.length !== state.favoriteModels.length) {
+          set({ favoriteModels: cleanedFavoriteModels })
         }
 
         if (!currentModelExists) {
@@ -144,6 +163,7 @@ export const useModelStore = create<ModelStore>()(
       partialize: (state) => ({
         model: state.model,
         recentModels: state.recentModels,
+        favoriteModels: state.favoriteModels,
         variants: state.variants,
       }),
     }

--- a/frontend/src/stores/modelStore.ts
+++ b/frontend/src/stores/modelStore.ts
@@ -16,6 +16,7 @@ interface ModelStore {
 
   setModel: (model: ModelSelection) => void
   syncModelState: (state: { recent: ModelSelection[], favorite: ModelSelection[], variant: Record<string, string | undefined> }) => void
+  toggleFavorite: (model: ModelSelection) => void
   syncFromConfig: (configModel: string | undefined, force?: boolean) => void
   validateAndSyncModel: (configModel: string | undefined, providers?: Provider[]) => void
   getModelString: () => string | null
@@ -67,6 +68,20 @@ export const useModelStore = create<ModelStore>()(
             ...state.variants,
           },
         }))
+      },
+
+      toggleFavorite: (model: ModelSelection) => {
+        set((state) => {
+          const exists = state.favoriteModels.some(
+            (favorite) => favorite.providerID === model.providerID && favorite.modelID === model.modelID
+          )
+
+          return {
+            favoriteModels: exists
+              ? state.favoriteModels.filter((favorite) => favorite.providerID !== model.providerID || favorite.modelID !== model.modelID)
+              : [model, ...state.favoriteModels],
+          }
+        })
       },
 
       syncFromConfig: (configModel: string | undefined, force = false) => {


### PR DESCRIPTION
## Summary
- Add favorites functionality for model selection
- Add toggle favorite UI in ModelQuickSelect and ModelSelectDialog
- Add welcome message on new assistant session creation
- Show provider name prefix when model display names are ambiguous
- Fix directory scoping for getProviders API calls

## Changes
- `backend/src/routes/providers.ts` - Add toggleFavoriteModel endpoint
- `backend/src/services/opencode-single-server.ts` - Add XDG_STATE_HOME env var
- `frontend/src/api/providers.ts` - Add toggleOpenCodeFavoriteModel API
- `frontend/src/components/message/PromptInput.tsx` - Fix directory scoping
- `frontend/src/components/model/ModelQuickSelect.tsx` - Add favorites UI
- `frontend/src/components/model/ModelSelectDialog.tsx` - Add favorites toggle
- `frontend/src/hooks/useAssistantSessionLauncher.ts` - Send welcome message
- `frontend/src/hooks/useAssistantSessionLauncher.test.tsx` - Test welcome message
- `frontend/src/hooks/useModelSelection.ts` - Add toggleFavorite hook
- `frontend/src/hooks/useVariants.ts` - Fix directory scoping
- `frontend/src/stores/modelStore.ts` - Add toggleFavorite store method

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## Checklist

- [x] Code follows project style (no comments, named imports)
- [x] TypeScript types are properly defined
- [x] Tests added/updated (80% coverage target)
- [x] `pnpm lint` passes locally
- [x] `pnpm typecheck` passes locally