### PR TITLE
fix: enable swipe-back suspension on more drawer and remove unused variable

### DIFF
--- a/frontend/src/components/navigation/MoreDrawer.tsx
+++ b/frontend/src/components/navigation/MoreDrawer.tsx
@@ -30,7 +30,7 @@ export function MoreDrawer({ isOpen, onClose }: MoreDrawerProps) {
   const [commandsOpen, setCommandsOpen] = useState(false)
   const [mentionFileBrowserOpen, setMentionFileBrowserOpen] = useState(false)
   const swipeRef = useRef<HTMLDivElement>(null)
-  const { bind } = useSwipeBack(onClose, { enabled: true, suspendsRouteSwipe: false })
+  const { bind } = useSwipeBack(onClose, { enabled: true, suspendsRouteSwipe: true })
   const { logout } = useAuth()
   const { data: health } = useServerHealth()
   const isSessionDetail = /^\/repos\/\d+\/sessions\/[^/]+$/.test(location.pathname)

--- a/frontend/src/components/navigation/moreDrawerItems.ts
+++ b/frontend/src/components/navigation/moreDrawerItems.ts
@@ -70,7 +70,6 @@ export function buildNavModel(pathname: string): NavModel {
 
   const sessionDetailMatch = /^\/repos\/(\d+)\/sessions\/[^/]+$/.exec(pathname)
   if (sessionDetailMatch) {
-    const id = sessionDetailMatch[1]
     const items: MoreDrawerItem[] = [
       { key: 'files', label: 'Files', icon: Folder, dialog: 'files' },
       { key: 'mcp', label: 'MCP', icon: Plug, dialog: 'mcp' },


### PR DESCRIPTION
## Summary
- Enable suspendsRouteSwipe on the more drawer's swipe-back gesture
- Remove unused session ID variable in session detail navigation model

## Changes
- frontend/src/components/navigation/MoreDrawer.tsx - Set suspendsRouteSwipe to true
- frontend/src/components/navigation/moreDrawerItems.ts - Remove unused id variable

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows project style (no comments, named imports)
- [x] TypeScript types are properly defined