### PR TITLE
fix: preserve model form during config refresh

### DIFF
--- a/frontend/src/components/settings/OpenCodeModelDialog.tsx
+++ b/frontend/src/components/settings/OpenCodeModelDialog.tsx
@@ -1,7 +1,7 @@
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
@@ -248,13 +248,23 @@ export function OpenCodeModelDialog({
   const { isValid } = form.formState
   const createNewProvider = form.watch('createNewProvider')
   const newProviderType = form.watch('newProviderType')
+  const resetKeyRef = useRef<string | null>(null)
+  const resetKey = editingModel
+    ? `edit-${editingModel.providerId}-${editingModel.modelId}`
+    : `create-${selectedProviderId || availableProviders[0] || ''}`
 
   useEffect(() => {
-    if (open) {
+    if (!open) {
+      resetKeyRef.current = null
+      return
+    }
+
+    if (resetKeyRef.current !== resetKey) {
+      resetKeyRef.current = resetKey
       form.reset(getDefaultValues())
       void form.trigger()
     }
-  }, [open, form, getDefaultValues])
+  }, [open, resetKey, form, getDefaultValues])
 
   const handleSubmit = (values: ModelFormValues) => {
     const extra = parseOptionalJsonField(values.extraJson)

--- a/frontend/src/components/settings/OpenCodeModelsEditor.test.tsx
+++ b/frontend/src/components/settings/OpenCodeModelsEditor.test.tsx
@@ -172,6 +172,29 @@ describe('OpenCodeModelDialog', () => {
         expect(screen.getByText(/must use only letters, numbers/i)).toBeInTheDocument()
       })
     })
+
+    it('should preserve create form values when provider props refresh', async () => {
+      const { OpenCodeModelDialog } = await import('./OpenCodeModelDialog')
+      const props = {
+        ...defaultProps,
+        availableProviders: ['openai'],
+        existingProviders: { openai: { name: 'OpenAI' } },
+      }
+      const { rerender } = render(<OpenCodeModelDialog {...props} />)
+
+      const modelIdInput = document.querySelector('input[name="modelId"]') as HTMLInputElement
+      fireEvent.change(modelIdInput, { target: { value: 'gpt-5' } })
+
+      rerender(
+        <OpenCodeModelDialog
+          {...props}
+          availableProviders={['openai']}
+          existingProviders={{ openai: { name: 'OpenAI' } }}
+        />
+      )
+
+      expect(modelIdInput).toHaveValue('gpt-5')
+    })
   })
 
   describe('form submission', () => {


### PR DESCRIPTION
## Summary
- avoid resetting the Create Model dialog while it remains open across provider/config prop refreshes
- keep the initial open/edit reset behavior intact
- add a regression test that rerenders with refreshed provider props and preserves typed input

Fixes #184

## Checks
- `pnpm --filter frontend exec vitest run src/components/settings/OpenCodeModelsEditor.test.tsx`
- `pnpm --filter frontend exec eslint src/components/settings/OpenCodeModelDialog.tsx src/components/settings/OpenCodeModelsEditor.test.tsx --max-warnings=0`