### PR TITLE
fix(frontend): close sheet when opening new repo dialog

### DIFF
--- a/frontend/src/components/navigation/RepoQuickSwitchSheet.tsx
+++ b/frontend/src/components/navigation/RepoQuickSwitchSheet.tsx
@@ -91,7 +91,10 @@ export function RepoQuickSwitchSheet({ isOpen, onClose }: RepoQuickSwitchSheetPr
             <Button
               type="button"
               size="sm"
-              onClick={() => setAddRepoOpen(true)}
+              onClick={() => {
+                onClose()
+                setAddRepoOpen(true)
+              }}
               className="flex-shrink-0"
             >
               <Plus className="h-4 w-4" /> Repo


### PR DESCRIPTION
## Summary
- Close the repo quick switch sheet when clicking the "+ Repo" button, before opening AddRepoDialog

## Checks
- pnpm --filter frontend exec eslint src/components/navigation/RepoQuickSwitchSheet.tsx --max-warnings=0