### PR TITLE
fix(frontend): model selection validation and inline error banner

### DIFF
--- a/frontend/src/components/model/ModelQuickSelect.tsx
+++ b/frontend/src/components/model/ModelQuickSelect.tsx
@@ -51,31 +51,31 @@ export function ModelQuickSelect({
      return provider ? formatProviderName(provider) : providerID
    }, [providersData])
 
-   const favoriteModelsWithNames = useMemo(() => {
-     return favoriteModels
-       .filter(favorite => `${favorite.providerID}/${favorite.modelID}` !== modelString)
-       .slice(0, 5)
-       .map(favorite => ({
-          ...favorite,
-          displayName: getDisplayName(favorite.providerID, favorite.modelID),
-          providerName: getProviderName(favorite.providerID),
-          key: `${favorite.providerID}/${favorite.modelID}`,
-        }))
+    const favoriteModelsWithNames = useMemo(() => {
+      return favoriteModels
+        .filter(favorite => `${favorite.providerID}/${favorite.modelID}` !== modelString)
+        .slice(0, 5)
+        .map(favorite => ({
+           ...favorite,
+           displayName: getDisplayName(favorite.providerID, favorite.modelID),
+           providerName: getProviderName(favorite.providerID),
+           key: `${favorite.providerID}/${favorite.modelID}`,
+         }))
     }, [favoriteModels, getDisplayName, getProviderName, modelString])
 
-   const recentModelsWithNames = useMemo(() => {
-     return recentModels
-       .filter(recent => {
-         const key = `${recent.providerID}/${recent.modelID}`
-         return key !== modelString && !favoriteModels.some(favorite => favorite.providerID === recent.providerID && favorite.modelID === recent.modelID)
-       })
-       .slice(0, 5)
-       .map(recent => ({
-          ...recent,
-          displayName: getDisplayName(recent.providerID, recent.modelID),
-          providerName: getProviderName(recent.providerID),
-          key: `${recent.providerID}/${recent.modelID}`,
-        }))
+    const recentModelsWithNames = useMemo(() => {
+      return recentModels
+        .filter(recent => {
+          const key = `${recent.providerID}/${recent.modelID}`
+          return key !== modelString && !favoriteModels.some(favorite => favorite.providerID === recent.providerID && favorite.modelID === recent.modelID)
+        })
+        .slice(0, 5)
+        .map(recent => ({
+           ...recent,
+           displayName: getDisplayName(recent.providerID, recent.modelID),
+           providerName: getProviderName(recent.providerID),
+           key: `${recent.providerID}/${recent.modelID}`,
+         }))
     }, [recentModels, favoriteModels, getDisplayName, getProviderName, modelString])
 
   const duplicateDisplayNames = useMemo(() => {
@@ -85,6 +85,15 @@ export function ModelQuickSelect({
     }, {})
 
     return new Set(Object.entries(counts).filter(([, count]) => count > 1).map(([name]) => name))
+  }, [favoriteModelsWithNames, recentModelsWithNames])
+
+  const duplicateModelIds = useMemo(() => {
+    const counts = [...favoriteModelsWithNames, ...recentModelsWithNames].reduce<Record<string, number>>((acc, item) => {
+      acc[item.modelID] = (acc[item.modelID] || 0) + 1
+      return acc
+    }, {})
+
+    return new Set(Object.entries(counts).filter(([, count]) => count > 1).map(([id]) => id))
   }, [favoriteModelsWithNames, recentModelsWithNames])
 
   const handleVariantSelect = (variant: string | undefined) => {
@@ -122,7 +131,7 @@ export function ModelQuickSelect({
           <>
             <DropdownMenuItem className="flex items-center justify-between font-medium">
               <span className="truncate text-orange-500">
-                {duplicateDisplayNames.has(currentModelDisplayName)
+                {duplicateModelIds.has(model.modelID) || duplicateDisplayNames.has(currentModelDisplayName)
                   ? `${currentProviderName}/${currentModelDisplayName}`
                   : currentModelDisplayName}
               </span>
@@ -170,7 +179,7 @@ export function ModelQuickSelect({
                 className="flex items-center justify-between"
               >
                 <span className="truncate">
-                  {duplicateDisplayNames.has(favorite.displayName)
+                  {duplicateModelIds.has(favorite.modelID) || duplicateDisplayNames.has(favorite.displayName)
                     ? `${favorite.providerName}/${favorite.displayName}`
                     : favorite.displayName}
                 </span>
@@ -189,7 +198,7 @@ export function ModelQuickSelect({
                 className="flex items-center justify-between"
               >
                 <span className="truncate">
-                  {duplicateDisplayNames.has(recent.displayName)
+                  {duplicateModelIds.has(recent.modelID) || duplicateDisplayNames.has(recent.displayName)
                     ? `${recent.providerName}/${recent.displayName}`
                     : recent.displayName}
                 </span>

--- a/frontend/src/components/session/SessionSendErrorBanner.test.tsx
+++ b/frontend/src/components/session/SessionSendErrorBanner.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { SessionSendErrorBanner } from './SessionSendErrorBanner'
+import { useSendErrorStore } from '@/stores/sendErrorStore'
+
+vi.mock('@/lib/toast', () => ({
+  showToast: { error: vi.fn() },
+}))
+
+describe('SessionSendErrorBanner', () => {
+  beforeEach(() => {
+    useSendErrorStore.setState({ errors: {} })
+  })
+
+  it('renders banner when error exists for session', () => {
+    useSendErrorStore.getState().setError({
+      sessionID: 'test-session',
+      title: 'Error',
+      message: 'Something failed',
+      detail: 'Stack trace here',
+    })
+
+    render(<SessionSendErrorBanner sessionId="test-session" />)
+    expect(screen.getByText('Error')).toBeInTheDocument()
+    expect(screen.getByText('Something failed')).toBeInTheDocument()
+    expect(screen.getByText('Stack trace here')).toBeInTheDocument()
+  })
+
+  it('does not render banner when no error exists', () => {
+    render(<SessionSendErrorBanner sessionId="test-session" />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('does not render banner when sessionId is undefined', () => {
+    useSendErrorStore.getState().setError({
+      sessionID: 'test-session',
+      title: 'Error',
+      message: 'Something failed',
+    })
+
+    render(<SessionSendErrorBanner sessionId={undefined} />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('clears error on dismiss', () => {
+    useSendErrorStore.getState().setError({
+      sessionID: 'test-session',
+      title: 'Error',
+      message: 'Something failed',
+    })
+
+    render(<SessionSendErrorBanner sessionId="test-session" />)
+    expect(screen.getByText('Something failed')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByText('Something failed')).not.toBeInTheDocument()
+    expect(useSendErrorStore.getState().getError('test-session')).toBeNull()
+  })
+
+  it('does not call showToast.error', async () => {
+    const { showToast } = await import('@/lib/toast')
+    useSendErrorStore.getState().setError({
+      sessionID: 'test-session',
+      title: 'Error',
+      message: 'Something failed',
+    })
+
+    render(<SessionSendErrorBanner sessionId="test-session" />)
+    expect(showToast.error).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/session/SessionSendErrorBanner.tsx
+++ b/frontend/src/components/session/SessionSendErrorBanner.tsx
@@ -1,0 +1,23 @@
+import { ErrorBanner } from '@/components/ui/error-banner'
+import { useSendErrorStore } from '@/stores/sendErrorStore'
+
+interface SessionSendErrorBannerProps {
+  sessionId: string | undefined
+}
+
+export function SessionSendErrorBanner({ sessionId }: SessionSendErrorBannerProps) {
+  const sendError = useSendErrorStore((s) => sessionId ? s.errors[sessionId] : null)
+  const clearSendError = useSendErrorStore((s) => s.clearError)
+
+  if (!sendError || !sessionId) return null
+
+  return (
+    <ErrorBanner
+      title={sendError.title}
+      summary={sendError.message}
+      detail={sendError.detail}
+      onDismiss={() => clearSendError(sessionId)}
+      className="mb-2"
+    />
+  )
+}

--- a/frontend/src/components/source-control/GitErrorBanner.tsx
+++ b/frontend/src/components/source-control/GitErrorBanner.tsx
@@ -1,6 +1,4 @@
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
-import { AlertCircle, X } from 'lucide-react'
+import { ErrorBanner } from '@/components/ui/error-banner'
 
 interface GitErrorBannerProps {
   error: { summary: string; detail?: string }
@@ -9,26 +7,11 @@ interface GitErrorBannerProps {
 
 export function GitErrorBanner({ error, onDismiss }: GitErrorBannerProps) {
   return (
-    <Alert variant="destructive" className="mb-0 p-3 sm:p-4 [&>svg]:hidden [&>svg~*]:pl-0">
-      <div className="flex flex-col gap-2">
-        <div className="flex items-start gap-2">
-          <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-          <AlertDescription className="flex-1 min-w-0 text-sm">{error.summary}</AlertDescription>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0 flex-shrink-0"
-            onClick={onDismiss}
-          >
-            <X className="w-3.5 h-3.5" />
-          </Button>
-        </div>
-        {error.detail && (
-          <pre className="p-2 rounded border bg-destructive/5 border-destructive/20 text-xs font-mono overflow-auto max-h-32">
-            {error.detail}
-          </pre>
-        )}
-      </div>
-    </Alert>
+    <ErrorBanner
+      summary={error.summary}
+      detail={error.detail}
+      onDismiss={onDismiss}
+      className="mb-0 p-3 sm:p-4 [&>svg]:hidden [&>svg~*]:pl-0"
+    />
   )
 }

--- a/frontend/src/components/ui/error-banner.test.tsx
+++ b/frontend/src/components/ui/error-banner.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ErrorBanner } from './error-banner'
+
+describe('ErrorBanner', () => {
+  it('renders summary text', () => {
+    render(<ErrorBanner summary="Something went wrong" />)
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+  })
+
+  it('renders title when provided', () => {
+    render(<ErrorBanner title="Error" summary="Something went wrong" />)
+    expect(screen.getByText('Error')).toBeInTheDocument()
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+  })
+
+  it('renders detail when provided', () => {
+    render(
+      <ErrorBanner
+        summary="Something went wrong"
+        detail="Stack trace here"
+      />,
+    )
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.getByText('Stack trace here')).toBeInTheDocument()
+  })
+
+  it('does not render dismiss button when onDismiss is not provided', () => {
+    render(<ErrorBanner summary="Something went wrong" />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('renders dismiss button when onDismiss is provided', () => {
+    const onDismiss = vi.fn()
+    render(
+      <ErrorBanner summary="Something went wrong" onDismiss={onDismiss} />,
+    )
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('calls onDismiss when dismiss button is clicked', () => {
+    const onDismiss = vi.fn()
+    render(
+      <ErrorBanner summary="Something went wrong" onDismiss={onDismiss} />,
+    )
+    fireEvent.click(screen.getByRole('button'))
+    expect(onDismiss).toHaveBeenCalled()
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <ErrorBanner summary="Something went wrong" className="custom-class" />,
+    )
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+})

--- a/frontend/src/components/ui/error-banner.tsx
+++ b/frontend/src/components/ui/error-banner.tsx
@@ -1,0 +1,44 @@
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { AlertCircle, X } from 'lucide-react'
+
+export interface ErrorBannerProps {
+  title?: string
+  summary: string
+  detail?: string
+  onDismiss?: () => void
+  className?: string
+}
+
+export function ErrorBanner({ title, summary, detail, onDismiss, className }: ErrorBannerProps) {
+  return (
+    <Alert variant="destructive" className={className}>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-start gap-2">
+          <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            {title && (
+              <AlertTitle className="mb-1 font-medium leading-none tracking-tight">{title}</AlertTitle>
+            )}
+            <AlertDescription className="text-sm">{summary}</AlertDescription>
+          </div>
+          {onDismiss && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0 flex-shrink-0"
+              onClick={onDismiss}
+            >
+              <X className="w-3.5 h-3.5" />
+            </Button>
+          )}
+        </div>
+        {detail && (
+          <pre className="p-2 rounded border bg-destructive/5 border-destructive/20 text-xs font-mono overflow-auto max-h-32">
+            {detail}
+          </pre>
+        )}
+      </div>
+    </Alert>
+  )
+}

--- a/frontend/src/hooks/useOpenCode.ts
+++ b/frontend/src/hooks/useOpenCode.ts
@@ -12,6 +12,7 @@ import type { paths, components } from "../api/opencode-types";
 import { parseNetworkError } from "../lib/opencode-errors";
 import { showToast } from "../lib/toast";
 import { useSessionStatus } from "../stores/sessionStatusStore";
+import { useSendErrorStore } from "../stores/sendErrorStore";
 
 type AssistantMessage = components["schemas"]["AssistantMessage"];
 
@@ -300,6 +301,22 @@ export const useSendPrompt = (opcodeUrl: string | null | undefined, directory?: 
       if (model) {
         const parsedModel = parseModelString(model);
         if (parsedModel) {
+          const cachedProviders = queryClient.getQueryData<{
+            providers: Array<{ id: string; models: Record<string, unknown> }>;
+          }>(['opencode', 'providers', opcodeUrl, directory]);
+          if (cachedProviders?.providers) {
+            const provider = cachedProviders.providers.find(
+              (p) => p.id === parsedModel.providerID,
+            );
+            if (!provider || !(parsedModel.modelID in provider.models)) {
+              throw new FetchError(
+                'Selected model is no longer available. Pick a different model.',
+                409,
+                'MODEL_UNAVAILABLE',
+              );
+            }
+          }
+
           requestData.model = {
             providerID: parsedModel.providerID,
             modelID: parsedModel.modelID,
@@ -342,15 +359,19 @@ export const useSendPrompt = (opcodeUrl: string | null | undefined, directory?: 
       }
 
       const parsed = parseNetworkError(error);
-      showToast.error(parsed.title, {
-        description: parsed.message,
-        duration: 5000,
+      useSendErrorStore.getState().setError({
+        sessionID,
+        title: parsed.title,
+        message: parsed.message,
+        detail: error instanceof FetchError ? error.detail : undefined,
       });
     },
     onSuccess: async (data, variables) => {
       const { sessionID } = variables;
       const { response } = data;
       const messagesQueryKey = ["opencode", "messages", opcodeUrl, sessionID, directory];
+
+      useSendErrorStore.getState().clearError(sessionID);
 
       if (data.queued || !response) {
         queryClient.invalidateQueries({ queryKey: messagesQueryKey });

--- a/frontend/src/hooks/useSendPrompt.test.ts
+++ b/frontend/src/hooks/useSendPrompt.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createElement } from 'react'
+import { useSendPrompt } from './useOpenCode'
+import { FetchError } from '../api/fetchWrapper'
+
+const mockSendPrompt = vi.fn()
+const mockSendPromptAsync = vi.fn()
+
+vi.mock('../api/opencode', async () => {
+  const actual = await vi.importActual('../api/opencode')
+  return {
+    ...actual,
+    OpenCodeClient: vi.fn().mockImplementation(() => ({
+      sendPrompt: mockSendPrompt,
+      sendPromptAsync: mockSendPromptAsync,
+    })),
+  }
+})
+
+vi.mock('@/stores/sessionStatusStore', () => ({
+  useSessionStatus: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('../lib/toast', () => ({
+  showToast: { error: vi.fn() },
+}))
+
+vi.mock('../lib/opencode-errors', () => ({
+  parseNetworkError: vi.fn((err) => ({
+    title: 'Error',
+    message: err.message,
+    isRetryable: false,
+  })),
+}))
+
+const mockClearError = vi.fn()
+const mockSetError = vi.fn()
+
+vi.mock('../stores/sendErrorStore', () => ({
+  useSendErrorStore: {
+    getState: () => ({
+      clearError: mockClearError,
+      setError: mockSetError,
+      getError: vi.fn(),
+    }),
+  },
+}))
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+describe('useSendPrompt', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = createTestQueryClient()
+    mockSendPrompt.mockResolvedValue({
+      info: { id: 'test-response' },
+      parts: [],
+    })
+    mockSendPromptAsync.mockResolvedValue(undefined)
+  })
+
+  const renderHookWithProviders = () =>
+    renderHook(
+      () => useSendPrompt('http://localhost:5551', '/test'),
+      {
+        wrapper: ({ children }) =>
+          createElement(QueryClientProvider, { client: queryClient }, children),
+      }
+    )
+
+  it('proceeds when no providers in cache', async () => {
+    const { result } = renderHookWithProviders()
+
+    await expect(
+      result.current.mutateAsync({
+        sessionID: 'test-session',
+        prompt: 'Hello',
+        model: 'anthropic/claude-sonnet-4',
+      })
+    ).resolves.toBeDefined()
+
+    expect(mockSendPrompt).toHaveBeenCalled()
+  })
+
+  it('throws FetchError with MODEL_UNAVAILABLE when model not in providers', async () => {
+    queryClient.setQueryData(
+      ['opencode', 'providers', 'http://localhost:5551', '/test'],
+      {
+        providers: [
+          {
+            id: 'openai',
+            name: 'OpenAI',
+            models: {
+              'gpt-4': { id: 'gpt-4', name: 'GPT-4' },
+            },
+            isConnected: true,
+          },
+        ],
+        connected: ['openai'],
+        default: {},
+      }
+    )
+
+    const { result } = renderHookWithProviders()
+
+    let error: Error | undefined
+    try {
+      await result.current.mutateAsync({
+        sessionID: 'test-session',
+        prompt: 'Hello',
+        model: 'anthropic/claude-sonnet-4',
+      })
+    } catch (e) {
+      error = e as Error
+    }
+
+    expect(error).toBeInstanceOf(FetchError)
+    expect((error as FetchError).code).toBe('MODEL_UNAVAILABLE')
+    expect((error as FetchError).statusCode).toBe(409)
+    expect(error!.message).toBe('Selected model is no longer available. Pick a different model.')
+    expect(mockSendPrompt).not.toHaveBeenCalled()
+  })
+
+  it('proceeds when model exists in providers', async () => {
+    queryClient.setQueryData(
+      ['opencode', 'providers', 'http://localhost:5551', '/test'],
+      {
+        providers: [
+          {
+            id: 'anthropic',
+            name: 'Anthropic',
+            models: {
+              'claude-sonnet-4': { id: 'claude-sonnet-4', name: 'Claude Sonnet 4' },
+            },
+            isConnected: true,
+          },
+        ],
+        connected: ['anthropic'],
+        default: {},
+      }
+    )
+
+    const { result } = renderHookWithProviders()
+
+    await expect(
+      result.current.mutateAsync({
+        sessionID: 'test-session',
+        prompt: 'Hello',
+        model: 'anthropic/claude-sonnet-4',
+      })
+    ).resolves.toBeDefined()
+
+    expect(mockSendPrompt).toHaveBeenCalled()
+  })
+
+  it('clears stored send error on successful queued retry', async () => {
+    mockClearError.mockClear()
+
+    const { result } = renderHookWithProviders()
+
+    await expect(
+      result.current.mutateAsync({
+        sessionID: 'session-1',
+        prompt: 'Hello',
+        queued: true,
+      })
+    ).resolves.toEqual(expect.objectContaining({ queued: true }))
+
+    expect(mockClearError).toHaveBeenCalledWith('session-1')
+  })
+
+  it('clears stored send error on successful non-queued response', async () => {
+    mockClearError.mockClear()
+
+    const { result } = renderHookWithProviders()
+
+    await expect(
+      result.current.mutateAsync({
+        sessionID: 'session-2',
+        prompt: 'Hello',
+      })
+    ).resolves.toBeDefined()
+
+    expect(mockClearError).toHaveBeenCalledWith('session-2')
+  })
+})

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -47,6 +47,7 @@ import { QuestionPrompt } from "@/components/session/QuestionPrompt";
 import { MinimizedQuestionIndicator } from "@/components/session/MinimizedQuestionIndicator";
 import { PendingActionsGroup } from "@/components/notifications/PendingActionsGroup";
 import { SourceControlPanel } from "@/components/source-control";
+import { SessionSendErrorBanner } from "@/components/session/SessionSendErrorBanner";
 import { SessionTodoDisplay } from "@/components/message/SessionTodoDisplay";
 import { useDialogParam } from "@/hooks/useDialogParam";
 import { useSidebarAction } from "@/hooks/useSidebarAction";
@@ -581,6 +582,7 @@ export function SessionDetail() {
                   onMinimize={() => handleMinimizeQuestion(currentQuestion)}
                 />
               )}
+              <SessionSendErrorBanner sessionId={sessionId} />
               <PromptInput
                 ref={promptInputRef}
                 opcodeUrl={opcodeUrl}

--- a/frontend/src/pages/__tests__/SessionDetail.sendError.test.tsx
+++ b/frontend/src/pages/__tests__/SessionDetail.sendError.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SessionSendErrorBanner } from '@/components/session/SessionSendErrorBanner'
+import { useSendErrorStore } from '@/stores/sendErrorStore'
+
+vi.mock('@/lib/toast', () => ({
+  showToast: { error: vi.fn() },
+}))
+
+describe('SessionDetail send error integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useSendErrorStore.setState({ errors: {} })
+  })
+
+  it('shows error banner with title, message, and detail when store is seeded', () => {
+    useSendErrorStore.getState().setError({
+      sessionID: 'sess-1',
+      title: 'Model Unavailable',
+      message: 'Selected model is no longer available.',
+      detail: '409 Conflict',
+    })
+
+    render(<SessionSendErrorBanner sessionId="sess-1" />)
+
+    expect(screen.getByText('Model Unavailable')).toBeInTheDocument()
+    expect(screen.getByText('Selected model is no longer available.')).toBeInTheDocument()
+    expect(screen.getByText('409 Conflict')).toBeInTheDocument()
+  })
+
+  it('dismisses banner and clears store entry on click', () => {
+    useSendErrorStore.getState().setError({
+      sessionID: 'sess-2',
+      title: 'Error',
+      message: 'Something failed',
+    })
+
+    render(<SessionSendErrorBanner sessionId="sess-2" />)
+    expect(screen.getByText('Something failed')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.queryByText('Something failed')).not.toBeInTheDocument()
+    expect(useSendErrorStore.getState().getError('sess-2')).toBeNull()
+  })
+
+  it('does not trigger a toast error when banner renders', async () => {
+    const { showToast } = await import('@/lib/toast')
+
+    useSendErrorStore.getState().setError({
+      sessionID: 'sess-3',
+      title: 'Error',
+      message: 'No toast please',
+    })
+
+    render(<SessionSendErrorBanner sessionId="sess-3" />)
+    expect(screen.getByText('No toast please')).toBeInTheDocument()
+    expect(showToast.error).not.toHaveBeenCalled()
+  })
+
+  it('does not render banner when no error exists for session', () => {
+    render(<SessionSendErrorBanner sessionId="sess-empty" />)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/stores/modelStore.test.ts
+++ b/frontend/src/stores/modelStore.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useModelStore } from '@/stores/modelStore'
+import type { Provider } from '@/api/providers'
+
+vi.mock('zustand/middleware', async () => {
+  const actual = await vi.importActual('zustand/middleware')
+  return {
+    ...actual,
+    persist: (config: any) => config,
+  }
+})
+
+function makeProvider(overrides: Partial<Provider>): Provider {
+  return {
+    id: overrides.id ?? 'test-provider',
+    name: overrides.name ?? 'Test Provider',
+    models: overrides.models ?? {},
+    env: [],
+    isConnected: true,
+    options: {},
+    ...overrides,
+  }
+}
+
+describe('validateAndSyncModel', () => {
+  beforeEach(() => {
+    useModelStore.setState({
+      model: null,
+      agentModels: {},
+      recentModels: [],
+      favoriteModels: [],
+      variants: {},
+      lastConfigModel: undefined,
+    })
+  })
+
+  it('falls back to syncFromConfig when providers is undefined', () => {
+    useModelStore.getState().validateAndSyncModel('anthropic/claude-sonnet-4', undefined)
+
+    expect(useModelStore.getState().model).toEqual({ providerID: 'anthropic', modelID: 'claude-sonnet-4' })
+  })
+
+  it('sets active model from configModel when current model not in providers but configModel parses to valid model', () => {
+    const providers = [
+      makeProvider({
+        id: 'openai',
+        models: { 'gpt-4o': { id: 'gpt-4o', name: 'GPT-4o' } },
+      }),
+    ]
+
+    useModelStore.setState({
+      model: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+    })
+
+    useModelStore.getState().validateAndSyncModel('openai/gpt-4o', providers)
+
+    expect(useModelStore.getState().model).toEqual({ providerID: 'openai', modelID: 'gpt-4o' })
+  })
+
+  it('clears active model when invalid and no config fallback', () => {
+    const providers = [
+      makeProvider({
+        id: 'openai',
+        models: { 'gpt-4o': { id: 'gpt-4o', name: 'GPT-4o' } },
+      }),
+    ]
+
+    useModelStore.setState({
+      model: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+    })
+
+    useModelStore.getState().validateAndSyncModel(undefined, providers)
+
+    expect(useModelStore.getState().model).toBeNull()
+  })
+
+  it('prunes stale recents and favorites, keeps valid entries', () => {
+    const providers = [
+      makeProvider({
+        id: 'anthropic',
+        models: { 'claude-sonnet-4': { id: 'claude-sonnet-4', name: 'Claude Sonnet 4' } },
+      }),
+    ]
+
+    useModelStore.setState({
+      model: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+      recentModels: [
+        { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+        { providerID: 'openai', modelID: 'gpt-4o' },
+      ],
+      favoriteModels: [
+        { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+        { providerID: 'openai', modelID: 'gpt-4o' },
+      ],
+    })
+
+    useModelStore.getState().validateAndSyncModel('anthropic/claude-sonnet-4', providers)
+
+    expect(useModelStore.getState().recentModels).toEqual([
+      { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+    ])
+    expect(useModelStore.getState().favoriteModels).toEqual([
+      { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+    ])
+  })
+
+  it('is idempotent when re-running with same valid state', () => {
+    const providers = [
+      makeProvider({
+        id: 'anthropic',
+        models: { 'claude-sonnet-4': { id: 'claude-sonnet-4', name: 'Claude Sonnet 4' } },
+      }),
+    ]
+
+    useModelStore.setState({
+      model: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+      recentModels: [{ providerID: 'anthropic', modelID: 'claude-sonnet-4' }],
+      favoriteModels: [{ providerID: 'anthropic', modelID: 'claude-sonnet-4' }],
+    })
+
+    useModelStore.getState().validateAndSyncModel('anthropic/claude-sonnet-4', providers)
+
+    const afterFirst = useModelStore.getState()
+
+    let updateCount = 0
+    const unsubscribe = useModelStore.subscribe(() => {
+      updateCount++
+    })
+
+    useModelStore.getState().validateAndSyncModel('anthropic/claude-sonnet-4', providers)
+    unsubscribe()
+
+    const afterSecond = useModelStore.getState()
+
+    expect(updateCount).toBe(0)
+    expect(afterSecond.model).toEqual(afterFirst.model)
+    expect(afterSecond.recentModels).toEqual(afterFirst.recentModels)
+    expect(afterSecond.favoriteModels).toEqual(afterFirst.favoriteModels)
+  })
+})

--- a/frontend/src/stores/modelStore.ts
+++ b/frontend/src/stores/modelStore.ts
@@ -129,14 +129,14 @@ export const useModelStore = create<ModelStore>()(
       },
 
       validateAndSyncModel: (configModel: string | undefined, providers?: Provider[]) => {
-        if (!configModel) return
-
-        const state = get()
-
         if (!providers) {
-          get().syncFromConfig(configModel)
+          if (configModel) {
+            get().syncFromConfig(configModel)
+          }
           return
         }
+
+        const state = get()
 
         const modelExists = (model: ModelSelection) =>
           providers.some(
@@ -157,7 +157,16 @@ export const useModelStore = create<ModelStore>()(
         }
 
         if (!currentModelExists) {
-          get().syncFromConfig(configModel, true)
+          const parsedConfig = configModel ? parseModelString(configModel) : null
+          const configIsValid = parsedConfig
+            ? providers.some(p => p.id === parsedConfig.providerID && p.models && parsedConfig.modelID in p.models)
+            : false
+
+          if (configIsValid && configModel) {
+            get().syncFromConfig(configModel, true)
+          } else {
+            set({ model: null, lastConfigModel: configModel })
+          }
         }
       },
 

--- a/frontend/src/stores/sendErrorStore.test.ts
+++ b/frontend/src/stores/sendErrorStore.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useSendErrorStore } from './sendErrorStore'
+
+describe('useSendErrorStore', () => {
+  beforeEach(() => {
+    useSendErrorStore.setState({ errors: {} })
+  })
+
+  it('stores error keyed by sessionID', () => {
+    const err = { sessionID: 'session-1', title: 'Error', message: 'Something failed' }
+    useSendErrorStore.getState().setError(err)
+    expect(useSendErrorStore.getState().getError('session-1')).toEqual(err)
+  })
+
+  it('clears error only for the specified sessionID', () => {
+    useSendErrorStore.getState().setError({ sessionID: 'session-1', title: 'Error', message: 'msg1' })
+    useSendErrorStore.getState().setError({ sessionID: 'session-2', title: 'Error', message: 'msg2' })
+    useSendErrorStore.getState().clearError('session-1')
+    expect(useSendErrorStore.getState().getError('session-1')).toBeNull()
+    expect(useSendErrorStore.getState().getError('session-2')).not.toBeNull()
+  })
+
+  it('returns null when no error exists for sessionID', () => {
+    expect(useSendErrorStore.getState().getError('nonexistent')).toBeNull()
+  })
+})

--- a/frontend/src/stores/sendErrorStore.ts
+++ b/frontend/src/stores/sendErrorStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand'
+
+export interface SendError {
+  sessionID: string
+  title: string
+  message: string
+  detail?: string
+}
+
+interface SendErrorStore {
+  errors: Record<string, SendError>
+  setError: (err: SendError) => void
+  clearError: (sessionID: string) => void
+  getError: (sessionID: string) => SendError | null
+}
+
+export const useSendErrorStore = create<SendErrorStore>((set, get) => ({
+  errors: {},
+  setError: (err: SendError) => {
+    set((state) => ({
+      errors: { ...state.errors, [err.sessionID]: err },
+    }))
+  },
+  clearError: (sessionID: string) => {
+    set((state) => {
+      const newErrors = { ...state.errors }
+      delete newErrors[sessionID]
+      return { errors: newErrors }
+    })
+  },
+  getError: (sessionID: string) => {
+    return get().errors[sessionID] || null
+  },
+}))


### PR DESCRIPTION
## Summary
- Validate model availability before sending prompts to prevent invalid request errors
- Replace toast-based send error handling with persistent inline error banners
- Fix stale model state by properly clearing active model when provider changes
- Add preflight check in useSendPrompt to block requests to unavailable models
- Refactor GitErrorBanner into reusable ErrorBanner component

## Changes
- Add model availability preflight check in useOpenCode.ts
- Create sendErrorStore for per-session error tracking
- Add ErrorBanner UI component with title, summary, detail, and dismiss
- Add SessionSendErrorBanner component for session-specific errors
- Fix validateAndSyncModel to clear stale model selection
- Replace showToast.error with inline error banners in useSendPrompt
- Add 29 new tests across 6 test files

## Checks
- pnpm vitest run src/stores/modelStore.test.ts src/stores/sendErrorStore.test.ts src/hooks/useSendPrompt.test.ts src/components/ui/error-banner.test.tsx src/components/session/SessionSendErrorBanner.test.tsx src/pages/__tests__/SessionDetail.sendError.test.tsx