### PR TITLE
feat(frontend): add route loading skeleton and error boundary

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,9 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createBrowserRouter, RouterProvider, Outlet, useNavigate, useLocation } from 'react-router-dom'
+import { createBrowserRouter, RouterProvider, Outlet, useNavigate, useLocation, useNavigation } from 'react-router-dom'
 import { useEffect, useRef, useCallback } from 'react'
+import { AppLoadingSkeleton } from '@/components/ui/AppLoadingSkeleton'
+import { RouteErrorBoundary } from '@/components/ui/RouteErrorBoundary'
 import { Toaster } from 'sonner'
 import { Repos } from './pages/Repos'
 import { RepoDetail } from './pages/RepoDetail'
@@ -85,6 +87,7 @@ function PermissionDialogWrapper() {
 function AppShell() {
   const navigate = useNavigate()
   const location = useLocation()
+  const navigation = useNavigation()
   const rootRef = useRef<HTMLDivElement>(null)
   const { openSheet } = useMobileTabBar()
   useTheme()
@@ -155,6 +158,10 @@ function AppShell() {
     return () => channel.close()
   }, [navigate])
 
+  if (navigation.state === 'loading') {
+    return <AppLoadingSkeleton />
+  }
+
   return (
     <AuthProvider>
       <EventProvider>
@@ -187,6 +194,8 @@ function AppShell() {
 const router = createBrowserRouter([
   {
     element: <AppShell />,
+    errorElement: <RouteErrorBoundary />,
+    HydrateFallback: AppLoadingSkeleton,
     children: [
       {
         path: '/login',

--- a/frontend/src/components/ui/AppLoadingSkeleton.tsx
+++ b/frontend/src/components/ui/AppLoadingSkeleton.tsx
@@ -1,0 +1,63 @@
+function SkeletonBlock({ className }: { className?: string }) {
+  return <div className={`bg-muted animate-pulse rounded ${className ?? ''}`} />
+}
+
+function DesktopSidebarSkeleton() {
+  return (
+    <div className="hidden sm:flex flex-col w-60 shrink-0 h-full border-r border-border bg-card p-3 gap-3">
+      <SkeletonBlock className="h-8 w-32 mb-2" />
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <SkeletonBlock className="h-4 w-4 shrink-0" />
+          <SkeletonBlock className="h-4 flex-1" />
+        </div>
+      ))}
+      <div className="mt-auto flex items-center gap-2">
+        <SkeletonBlock className="h-7 w-7 rounded-full shrink-0" />
+        <SkeletonBlock className="h-4 w-24" />
+      </div>
+    </div>
+  )
+}
+
+function MobileTabBarSkeleton() {
+  return (
+    <div className="sm:hidden fixed bottom-0 inset-x-0 h-16 border-t border-border bg-card flex items-center justify-around px-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="flex flex-col items-center gap-1">
+          <SkeletonBlock className="h-5 w-5" />
+          <SkeletonBlock className="h-2.5 w-8" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ContentSkeleton() {
+  return (
+    <div className="flex-1 min-w-0 flex flex-col p-4 gap-4 overflow-hidden">
+      <SkeletonBlock className="h-8 w-48" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="border border-border rounded-xl p-3 bg-card space-y-2">
+            <div className="flex items-center gap-2">
+              <SkeletonBlock className="h-5 w-5 shrink-0" />
+              <SkeletonBlock className="h-5 w-32" />
+            </div>
+            <SkeletonBlock className="h-4 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function AppLoadingSkeleton() {
+  return (
+    <div className="flex h-dvh w-full min-w-0 bg-background">
+      <DesktopSidebarSkeleton />
+      <ContentSkeleton />
+      <MobileTabBarSkeleton />
+    </div>
+  )
+}

--- a/frontend/src/components/ui/RouteErrorBoundary.tsx
+++ b/frontend/src/components/ui/RouteErrorBoundary.tsx
@@ -1,0 +1,81 @@
+import { useRouteError, useNavigate, isRouteErrorResponse } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { AppLoadingSkeleton } from '@/components/ui/AppLoadingSkeleton'
+import { AlertTriangle, RefreshCw, WifiOff } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+function isNetworkError(error: unknown): boolean {
+  if (error instanceof TypeError && error.message === 'Failed to fetch') return true
+  if (error instanceof TypeError && error.message.includes('NetworkError')) return true
+  if (error instanceof TypeError && error.message.includes('network')) return true
+  return false
+}
+
+export function RouteErrorBoundary() {
+  const error = useRouteError()
+  const navigate = useNavigate()
+  const [reconnecting, setReconnecting] = useState(false)
+  const [online, setOnline] = useState(navigator.onLine)
+
+  useEffect(() => {
+    const handleOnline = () => setOnline(true)
+    const handleOffline = () => setOnline(false)
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (online && isNetworkError(error)) {
+      setReconnecting(true)
+      const timer = setTimeout(() => {
+        navigate(0)
+      }, 800)
+      return () => clearTimeout(timer)
+    }
+  }, [online, error, navigate])
+
+  if (isNetworkError(error)) {
+    if (reconnecting) return <AppLoadingSkeleton />
+
+    return (
+      <div className="flex h-dvh w-full min-w-0 bg-background">
+        <AppLoadingSkeleton />
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-background/80 backdrop-blur-sm">
+          <WifiOff className="w-10 h-10 text-muted-foreground" />
+          <div className="text-center space-y-1">
+            <p className="font-semibold text-foreground">No connection</p>
+            <p className="text-sm text-muted-foreground">Waiting to reconnect…</p>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => navigate(0)} className="gap-2">
+            <RefreshCw className="w-4 h-4" />
+            Retry now
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const message = isRouteErrorResponse(error)
+    ? `${error.status} ${error.statusText}`
+    : error instanceof Error
+      ? error.message
+      : 'An unexpected error occurred'
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-6 p-6 text-center bg-background">
+      <AlertTriangle className="w-12 h-12 text-destructive" />
+      <div className="space-y-2">
+        <h1 className="text-xl font-semibold text-foreground">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground max-w-sm">{message}</p>
+      </div>
+      <Button variant="outline" onClick={() => navigate(0)} className="gap-2">
+        <RefreshCw className="w-4 h-4" />
+        Try again
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/lib/auth-loaders.ts
+++ b/frontend/src/lib/auth-loaders.ts
@@ -1,6 +1,17 @@
 import { redirect } from 'react-router-dom'
 import { getSession } from './auth-client'
 
+function isNetworkError(error: unknown): boolean {
+  return error instanceof TypeError && (error.message === 'Failed to fetch' || error.message.includes('network'))
+}
+
+const defaultAuthConfig: AuthConfig = {
+  enabledProviders: ['credentials'],
+  registrationEnabled: true,
+  isFirstUser: false,
+  adminConfigured: false,
+}
+
 export interface AuthConfig {
   enabledProviders: string[]
   registrationEnabled: boolean
@@ -27,66 +38,84 @@ async function fetchAuthConfig(): Promise<AuthConfig> {
 }
 
 export async function loginLoader() {
-  const [config, session] = await Promise.all([
-    fetchAuthConfig(),
-    getSession(),
-  ])
+  try {
+    const [config, session] = await Promise.all([
+      fetchAuthConfig(),
+      getSession(),
+    ])
 
-  if (session.data?.user) {
-    return redirect('/')
+    if (session.data?.user) {
+      return redirect('/')
+    }
+
+    if (config.isFirstUser && !config.adminConfigured) {
+      return redirect('/setup')
+    }
+
+    return { config }
+  } catch (error) {
+    if (isNetworkError(error)) return { config: defaultAuthConfig }
+    throw error
   }
-
-  if (config.isFirstUser && !config.adminConfigured) {
-    return redirect('/setup')
-  }
-
-  return { config }
 }
 
 export async function setupLoader() {
-  const [config, session] = await Promise.all([
-    fetchAuthConfig(),
-    getSession(),
-  ])
+  try {
+    const [config, session] = await Promise.all([
+      fetchAuthConfig(),
+      getSession(),
+    ])
 
-  if (session.data?.user) {
-    return redirect('/')
+    if (session.data?.user) {
+      return redirect('/')
+    }
+
+    if (!config.isFirstUser || config.adminConfigured) {
+      return redirect('/login')
+    }
+
+    return { config }
+  } catch (error) {
+    if (isNetworkError(error)) return { config: defaultAuthConfig }
+    throw error
   }
-
-  if (!config.isFirstUser || config.adminConfigured) {
-    return redirect('/login')
-  }
-
-  return { config }
 }
 
 export async function registerLoader() {
-  const [config, session] = await Promise.all([
-    fetchAuthConfig(),
-    getSession(),
-  ])
+  try {
+    const [config, session] = await Promise.all([
+      fetchAuthConfig(),
+      getSession(),
+    ])
 
-  if (session.data?.user) {
-    return redirect('/')
+    if (session.data?.user) {
+      return redirect('/')
+    }
+
+    if (!config.registrationEnabled) {
+      return redirect('/login')
+    }
+
+    if (config.isFirstUser && !config.adminConfigured) {
+      return redirect('/setup')
+    }
+
+    return { config }
+  } catch (error) {
+    if (isNetworkError(error)) return { config: defaultAuthConfig }
+    throw error
   }
-
-  if (!config.registrationEnabled) {
-    return redirect('/login')
-  }
-
-  if (config.isFirstUser && !config.adminConfigured) {
-    return redirect('/setup')
-  }
-
-  return { config }
 }
 
 export async function protectedLoader() {
-  const session = await getSession()
-
-  if (!session.data?.user) {
-    return redirect('/login')
+  try {
+    const session = await getSession()
+    if (!session.data?.user) {
+      return redirect('/login')
+    }
+    return null
+  } catch (error) {
+    if (isNetworkError(error)) return null
+    throw error
   }
-
-  return null
 }


### PR DESCRIPTION
## Summary
- Add route loading skeleton (AppLoadingSkeleton) for full-page transitions with sidebar, content grid, and mobile tab bar
- Add route error boundary (RouteErrorBoundary) with network-aware detection and auto-reconnect
- Wrap auth loaders in try/catch with graceful network error handling and default fallback config

## Changes
- frontend/src/App.tsx — wires up useNavigation() loading state, errorElement, and HydrateFallback
- frontend/src/components/ui/AppLoadingSkeleton.tsx (new) — full-page skeleton component
- frontend/src/components/ui/RouteErrorBoundary.tsx (new) — error boundary with offline detection
- frontend/src/lib/auth-loaders.ts — wraps loaders in try/catch with graceful network error handling

## Checks
- pnpm lint
- pnpm build