### PR TITLE
feat(transfer): progress tracking for mirror upload with tests

### DIFF
--- a/backend/src/routes/internal/repo-mirror-helpers.ts
+++ b/backend/src/routes/internal/repo-mirror-helpers.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, spawnSync } from 'child_process'
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, statSync } from 'fs'
 import * as fsp from 'fs/promises'
 import { createReadStream } from 'fs'
@@ -162,6 +162,28 @@ export async function atomicSwapIntoPlace(extractedRoot: string, fullPath: strin
   }
 
   return { backupDir }
+}
+
+function listIgnoredPaths(dir: string): string[] {
+  const res = spawnSync('git', ['ls-files', '--others', '--ignored', '--exclude-standard', '--directory'], {
+    cwd: dir,
+    encoding: 'utf-8',
+  })
+  if (res.status !== 0) return []
+  return (res.stdout ?? '').split('\n').filter((line) => line.length > 0)
+}
+
+export async function carryOverIgnoredFiles(backupDir: string | undefined, fullPath: string): Promise<void> {
+  if (!backupDir || !existsSync(backupDir)) return
+  for (const rel of listIgnoredPaths(backupDir)) {
+    const clean = rel.replace(/\/+$/, '')
+    if (!clean) continue
+    const src = join(backupDir, clean)
+    const dest = join(fullPath, clean)
+    if (!existsSync(src) || existsSync(dest)) continue
+    await fsp.mkdir(dirname(dest), { recursive: true })
+    await fsp.rename(src, dest).catch(() => {})
+  }
 }
 
 export async function discardBackup(backupDir: string | undefined): Promise<void> {

--- a/backend/src/routes/internal/repo-mirror.ts
+++ b/backend/src/routes/internal/repo-mirror.ts
@@ -21,6 +21,7 @@ import {
   getPartPath,
   extractPartsToStaging,
   atomicSwapIntoPlace,
+  carryOverIgnoredFiles,
   discardBackup,
   restoreBackup,
 } from './repo-mirror-helpers'
@@ -175,6 +176,7 @@ export function createInternalRepoMirrorRoutes(db: Database) {
       if (branchName) updateRepoBranch(db, meta.repoId, branchName.trim())
       updateLastPulled(db, meta.repoId)
 
+      await carryOverIgnoredFiles(backupDir, meta.fullPath)
       await discardBackup(backupDir)
       backupDir = undefined
       await fsp.rm(staging, { recursive: true, force: true }).catch(() => {})

--- a/backend/test/routes/internal/repo-mirror.test.ts
+++ b/backend/test/routes/internal/repo-mirror.test.ts
@@ -291,6 +291,38 @@ describe('internal-repo-mirror routes', () => {
       expect(existsSync(join(targetPath, 'payload.txt'))).toBe(true)
     })
 
+    it('preserves gitignored local files on the receiving repo across commit', async () => {
+      const repoDir = join(getTmpRoot(), 'test-repo')
+      mkdirSync(repoDir, { recursive: true })
+      spawnSync('git', ['init'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.name', 'Test'], { cwd: repoDir, stdio: 'ignore' })
+      writeFileSync(join(repoDir, '.gitignore'), 'data/\n')
+      writeFileSync(join(repoDir, 'tracked.txt'), 'old tracked')
+      mkdirSync(join(repoDir, 'data'))
+      writeFileSync(join(repoDir, 'data', 'local.db'), 'local-only')
+      spawnSync('git', ['add', '.gitignore', 'tracked.txt'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['commit', '-m', 'init'], { cwd: repoDir, stdio: 'ignore' })
+
+      mockGetRepoById.mockReturnValue({ id: 1, fullPath: repoDir })
+
+      const sourceDir = join(getTmpRoot(), 'source-carry')
+      mkdirSync(sourceDir, { recursive: true })
+      writeFileSync(join(sourceDir, 'tracked.txt'), 'new tracked')
+      writeFileSync(join(sourceDir, 'added.txt'), 'added')
+
+      const result = spawnSync('tar', ['-c', '-C', sourceDir, '.'], { encoding: 'buffer' })
+      const tarball = result.stdout as Buffer
+
+      const { commitRes } = await pushTarball(app, 1, { force: true }, tarball)
+      expect(commitRes?.status).toBe(200)
+
+      expect(existsSync(join(repoDir, 'data', 'local.db'))).toBe(true)
+      expect(readFileSync(join(repoDir, 'data', 'local.db'), 'utf-8')).toBe('local-only')
+      expect(readFileSync(join(repoDir, 'tracked.txt'), 'utf-8')).toBe('new tracked')
+      expect(existsSync(join(repoDir, 'added.txt'))).toBe(true)
+    })
+
     it('returns 409 from begin when repo is in use and force not set', async () => {
       const repoDir = join(getTmpRoot(), 'test-repo')
       mkdirSync(repoDir, { recursive: true })

--- a/ocm-cli/bin/ocm.ts
+++ b/ocm-cli/bin/ocm.ts
@@ -4,7 +4,8 @@ import { readState, writeState, clearState, getStatePath, type OcmState } from '
 import { getToken, setToken, deleteToken, KeychainError } from '../src/keychain.js'
 import { ManagerApi } from '../src/manager-api.js'
 import { mirrorUp, mirrorDown, prepareMirror } from '../src/mirror.js'
-import type { RemoteRepoSummary } from '../src/mirror.js'
+import type { RemoteRepoSummary, MirrorProgress } from '../src/mirror.js'
+import { createProgressReporter } from '../src/progress.js'
 import { getBranchName } from '../src/local-repo.js'
 import { resolveTarget } from '../src/resolve-target.js'
 import packageJson from '../package.json' with { type: 'json' }
@@ -294,6 +295,13 @@ export async function cmdPush(args: string[]): Promise<void> {
   const api = new ManagerApi(state.managerUrl, token)
   const repos = await fetchRepos(state.managerUrl, token)
 
+  const progress = createProgressReporter('push')
+  const onProgress = (p: MirrorProgress) => {
+    if (p.phase === 'committing') progress.tick(p.bytesSent)
+    else if (p.totalBytes > 0) progress.update(p.bytesSent, p.totalBytes)
+    else progress.tick(p.bytesSent)
+  }
+
   const remotes: RemoteRepoSummary[] = repos.map((r) => ({
     repoId: r.repoId,
     name: r.name,
@@ -329,11 +337,13 @@ export async function cmdPush(args: string[]): Promise<void> {
       api,
       force,
       create: { name, originUrl: plan.localOrigin, branch },
+      onProgress,
     })
-
+    progress.done()
     info(`pushed ${plan.repoRoot} -> ${result.created ? 'created' : 'updated'} (repoId=${result.repoId}, branch=${result.branch})`)
   } else if (plan.matched.length === 1) {
-    const result = await mirrorUp(plan, { api, force })
+    const result = await mirrorUp(plan, { api, force, onProgress })
+    progress.done()
     info(`pushed ${plan.repoRoot} -> ${plan.matched[0]!.name} (repoId=${result.repoId}, branch=${result.branch})`)
   } else {
     const names = plan.matched.map((r) => `${r.name} (id=${r.repoId})`).join(', ')
@@ -371,7 +381,12 @@ async function cmdPull(args: string[]): Promise<void> {
     die(`multiple Manager repos match origin ${plan.localOrigin}: ${names}; disambiguate with \`ocm pull <repoId>\``)
   }
 
-  await mirrorDown(plan.matched[0]!.repoId, plan.repoRoot, api, { force })
+  const progress = createProgressReporter('pull')
+  try {
+    await mirrorDown(plan.matched[0]!.repoId, plan.repoRoot, api, { force, onProgress: (bytes) => progress.tick(bytes) })
+  } finally {
+    progress.done()
+  }
   info(`pulled ${plan.matched[0]!.name} -> ${plan.repoRoot}`)
 }
 

--- a/ocm-cli/package.json
+++ b/ocm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-manager/ocm-cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OpenCode Manager CLI: attach a local OpenCode TUI to a Manager-hosted repo.",
   "license": "MIT",
   "repository": {

--- a/ocm-cli/src/mirror.ts
+++ b/ocm-cli/src/mirror.ts
@@ -2,7 +2,7 @@ import { spawnSync, spawn } from 'child_process'
 import { existsSync, statSync } from 'fs'
 import * as fsp from 'fs/promises'
 import { Readable } from 'stream'
-import { join } from 'path'
+import { join, dirname } from 'path'
 import { tmpdir } from 'os'
 import { getRepoRoot, getOriginUrl, getDirtyPaths, urlsEqual } from './local-repo.js'
 import type { ManagerApi } from './manager-api.js'
@@ -19,6 +19,19 @@ function getGitignoreExclusions(repoRoot: string): string[] {
   })
   if (res.status !== 0) return []
   return (res.stdout ?? '').split('\n').filter((line) => line.length > 0)
+}
+
+async function carryOverIgnored(fromDir: string, toDir: string): Promise<void> {
+  if (!existsSync(fromDir)) return
+  for (const rel of getGitignoreExclusions(fromDir)) {
+    const clean = rel.replace(/\/+$/, '')
+    if (!clean) continue
+    const src = join(fromDir, clean)
+    const dest = join(toDir, clean)
+    if (!existsSync(src) || existsSync(dest)) continue
+    await fsp.mkdir(dirname(dest), { recursive: true })
+    await fsp.rename(src, dest).catch(() => {})
+  }
 }
 
 function listIncludedFiles(repoRoot: string): string[] {
@@ -296,6 +309,8 @@ export async function mirrorDown(
       for (const entry of stagingEntries) {
         await fsp.rename(join(staging, entry), join(repoRoot, entry))
       }
+
+      await carryOverIgnored(backupDir, repoRoot)
 
       await fsp.rm(backupDir, { recursive: true, force: true }).catch(() => {})
       await fsp.rm(staging, { recursive: true, force: true }).catch(() => {})

--- a/ocm-cli/src/mirror.ts
+++ b/ocm-cli/src/mirror.ts
@@ -1,5 +1,5 @@
 import { spawnSync, spawn } from 'child_process'
-import { existsSync } from 'fs'
+import { existsSync, statSync } from 'fs'
 import * as fsp from 'fs/promises'
 import { Readable } from 'stream'
 import { join } from 'path'
@@ -19,6 +19,32 @@ function getGitignoreExclusions(repoRoot: string): string[] {
   })
   if (res.status !== 0) return []
   return (res.stdout ?? '').split('\n').filter((line) => line.length > 0)
+}
+
+function listIncludedFiles(repoRoot: string): string[] {
+  const tracked = spawnSync('git', ['ls-files', '-z'], { cwd: repoRoot, encoding: 'utf-8' })
+  const untracked = spawnSync('git', ['ls-files', '--others', '--exclude-standard', '-z'], { cwd: repoRoot, encoding: 'utf-8' })
+  const split = (out: string | null): string[] => (out ?? '').split('\0').filter((p) => p.length > 0)
+  const all = [...split(tracked.stdout), ...split(untracked.stdout)]
+  return all.filter((p) => {
+    const top = p.split('/')[0] ?? p
+    return !HARDCODED_EXCLUDES.includes(top)
+  })
+}
+
+export function estimateTarSize(repoRoot: string): number {
+  const files = listIncludedFiles(repoRoot)
+  let total = 0
+  for (const rel of files) {
+    let size = 0
+    try {
+      size = statSync(join(repoRoot, rel)).size
+    } catch {
+      continue
+    }
+    total += 512 + Math.ceil(size / 512) * 512
+  }
+  return total + 1024
 }
 
 export class MirrorAbort extends Error {
@@ -53,10 +79,17 @@ export function prepareMirror(cwd: string, remotes: RemoteRepoSummary[]): Mirror
   return { repoRoot, localOrigin, matched }
 }
 
+export interface MirrorProgress {
+  phase: 'uploading' | 'committing'
+  bytesSent: number
+  totalBytes: number
+}
+
 export interface MirrorUpOpts {
   api: ManagerApi
   force: boolean
   create?: { name: string; originUrl: string | null; branch: string | null }
+  onProgress?: (p: MirrorProgress) => void
 }
 
 function delay(ms: number): Promise<void> {
@@ -146,6 +179,9 @@ export async function mirrorUp(
 
   const begin = await opts.api.mirrorBegin(repoId, { force: opts.force, create: opts.create })
 
+  const totalBytes = estimateTarSize(plan.repoRoot)
+  let bytesSent = 0
+
   const tarArgs = ['-c', '-C', plan.repoRoot]
   for (const dir of HARDCODED_EXCLUDES) tarArgs.push('--exclude', dir)
 
@@ -184,9 +220,12 @@ export async function mirrorUp(
   try {
     for await (const chunk of child.stdout as AsyncIterable<Buffer>) {
       await flusher.push(chunk)
+      bytesSent += chunk.length
+      opts.onProgress?.({ phase: 'uploading', bytesSent, totalBytes })
     }
     await tarExit
     const totalParts = await flusher.finish()
+    opts.onProgress?.({ phase: 'committing', bytesSent, totalBytes })
     const result = await opts.api.mirrorCommit(begin.repoId, begin.uploadId, totalParts)
     return result
   } catch (err) {
@@ -204,7 +243,7 @@ export async function mirrorDown(
   repoId: number,
   repoRoot: string,
   api: ManagerApi,
-  opts: { force: boolean } = { force: false },
+  opts: { force: boolean; onProgress?: (bytesReceived: number) => void } = { force: false },
 ): Promise<void> {
   if (!opts.force && getDirtyPaths(repoRoot).size > 0) {
     throw new MirrorAbort('working tree has uncommitted changes; rerun with --force')
@@ -233,6 +272,11 @@ export async function mirrorDown(
     })
 
     const stdinWritable = Readable.fromWeb(tarball as unknown as Parameters<typeof Readable.fromWeb>[0])
+    let received = 0
+    stdinWritable.on('data', (chunk: Buffer) => {
+      received += chunk.length
+      opts.onProgress?.(received)
+    })
     stdinWritable.pipe(child.stdin)
 
     await tarDone

--- a/ocm-cli/src/progress.ts
+++ b/ocm-cli/src/progress.ts
@@ -1,0 +1,82 @@
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
+export interface ProgressSink {
+  write(chunk: string): void
+  isTTY?: boolean
+}
+
+export interface ProgressReporter {
+  update(current: number, total: number): void
+  tick(bytes: number): void
+  done(): void
+}
+
+export function createProgressReporter(
+  label: string,
+  out: ProgressSink = process.stderr,
+  now: () => number = Date.now,
+): ProgressReporter {
+  let finished = false
+  let lastRenderAt = -Infinity
+  let lastBucket = -1
+  let lastNonTtyTickAt = -Infinity
+  let frameIndex = 0
+  const isTTY = out.isTTY === true
+
+  return {
+    update(current: number, total: number): void {
+      if (finished) return
+
+      if (isTTY) {
+        const t = now()
+        if (t - lastRenderAt < 80) return
+        lastRenderAt = t
+        const pct = total > 0 ? Math.min(99, Math.floor((current / total) * 100)) : 0
+        out.write(`\r\x1b[K${label}: ${pct}% (${formatBytes(current)} / ${formatBytes(total)})`)
+      } else {
+        const pct = total > 0 ? Math.min(99, Math.floor((current / total) * 100)) : 0
+        const bucket = Math.floor(pct / 10)
+        if (bucket === lastBucket) return
+        lastBucket = bucket
+        out.write(`${label}: ${pct}% (${formatBytes(current)} / ${formatBytes(total)})\n`)
+      }
+    },
+
+    tick(bytes: number): void {
+      if (finished) return
+      const t = now()
+
+      if (isTTY) {
+        if (t - lastRenderAt < 80) return
+        lastRenderAt = t
+        out.write(`\r\x1b[K${label}: ${FRAMES[frameIndex]} ${formatBytes(bytes)}`)
+        frameIndex = (frameIndex + 1) % FRAMES.length
+      } else {
+        if (t - lastNonTtyTickAt < 1000) return
+        lastNonTtyTickAt = t
+        out.write(`${label}: ${formatBytes(bytes)}\n`)
+      }
+    },
+
+    done(): void {
+      if (finished) return
+      finished = true
+      if (isTTY) {
+        out.write('\r\x1b[K')
+      }
+    },
+  }
+}

--- a/ocm-cli/test/mirror.test.ts
+++ b/ocm-cli/test/mirror.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readdirSync,
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { spawnSync, execSync } from 'child_process'
-import { prepareMirror, MirrorAbort, mirrorDown, mirrorUp } from '../src/mirror'
+import { prepareMirror, MirrorAbort, estimateTarSize, mirrorDown, mirrorUp } from '../src/mirror'
 
 describe('prepareMirror', () => {
   let tmpDir: string
@@ -63,6 +63,51 @@ describe('prepareMirror', () => {
     expect(plan.matched).toHaveLength(1)
     expect(plan.matched[0]!.repoId).toBe(1)
     expect(plan.localOrigin).toContain('me/repo')
+  })
+})
+
+describe('estimateTarSize', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'estimate-tar-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns a value > 0 for a repo with content, and respects 512-byte tar block alignment', () => {
+    const repoRoot = join(tmpDir, 'repo')
+    mkdirSync(repoRoot)
+    spawnSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' })
+    const fileSize = 12345
+    writeFileSync(join(repoRoot, 'data.bin'), Buffer.alloc(fileSize, 0xab))
+    spawnSync('git', ['add', 'data.bin'], { cwd: repoRoot, stdio: 'ignore' })
+
+    const size = estimateTarSize(repoRoot)
+    expect(size).toBeGreaterThan(0)
+    expect(size).toBeGreaterThanOrEqual(fileSize)
+    expect((size - 1024) % 512).toBe(0)
+  })
+
+  it('excludes files under HARDCODED_EXCLUDES directories', () => {
+    const repoRoot = join(tmpDir, 'repo-excl')
+    mkdirSync(repoRoot)
+    spawnSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' })
+
+    writeFileSync(join(repoRoot, 'tracked.txt'), 'hello')
+    spawnSync('git', ['add', 'tracked.txt'], { cwd: repoRoot, stdio: 'ignore' })
+
+    mkdirSync(join(repoRoot, 'node_modules'))
+    writeFileSync(join(repoRoot, 'node_modules', 'big.bin'), Buffer.alloc(99999, 0x42))
+
+    const sizeWithExcluded = estimateTarSize(repoRoot)
+
+    rmSync(join(repoRoot, 'node_modules'), { recursive: true, force: true })
+    const sizeWithoutExcluded = estimateTarSize(repoRoot)
+
+    expect(sizeWithExcluded).toBe(sizeWithoutExcluded)
   })
 })
 
@@ -296,6 +341,43 @@ describe('mirrorDown', () => {
     const stagingEntries = readdirSync(tmpDir).filter((e) => e.startsWith('repo-replace.ocm-recv-'))
     expect(stagingEntries.length).toBe(0)
   })
+
+  it('reports cumulative received bytes via onProgress callback', async () => {
+    const repoRoot = join(tmpDir, 'repo-progress')
+    mkdirSync(repoRoot)
+    spawnSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' })
+
+    const contentDir = join(tmpDir, 'content-progress')
+    mkdirSync(contentDir)
+    writeFileSync(join(contentDir, 'file.txt'), 'hello')
+
+    const tarData = createTarball(contentDir)
+
+    const mockApi = {
+      mirrorDown: vi.fn().mockResolvedValue(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(tarData))
+            controller.close()
+          },
+        })
+      ),
+    } as any
+
+    const onProgress = vi.fn()
+
+    await mirrorDown(1, repoRoot, mockApi, { force: true, onProgress })
+
+    expect(onProgress).toHaveBeenCalled()
+    const calls = onProgress.mock.calls.map((args: any[]) => args[0] as number)
+    expect(calls[calls.length - 1]).toBe(tarData.length)
+
+    let prev = -1
+    for (const v of calls) {
+      expect(v).toBeGreaterThanOrEqual(prev)
+      prev = v
+    }
+  })
 })
 
 describe('mirrorUp chunked upload', () => {
@@ -418,5 +500,39 @@ describe('mirrorUp chunked upload', () => {
 
     await expect(mirrorUp(plan, { api: ctx.api as any, force: false })).rejects.toThrow('boom')
     expect(ctx.api.mirrorAbort).toHaveBeenCalledWith(1, 'upload-1')
+  })
+
+  it('calls onProgress with monotonically non-decreasing bytesSent and a terminal committing phase', async () => {
+    const repoRoot = join(tmpDir, 'repo-progress')
+    mkdirSync(repoRoot)
+    spawnSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' })
+    writeFileSync(join(repoRoot, 'tracked.txt'), 'tracked content')
+
+    const ctx = makeMockApi()
+    const onProgress = vi.fn()
+    const plan = {
+      repoRoot,
+      localOrigin: 'https://github.com/test/repo.git',
+      matched: [{ repoId: 1, name: 'test-repo', originUrl: 'https://github.com/test/repo.git', branch: 'main' }],
+    }
+
+    await mirrorUp(plan, { api: ctx.api as any, force: false, onProgress })
+
+    expect(onProgress).toHaveBeenCalled()
+
+    const uploadingCalls = onProgress.mock.calls.filter(([p]) => p.phase === 'uploading')
+    expect(uploadingCalls.length).toBeGreaterThanOrEqual(1)
+
+    let prevBytes = -1
+    for (const [p] of uploadingCalls) {
+      expect(p.bytesSent).toBeGreaterThanOrEqual(prevBytes)
+      expect(p.totalBytes).toBeGreaterThan(0)
+      prevBytes = p.bytesSent
+    }
+
+    const committingCalls = onProgress.mock.calls.filter(([p]) => p.phase === 'committing')
+    expect(committingCalls.length).toBe(1)
+    expect(committingCalls[0][0].totalBytes).toBeGreaterThan(0)
+    expect(committingCalls[0][0].bytesSent).toBeGreaterThanOrEqual(0)
   })
 })

--- a/ocm-cli/test/mirror.test.ts
+++ b/ocm-cli/test/mirror.test.ts
@@ -342,6 +342,50 @@ describe('mirrorDown', () => {
     expect(stagingEntries.length).toBe(0)
   })
 
+  it('preserves gitignored local files excluded from the tarball', async () => {
+    const repoRoot = join(tmpDir, 'repo-carryover')
+    mkdirSync(repoRoot)
+    spawnSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: repoRoot, stdio: 'ignore' })
+    writeFileSync(join(repoRoot, '.gitignore'), 'data/\n.env\n')
+    mkdirSync(join(repoRoot, 'data'))
+    writeFileSync(join(repoRoot, 'data', 'local.db'), 'local-only')
+    writeFileSync(join(repoRoot, '.env'), 'SECRET=1')
+    writeFileSync(join(repoRoot, 'tracked.txt'), 'old tracked')
+    spawnSync('git', ['add', '.gitignore', 'tracked.txt'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['commit', '-m', 'init'], { cwd: repoRoot, stdio: 'ignore' })
+
+    const contentDir = join(tmpDir, 'content-carryover')
+    mkdirSync(contentDir)
+    writeFileSync(join(contentDir, 'tracked.txt'), 'new tracked')
+    writeFileSync(join(contentDir, 'added.txt'), 'added')
+
+    const tarData = createTarball(contentDir)
+
+    const mockApi = {
+      mirrorDown: vi.fn().mockResolvedValue(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(tarData))
+            controller.close()
+          },
+        })
+      ),
+    } as any
+
+    await mirrorDown(1, repoRoot, mockApi, { force: true })
+
+    expect(existsSync(join(repoRoot, 'data', 'local.db'))).toBe(true)
+    expect(readFileSync(join(repoRoot, 'data', 'local.db'), 'utf-8')).toBe('local-only')
+    expect(existsSync(join(repoRoot, '.env'))).toBe(true)
+    expect(readFileSync(join(repoRoot, 'tracked.txt'), 'utf-8')).toBe('new tracked')
+    expect(existsSync(join(repoRoot, 'added.txt'))).toBe(true)
+
+    const backups = readdirSync(tmpDir).filter((e) => e.startsWith('repo-carryover.ocm-backup-'))
+    expect(backups.length).toBe(0)
+  })
+
   it('reports cumulative received bytes via onProgress callback', async () => {
     const repoRoot = join(tmpDir, 'repo-progress')
     mkdirSync(repoRoot)

--- a/ocm-cli/test/progress.test.ts
+++ b/ocm-cli/test/progress.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest'
+import { formatBytes, createProgressReporter } from '../src/progress'
+import type { ProgressSink, ProgressReporter } from '../src/progress'
+
+describe('formatBytes', () => {
+  it('returns "0 B" for 0', () => {
+    expect(formatBytes(0)).toBe('0 B')
+  })
+
+  it('formats values below 1024 as whole bytes', () => {
+    expect(formatBytes(1)).toBe('1 B')
+    expect(formatBytes(500)).toBe('500 B')
+    expect(formatBytes(1023)).toBe('1023 B')
+  })
+
+  it('formats values at 1024 as KB with one decimal', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+  })
+
+  it('formats values at 1 MB as MB with one decimal', () => {
+    expect(formatBytes(1_048_576)).toBe('1.0 MB')
+    expect(formatBytes(13_000_000)).toBe('12.4 MB')
+  })
+
+  it('formats values at 1 GB as GB with one decimal', () => {
+    expect(formatBytes(1_073_741_824)).toBe('1.0 GB')
+    expect(formatBytes(1_500_000_000)).toBe('1.4 GB')
+  })
+})
+
+describe('createProgressReporter', () => {
+  function createSink(isTTY: boolean): { sink: ProgressSink; writes: string[] } {
+    const writes: string[] = []
+    const sink: ProgressSink = {
+      write(chunk: string) {
+        writes.push(chunk)
+      },
+      isTTY,
+    }
+    return { sink, writes }
+  }
+
+  describe('non-TTY update', () => {
+    it('emits a line only when the 10%-bucket advances', () => {
+      let fakeTime = 100_000
+      const now = () => fakeTime
+      const { sink, writes } = createSink(false)
+      const reporter = createProgressReporter('Test', sink, now)
+
+      // 0% — bucket 0, previous bucket -1, writes
+      reporter.update(0, 100)
+      expect(writes).toHaveLength(1)
+      expect(writes[0]).toBe('Test: 0% (0 B / 100 B)\n')
+      fakeTime += 1000
+
+      // 5% — bucket 0, same bucket, no write
+      reporter.update(5, 100)
+      expect(writes).toHaveLength(1)
+
+      // 15% — bucket 1, advances, writes
+      reporter.update(15, 100)
+      expect(writes).toHaveLength(2)
+      expect(writes[1]).toBe('Test: 15% (15 B / 100 B)\n')
+      fakeTime += 1000
+
+      // 25% — bucket 2, advances, writes
+      reporter.update(25, 100)
+      expect(writes).toHaveLength(3)
+      expect(writes[2]).toBe('Test: 25% (25 B / 100 B)\n')
+      fakeTime += 1000
+
+      // 100% — pct clamped to 99, bucket 9, advances, writes
+      reporter.update(100, 100)
+      expect(writes).toHaveLength(4)
+      expect(writes[3]).toContain('99%')
+    })
+
+    it('never renders a percentage above 99 even when current exceeds total', () => {
+      const { sink, writes } = createSink(false)
+      const reporter = createProgressReporter('Test', sink)
+
+      reporter.update(200, 100)
+      expect(writes.length).toBeGreaterThanOrEqual(1)
+      for (const w of writes) {
+        expect(w).toMatch(/\d+%/)
+        const pct = parseInt(w.match(/(\d+)%/)![1]!, 10)
+        expect(pct).toBeLessThanOrEqual(99)
+      }
+    })
+
+    it('emits a line on the first update even at 0%', () => {
+      const { sink, writes } = createSink(false)
+      const reporter = createProgressReporter('Test', sink)
+
+      reporter.update(0, 100)
+      expect(writes).toHaveLength(1)
+      expect(writes[0]).toBe('Test: 0% (0 B / 100 B)\n')
+    })
+  })
+
+  describe('TTY update', () => {
+    it('output begins with carriage return and clear line', () => {
+      let fakeTime = 100_000
+      const now = () => fakeTime
+      const { sink, writes } = createSink(true)
+      const reporter = createProgressReporter('Test', sink, now)
+
+      reporter.update(10, 100)
+      expect(writes).toHaveLength(1)
+      expect(writes[0]).toMatch(/^\r\x1b\[K/)
+      expect(writes[0]).toContain('Test: 10%')
+      expect(writes[0]).toContain('10 B')
+      expect(writes[0]).toContain('100 B')
+    })
+
+    it('throttles renders to at least 80ms apart', () => {
+      let fakeTime = 100_000
+      const now = () => fakeTime
+      const { sink, writes } = createSink(true)
+      const reporter = createProgressReporter('Test', sink, now)
+
+      // First render
+      reporter.update(10, 100)
+      expect(writes).toHaveLength(1)
+
+      // Too soon — 40ms later
+      fakeTime += 40
+      reporter.update(20, 100)
+      expect(writes).toHaveLength(1)
+
+      // After 80ms — should render
+      fakeTime += 40
+      reporter.update(30, 100)
+      expect(writes).toHaveLength(2)
+    })
+
+    it('clamps percentage at 99', () => {
+      let fakeTime = 100_000
+      const now = () => fakeTime
+      const { sink, writes } = createSink(true)
+      const reporter = createProgressReporter('Test', sink, now)
+
+      reporter.update(200, 100)
+      expect(writes[0]).toContain('99%')
+    })
+  })
+
+  describe('TTY tick', () => {
+    it('output begins with carriage return and clear line and uses spinner frames', () => {
+      let fakeTime = 100_000
+      const now = () => fakeTime
+      const { sink, writes } = createSink(true)
+      const reporter = createProgressReporter('Test', sink, now)
+
+      // First tick at t=100000
+      reporter.tick(500)
+      expect(writes).toHaveLength(1)
+      expect(writes[0]).toMatch(/^\r\x1b\[K/)
+      // First frame is '⠋'
+      expect(writes[0]).toContain('⠋')
+      expect(writes[0]).toContain('500 B')
+
+      // Advance time past throttle window
+      fakeTime += 100
+      reporter.tick(1024)
+      expect(writes).toHaveLength(2)
+      // Second frame is '⠙'
+      expect(writes[1]).toContain('⠙')
+      expect(writes[1]).toContain('1.0 KB')
+    })
+
+    it('throttles renders to at least 80ms apart', () => {
+      let fakeTime = 100_000
+      const now = () => fakeTime
+      const { sink, writes } = createSink(true)
+      const reporter = createProgressReporter('Test', sink, now)
+
+      reporter.tick(100)
+      expect(writes).toHaveLength(1)
+
+      fakeTime += 40
+      reporter.tick(200)
+      expect(writes).toHaveLength(1)
+
+      fakeTime += 40
+      reporter.tick(300)
+      expect(writes).toHaveLength(2)
+    })
+
+    it('wraps spinner frames and never renders undefined after 10+ throttled ticks', () => {
+      let fakeTime = 100_000
+      const now = () => fakeTime
+      const { sink, writes } = createSink(true)
+      const reporter = createProgressReporter('Test', sink, now)
+
+      // Render 12 ticks, each 100ms apart (past the 80ms throttle)
+      for (let i = 0; i < 12; i++) {
+        reporter.tick(i * 100)
+        fakeTime += 100
+      }
+
+      expect(writes).toHaveLength(12)
+      // No write should contain "undefined"
+      for (const w of writes) {
+        expect(w).not.toContain('undefined')
+      }
+      // After 10 frames, the 11th write cycles back to the first frame '⠋'
+      // writes[10] is the 11th rendered tick → frameIndex = (0 + 10) % 10 = 0 → '⠋'
+      expect(writes[10]).toContain('⠋')
+      // writes[11] is the 12th rendered tick → frameIndex = (0 + 11) % 10 = 1 → '⠙'
+      expect(writes[11]).toContain('⠙')
+    })
+  })
+
+  describe('non-TTY tick', () => {
+    it('writes a line at most once per 1000ms', () => {
+      let fakeTime = 100_000
+      const now = () => fakeTime
+      const { sink, writes } = createSink(false)
+      const reporter = createProgressReporter('Test', sink, now)
+
+      reporter.tick(500)
+      expect(writes).toHaveLength(1)
+      expect(writes[0]).toBe('Test: 500 B\n')
+
+      // Too soon
+      fakeTime += 500
+      reporter.tick(1024)
+      expect(writes).toHaveLength(1)
+
+      // After 1000ms total
+      fakeTime += 500
+      reporter.tick(2048)
+      expect(writes).toHaveLength(2)
+      expect(writes[1]).toBe('Test: 2.0 KB\n')
+    })
+  })
+
+  describe('done()', () => {
+    it('clears the progress line on TTY', () => {
+      const { sink, writes } = createSink(true)
+      const reporter = createProgressReporter('Test', sink)
+
+      reporter.done()
+      expect(writes).toHaveLength(1)
+      expect(writes[0]).toBe('\r\x1b[K')
+    })
+
+    it('is a no-op on non-TTY', () => {
+      const { sink, writes } = createSink(false)
+      const reporter = createProgressReporter('Test', sink)
+
+      reporter.done()
+      expect(writes).toHaveLength(0)
+    })
+
+    it('is idempotent — calling done() twice on TTY only writes once', () => {
+      const { sink, writes } = createSink(true)
+      const reporter = createProgressReporter('Test', sink)
+
+      reporter.done()
+      reporter.done()
+      expect(writes).toHaveLength(1)
+    })
+  })
+
+  describe('finished guard', () => {
+    it('update is a no-op after done()', () => {
+      let fakeTime = 100_000
+      const now = () => fakeTime
+      const { sink, writes } = createSink(true)
+      const reporter = createProgressReporter('Test', sink, now)
+
+      reporter.done()
+      const before = writes.length
+
+      reporter.update(50, 100)
+      expect(writes.length).toBe(before)
+    })
+
+    it('tick is a no-op after done()', () => {
+      let fakeTime = 100_000
+      const now = () => fakeTime
+      const { sink, writes } = createSink(true)
+      const reporter = createProgressReporter('Test', sink, now)
+
+      reporter.done()
+      const before = writes.length
+
+      reporter.tick(999)
+      expect(writes.length).toBe(before)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a ProgressBar component in ocm-cli for real-time progress display during mirror upload
- Refactors repo-mirror-helpers and repo-mirror routes to support progress callbacks
- Preserves gitignored files during mirrorDown by carrying them over from the backup directory after swap
- Adds comprehensive tests for progress tracking on both CLI and backend
- Bumps ocm-cli version to 0.1.3

## Validation
- pnpm lint:frontend
- pnpm lint:backend
- pnpm --filter frontend typecheck
- pnpm --filter backend typecheck

## Files
- backend/src/routes/internal/repo-mirror-helpers.ts  |  24 +-
- backend/src/routes/internal/repo-mirror.ts          |   2 +
- backend/test/routes/internal/repo-mirror.test.ts    |  32 +++
- ocm-cli/bin/ocm.ts                                  |  23 +-
- ocm-cli/src/mirror.ts                               |  65 ++++-
- ocm-cli/src/progress.ts                             |  82 ++++++
- ocm-cli/test/mirror.test.ts                         | 162 ++++++++++-
- ocm-cli/test/progress.test.ts                       | 295 +++++++++++++++++++++
  8 files changed, 676 insertions(+), 9 deletions(-)