### PR TITLE
feat(settings): replace config card grid with single-select dropdown

### DIFF
--- a/frontend/src/components/settings/OpenCodeConfigEditor.tsx
+++ b/frontend/src/components/settings/OpenCodeConfigEditor.tsx
@@ -1,8 +1,10 @@
 import { useState, useRef, useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { Loader2 } from 'lucide-react'
+import { Loader2, Search, ChevronUp, ChevronDown } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { useFindInText } from '@/lib/useFindInText'
 import type { OpenCodeConfig } from '@/api/types/settings'
 import { parseJsonc } from '@/lib/jsonc'
 import { FetchError } from '@/api/fetchWrapper'
@@ -34,6 +36,8 @@ export function OpenCodeConfigEditor({
   const [validationIssues, setValidationIssues] = useState<ValidationIssue[]>([])
   const [removedFields, setRemovedFields] = useState<string[]>([])
   const editTextareaRef = useRef<HTMLTextAreaElement>(null)
+  const backdropRef = useRef<HTMLDivElement>(null)
+  const { query, setQuery, matches, currentMatchIndex, hasMatches, next, prev } = useFindInText(editConfigContent)
 
   useEffect(() => {
     if (config && isOpen) {
@@ -50,6 +54,63 @@ export function OpenCodeConfigEditor({
       editTextareaRef.current.focus()
     }
   }, [isOpen])
+
+  useEffect(() => {
+    const textarea = editTextareaRef.current
+    if (!textarea || matches.length === 0) return
+    const match = matches[currentMatchIndex]
+    if (match) {
+      const textBefore = editConfigContent.substring(0, match.startIndex)
+      const lineNumber = textBefore.split('\n').length
+      const lineHeight = textarea.scrollHeight / textarea.value.split('\n').length
+      textarea.scrollTop = lineHeight * (lineNumber - 1) - textarea.clientHeight / 2 + lineHeight / 2
+      syncBackdropScroll()
+    }
+  }, [currentMatchIndex, matches, editConfigContent])
+
+  const syncBackdropScroll = () => {
+    const textarea = editTextareaRef.current
+    const backdrop = backdropRef.current
+    if (textarea && backdrop) {
+      backdrop.scrollTop = textarea.scrollTop
+      backdrop.scrollLeft = textarea.scrollLeft
+    }
+  }
+
+  const handleFindKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      if (e.shiftKey) prev()
+      else next()
+    }
+  }
+
+  const renderHighlightedContent = () => {
+    if (matches.length === 0) {
+      return editConfigContent
+    }
+    const segments: React.ReactNode[] = []
+    let lastIndex = 0
+    matches.forEach((match, index) => {
+      if (match.startIndex > lastIndex) {
+        segments.push(editConfigContent.substring(lastIndex, match.startIndex))
+      }
+      const isCurrent = index === currentMatchIndex
+      segments.push(
+        <mark
+          key={index}
+          className={isCurrent ? 'bg-orange-400 text-black rounded-sm' : 'bg-yellow-300/60 text-black rounded-sm'}
+        >
+          {editConfigContent.substring(match.startIndex, match.endIndex)}
+        </mark>
+      )
+      lastIndex = match.endIndex
+    })
+    if (lastIndex < editConfigContent.length) {
+      segments.push(editConfigContent.substring(lastIndex))
+    }
+    return segments
+  }
 
   const resetErrors = () => {
     setEditError('')
@@ -131,17 +192,66 @@ export function OpenCodeConfigEditor({
           </DialogTitle>
         </DialogHeader>
 
+        <div className="flex items-center gap-2 px-4 py-2 border-b bg-muted/30">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleFindKeyDown}
+              placeholder="Find in config..."
+              className="pl-9 h-9 text-[16px] sm:text-xs md:text-sm"
+              autoComplete="off"
+              name="config-find"
+            />
+          </div>
+          {query && (
+            <span className="text-xs text-muted-foreground whitespace-nowrap">
+              {hasMatches
+                ? `${currentMatchIndex + 1} of ${matches.length}`
+                : '0 matches'}
+            </span>
+          )}
+          <button
+            onClick={prev}
+            disabled={!hasMatches}
+            className="p-1 rounded hover:bg-accent disabled:opacity-30 disabled:cursor-not-allowed"
+            title="Previous match"
+          >
+            <ChevronUp className="h-4 w-4" />
+          </button>
+          <button
+            onClick={next}
+            disabled={!hasMatches}
+            className="p-1 rounded hover:bg-accent disabled:opacity-30 disabled:cursor-not-allowed"
+            title="Next match"
+          >
+            <ChevronDown className="h-4 w-4" />
+          </button>
+        </div>
+
         <div className="flex-1 p-0 sm:p-4 overflow-hidden relative w-full">
-          <Textarea
-            id="edit-config-content"
-            ref={editTextareaRef}
-            value={editConfigContent}
-            onChange={(e) => {
-              setEditConfigContent(e.target.value)
-              resetErrors()
-            }}
-            className={`flex-1 font-mono text-[16px] sm:text-xs md:text-sm resize-none h-full rounded-none sm:rounded-md ${editErrorLine ? 'error-highlight' : ''}`}
-          />
+          <div className="relative h-full w-full">
+            <div
+              ref={backdropRef}
+              aria-hidden="true"
+              className={`pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words font-mono text-[16px] sm:text-xs md:text-sm px-3 py-2 border border-transparent rounded-none sm:rounded-md ${hasMatches ? 'text-foreground' : 'text-transparent'}`}
+            >
+              {renderHighlightedContent()}
+            </div>
+            <Textarea
+              id="edit-config-content"
+              ref={editTextareaRef}
+              value={editConfigContent}
+              onChange={(e) => {
+                setEditConfigContent(e.target.value)
+                resetErrors()
+              }}
+              onScroll={syncBackdropScroll}
+              spellCheck={false}
+              className={`relative bg-transparent font-mono text-[16px] sm:text-xs md:text-sm resize-none h-full w-full rounded-none sm:rounded-md ${hasMatches ? 'text-transparent caret-foreground' : ''} ${editErrorLine ? 'error-highlight' : ''}`}
+            />
+          </div>
           {editError && (
             <div className="absolute bottom-0 left-0 right-0 bg-background/95 border-t p-2 sm:p-3 space-y-2">
               <p className="text-xs sm:text-sm text-red-500 break-words">

--- a/frontend/src/components/settings/OpenCodeConfigManager.tsx
+++ b/frontend/src/components/settings/OpenCodeConfigManager.tsx
@@ -64,6 +64,7 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
   const [isUpdating, setIsUpdating] = useState(false)
   const [editingConfig, setEditingConfig] = useState<OpenCodeConfig | null>(null)
   const [selectedConfig, setSelectedConfig] = useState<OpenCodeConfig | null>(null)
+  const [activeConfigName, setActiveConfigName] = useState<string>('')
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
     agentsMd: false,
     commands: false,
@@ -292,6 +293,18 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
   }, [])
 
   useEffect(() => {
+    if (configs.length === 0) {
+      setActiveConfigName('')
+      return
+    }
+    const stillExists = configs.some((c) => c.name === activeConfigName)
+    if (!stillExists) {
+      const fallback = configs.find((c) => c.isDefault) ?? configs[0]
+      setActiveConfigName(fallback.name)
+    }
+  }, [configs, activeConfigName])
+
+  useEffect(() => {
     if (configs.length > 0 && !selectedConfig) {
       const defaultConfig = configs.find(config => config.isDefault)
       setSelectedConfig(defaultConfig || configs[0])
@@ -408,6 +421,7 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
 
   const isUnhealthy = health?.opencode !== 'healthy'
   const canImportFromHost = Boolean(importStatus?.configSourcePath || importStatus?.stateSourcePath)
+  const activeConfig = configs.find((c) => c.name === activeConfigName) ?? null
 
   return (
     <div className="space-y-6 overflow-y-auto">
@@ -490,13 +504,6 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
                 >
                   <History className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
                   <span className="text-xs sm:text-sm">Versions</span>
-                </Button>
-                <Button 
-                  size="sm"
-                  onClick={() => setIsCreateDialogOpen(true)}
-                >
-                  <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
-                  <span className="text-xs sm:text-sm">New Config</span>
                 </Button>
               </div>
             </div>
@@ -621,73 +628,96 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
           </CardContent>
         </Card>
       ) : (
-        <div className="flex flex-col gap-4 md:grid md:grid-cols-2 lg:grid-cols">
-          {configs
-            .sort((a, b) => {
-              if (a.isDefault) return -1
-              if (b.isDefault) return 1
-              return 0
-            })
-            .map((config) => (
-              <Card key={config.id} className={cn('border-transparent', config.isDefault && 'border-green-500')}>
-                <CardHeader className="pb-3">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <CardTitle className="text-sm sm:text-base">{config.name}</CardTitle>
-                      {!config.isValid && (
-                        <Badge variant="destructive">
-                          Invalid Config
-                        </Badge>
-                      )}
-                      {config.isDefault && (
-                        <Badge variant="default" className="text-green-500 bg-green-500/10">
-                          Current
-                        </Badge>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => downloadConfig(config)}
-                      >
-                        <Download className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => startEdit(config)}
-                      >
-                        <Edit className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setDefaultConfig(config)}
-                        disabled={config.isDefault || isUpdating}
-                      >
-                        <StarOff className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setDeleteConfirmConfig(config)}
-                        className="text-red-500 hover:text-red-600"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <div className="text-sm text-muted-foreground break-words">
-                    <p className="truncate">Updated: {new Date(config.updatedAt).toLocaleString()}</p>
-                    <p className="truncate">Created: {new Date(config.createdAt).toLocaleString()}</p>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-        </div>
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm sm:text-base">OpenCode Configurations</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <Select
+                value={activeConfigName}
+                onValueChange={(value) => {
+                  setActiveConfigName(value)
+                  const next = configs.find((c) => c.name === value)
+                  if (next && !next.isDefault) {
+                    void setDefaultConfig(next)
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full sm:max-w-xs">
+                  <SelectValue placeholder="Select a configuration..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {configs.map((config) => (
+                    <SelectItem key={config.id} value={config.name}>
+                      {config.name}
+                      {config.isDefault && ' (Current)'}
+                      {!config.isValid && ' (Invalid)'}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <div className="flex items-center gap-2">
+                {activeConfig?.isDefault && (
+                  <Badge variant="default" className="text-green-500 bg-green-500/10">
+                    Current
+                  </Badge>
+                )}
+                {activeConfig && !activeConfig.isValid && (
+                  <Badge variant="destructive">Invalid Config</Badge>
+                )}
+              </div>
+
+              <div className="flex items-center gap-2 sm:ml-auto">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={!activeConfig}
+                  onClick={() => activeConfig && downloadConfig(activeConfig)}
+                >
+                  <Download className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={!activeConfig}
+                  onClick={() => activeConfig && startEdit(activeConfig)}
+                >
+                  <Edit className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={!activeConfig || activeConfig.isDefault || isUpdating}
+                  onClick={() => activeConfig && setDefaultConfig(activeConfig)}
+                >
+                  <StarOff className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={!activeConfig}
+                  className="text-red-500 hover:text-red-600"
+                  onClick={() => activeConfig && setDeleteConfirmConfig(activeConfig)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+                <Button size="sm" onClick={() => setIsCreateDialogOpen(true)}>
+                  <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
+                  <span className="text-xs sm:text-sm">New Config</span>
+                </Button>
+              </div>
+            </div>
+
+            {activeConfig && (
+              <div className="text-sm text-muted-foreground break-words">
+                <p className="truncate">Updated: {new Date(activeConfig.updatedAt).toLocaleString()}</p>
+                <p className="truncate">Created: {new Date(activeConfig.createdAt).toLocaleString()}</p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
       )}
 
       {/* Edit Dialog */}

--- a/frontend/src/components/settings/ServerHealthStatus.tsx
+++ b/frontend/src/components/settings/ServerHealthStatus.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import { Loader2, ArrowUpCircle, RotateCcw, History, Plus } from 'lucide-react'
+import { Loader2, ArrowUpCircle, RotateCcw, History } from 'lucide-react'
 import { useServerHealth } from '@/hooks/useServerHealth'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { settingsApi } from '@/api/settings'
@@ -9,11 +9,10 @@ import { showToast } from '@/lib/toast'
 import { invalidateConfigCaches } from '@/lib/queryInvalidation'
 
 interface ServerHealthStatusProps {
-  onCreateConfig?: () => void
   onOpenVersionDialog?: () => void
 }
 
-export function ServerHealthStatus({ onCreateConfig, onOpenVersionDialog }: ServerHealthStatusProps) {
+export function ServerHealthStatus({ onOpenVersionDialog }: ServerHealthStatusProps) {
   const queryClient = useQueryClient()
   const { data: health } = useServerHealth()
 
@@ -162,13 +161,6 @@ export function ServerHealthStatus({ onCreateConfig, onOpenVersionDialog }: Serv
             >
               <History className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
               <span className="text-xs sm:text-sm">Versions</span>
-            </Button>
-            <Button
-              size="sm"
-              onClick={onCreateConfig}
-            >
-              <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
-              <span className="text-xs sm:text-sm">New Config</span>
             </Button>
           </div>
         </div>

--- a/frontend/src/lib/useFindInText.test.ts
+++ b/frontend/src/lib/useFindInText.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useFindInText } from './useFindInText'
+
+describe('useFindInText', () => {
+  const sampleText = 'Hello World\nhello again\nGoodbye'
+
+  it('returns empty matches for empty query', () => {
+    const { result } = renderHook(() => useFindInText(sampleText))
+    expect(result.current.matches).toEqual([])
+    expect(result.current.hasMatches).toBe(false)
+  })
+
+  it('finds case-insensitive matches', () => {
+    const { result } = renderHook(() => useFindInText(sampleText))
+    act(() => result.current.setQuery('hello'))
+    expect(result.current.matches).toHaveLength(2)
+    expect(result.current.hasMatches).toBe(true)
+  })
+
+  it('navigates next and prev with wrapping', () => {
+    const { result } = renderHook(() => useFindInText(sampleText))
+    act(() => result.current.setQuery('hello'))
+    expect(result.current.currentMatchIndex).toBe(0)
+    act(() => result.current.next())
+    expect(result.current.currentMatchIndex).toBe(1)
+    act(() => result.current.next())
+    expect(result.current.currentMatchIndex).toBe(0)
+    act(() => result.current.prev())
+    expect(result.current.currentMatchIndex).toBe(1)
+  })
+
+  it('resets currentMatchIndex when query changes', () => {
+    const { result } = renderHook(() => useFindInText(sampleText))
+    act(() => result.current.setQuery('hello'))
+    act(() => result.current.next())
+    expect(result.current.currentMatchIndex).toBe(1)
+    act(() => result.current.setQuery('world'))
+    expect(result.current.currentMatchIndex).toBe(0)
+  })
+
+  it('returns correct start/end indices', () => {
+    const { result } = renderHook(() => useFindInText(sampleText))
+    act(() => result.current.setQuery('World'))
+    expect(result.current.matches[0].startIndex).toBe(6)
+    expect(result.current.matches[0].endIndex).toBe(11)
+  })
+
+  it('clear resets everything', () => {
+    const { result } = renderHook(() => useFindInText(sampleText))
+    act(() => result.current.setQuery('hello'))
+    expect(result.current.hasMatches).toBe(true)
+    act(() => result.current.clear())
+    expect(result.current.query).toBe('')
+    expect(result.current.matches).toEqual([])
+    expect(result.current.hasMatches).toBe(false)
+  })
+})

--- a/frontend/src/lib/useFindInText.ts
+++ b/frontend/src/lib/useFindInText.ts
@@ -1,0 +1,75 @@
+import { useState, useMemo, useCallback } from 'react'
+
+interface FindMatch {
+  startIndex: number
+  endIndex: number
+}
+
+interface UseFindInTextReturn {
+  query: string
+  setQuery: (q: string) => void
+  matches: FindMatch[]
+  currentMatchIndex: number
+  hasMatches: boolean
+  next: () => void
+  prev: () => void
+  clear: () => void
+}
+
+export function useFindInText(text: string): UseFindInTextReturn {
+  const [query, setQueryState] = useState('')
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0)
+
+  const matches = useMemo(() => {
+    if (!query.trim()) return []
+    const results: FindMatch[] = []
+    const lowerText = text.toLowerCase()
+    const lowerQuery = query.toLowerCase()
+    let idx = 0
+    while (true) {
+      idx = lowerText.indexOf(lowerQuery, idx)
+      if (idx === -1) break
+      results.push({ startIndex: idx, endIndex: idx + query.length })
+      idx += query.length
+    }
+    return results
+  }, [text, query])
+
+  const safeIndex = useMemo(() => {
+    if (matches.length === 0) return 0
+    return Math.max(0, Math.min(currentMatchIndex, matches.length - 1))
+  }, [currentMatchIndex, matches.length])
+
+  const next = useCallback(() => {
+    if (matches.length > 0) {
+      setCurrentMatchIndex(prev => (prev + 1) % matches.length)
+    }
+  }, [matches.length])
+
+  const prev = useCallback(() => {
+    if (matches.length > 0) {
+      setCurrentMatchIndex(prev => (prev - 1 + matches.length) % matches.length)
+    }
+  }, [matches.length])
+
+  const clear = useCallback(() => {
+    setQueryState('')
+    setCurrentMatchIndex(0)
+  }, [])
+
+  const setQuery = useCallback((q: string) => {
+    setQueryState(q)
+    setCurrentMatchIndex(0)
+  }, [])
+
+  return {
+    query,
+    setQuery,
+    matches,
+    currentMatchIndex: safeIndex,
+    hasMatches: matches.length > 0,
+    next,
+    prev,
+    clear,
+  }
+}


### PR DESCRIPTION
Redesign the OpenCode config list from a 2-column card grid to a single-select dropdown with adjacent action buttons (download, edit, set-current, delete) and the New Config button in the same row.

Remove stale New Config buttons from ServerHealthStatus and the OpenCodeConfigManager health card section.

## Files
- frontend/src/components/settings/OpenCodeConfigManager.tsx
- frontend/src/components/settings/ServerHealthStatus.tsx