### PR TITLE
fix(frontend): adapt session list to OpenCode v1.16.0 API response changes

### DIFF
--- a/frontend/src/api/opencode.test.ts
+++ b/frontend/src/api/opencode.test.ts
@@ -44,6 +44,45 @@ describe('OpenCodeClient', () => {
   })
 
   describe('listSessionsPage', () => {
+    it('handles v1.16.0+ API response format with data envelope and nested location', async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: 'ses_v2_1',
+                projectID: 'proj_v2',
+                parentID: 'parent_v2',
+                title: 'V2 Session',
+                time: { created: 3000, updated: 4000 },
+                location: { directory: '/my-repo', workspaceID: 'ws_v2' },
+                agent: 'default',
+                model: { id: 'gpt-4', providerID: 'openai' },
+                cost: 0.05,
+                tokens: { input: 100, output: 50, reasoning: 10, cache: { read: 0, write: 0 } },
+              },
+            ],
+            cursor: { next: 'v2_cursor' },
+          }),
+          { status: 200 },
+        ),
+      )
+
+      const result = await new OpenCodeClient('/api/opencode', '/repo').listSessionsPage({ limit: 10 })
+
+      expect(result.items).toHaveLength(1)
+      expect(result.items[0]).toMatchObject({
+        id: 'ses_v2_1',
+        projectID: 'proj_v2',
+        workspaceID: 'ws_v2',
+        directory: '/repo',
+        parentID: 'parent_v2',
+        title: 'V2 Session',
+        version: 'v2',
+      })
+      expect(result.nextCursor).toBe('v2_cursor')
+    })
+
     it('sends first-page params to /api/session with directory and returns adapted sessions', async () => {
       fetchMock.mockResolvedValue(
         new Response(

--- a/frontend/src/api/opencode.ts
+++ b/frontend/src/api/opencode.ts
@@ -27,13 +27,29 @@ type SessionV2Info = {
   id: string
   parentID?: string
   projectID: string
-  workspaceID?: string
   title: string
-  time: LegacySession['time']
-  path?: unknown
+  time: {
+    created: number
+    updated: number
+    archived?: number
+  }
+  location: {
+    directory: string
+    workspaceID?: string
+  }
+  agent?: string
+  model?: { id: string; providerID: string; variant?: string }
+  cost: number
+  tokens: {
+    input: number
+    output: number
+    reasoning: number
+    cache: { read: number; write: number }
+  }
+  subpath?: string
 }
 type SessionPageCursor = { previous?: string; next?: string }
-type SessionPageResponse = { items: SessionV2Info[]; cursor?: SessionPageCursor }
+type SessionPageResponse = { data: SessionV2Info[]; cursor?: SessionPageCursor }
 type SessionPageParams = { limit?: number; order?: 'asc' | 'desc'; search?: string; cursor?: string }
 type SessionPage = { items: LegacySession[]; nextCursor?: string }
 
@@ -41,8 +57,8 @@ function toLegacySession(session: SessionV2Info, directory?: string): LegacySess
   return {
     id: session.id,
     projectID: session.projectID,
-    workspaceID: session.workspaceID,
-    directory: directory ?? '',
+    workspaceID: session.location.workspaceID,
+    directory: directory ?? session.location.directory ?? '',
     parentID: session.parentID,
     title: session.title || 'Untitled Session',
     version: 'v2',
@@ -89,7 +105,7 @@ export class OpenCodeClient {
       params: queryParams,
     })
     return {
-      items: response.items.map((item) => toLegacySession(item, this.directory)),
+      items: response.data.map((item) => toLegacySession(item, this.directory)),
       nextCursor: response.cursor?.next,
     }
   }

--- a/frontend/src/api/opencode.ts
+++ b/frontend/src/api/opencode.ts
@@ -23,42 +23,67 @@ type LspStatusResponse = paths['/lsp']['get']['responses']['200']['content']['ap
 type LspStatus = LspStatusResponse[number]
 
 type LegacySession = SessionListResponse[number]
-type SessionV2Info = {
+
+/** Pre-v1.16.0 session shape returned by /api/session */
+type SessionV2InfoV1 = {
+  id: string
+  parentID?: string
+  projectID: string
+  workspaceID?: string
+  title: string
+  time: { created: number; updated: number; compacting?: number; archived?: number }
+  path?: unknown
+}
+
+/** v1.16.0+ session shape returned by /api/session */
+type SessionV2InfoV2 = {
   id: string
   parentID?: string
   projectID: string
   title: string
-  time: {
-    created: number
-    updated: number
-    archived?: number
-  }
-  location: {
-    directory: string
-    workspaceID?: string
-  }
+  time: { created: number; updated: number; archived?: number }
+  location: { directory: string; workspaceID?: string }
   agent?: string
   model?: { id: string; providerID: string; variant?: string }
   cost: number
-  tokens: {
-    input: number
-    output: number
-    reasoning: number
-    cache: { read: number; write: number }
-  }
+  tokens: { input: number; output: number; reasoning: number; cache: { read: number; write: number } }
   subpath?: string
 }
+
+type SessionV2Info = SessionV2InfoV1 | SessionV2InfoV2
 type SessionPageCursor = { previous?: string; next?: string }
-type SessionPageResponse = { data: SessionV2Info[]; cursor?: SessionPageCursor }
+
+/** Response from /api/session — may be old (items) or new (data) format */
+type SessionPageResponse = {
+  data?: SessionV2InfoV2[]
+  items?: SessionV2InfoV1[]
+  cursor?: SessionPageCursor
+}
 type SessionPageParams = { limit?: number; order?: 'asc' | 'desc'; search?: string; cursor?: string }
 type SessionPage = { items: LegacySession[]; nextCursor?: string }
 
+function isNewSession(session: SessionV2Info): session is SessionV2InfoV2 {
+  return 'location' in session && session.location !== undefined
+}
+
 function toLegacySession(session: SessionV2Info, directory?: string): LegacySession {
+  if (isNewSession(session)) {
+    return {
+      id: session.id,
+      projectID: session.projectID,
+      workspaceID: session.location.workspaceID,
+      directory: directory ?? session.location.directory ?? '',
+      parentID: session.parentID,
+      title: session.title || 'Untitled Session',
+      version: 'v2',
+      time: session.time,
+    } as LegacySession
+  }
   return {
     id: session.id,
     projectID: session.projectID,
-    workspaceID: session.location.workspaceID,
-    directory: directory ?? session.location.directory ?? '',
+    workspaceID: session.workspaceID,
+    directory: directory ?? '',
     parentID: session.parentID,
     title: session.title || 'Untitled Session',
     version: 'v2',
@@ -104,8 +129,9 @@ export class OpenCodeClient {
     const response = await fetchWrapper<SessionPageResponse>(`${this.baseURL}/api/session`, {
       params: queryParams,
     })
+    const rawItems = response.data ?? response.items ?? []
     return {
-      items: response.data.map((item) => toLegacySession(item, this.directory)),
+      items: rawItems.map((item) => toLegacySession(item, this.directory)),
       nextCursor: response.cursor?.next,
     }
   }


### PR DESCRIPTION
The OpenCode server v1.16.0 refactored the `/api/session` paginated endpoint. Two breaking changes required adaptation:

1. **Response wrapper renamed from `items` to `data`** — the session array is now at `response.data` instead of `response.items`.
2. **Session object structure changed** — `workspaceID` and `directory` moved into a nested `location` object, the `version` field was removed, and new fields (`agent`, `model`, `cost`, `tokens`, `subpath`) were added.

The `toLegacySession()` bridge normalizes the new shape back to the legacy flat format so all existing consumers (SessionList, SessionCard, delete flow, etc.) continue to work unchanged.

## Files
- frontend/src/api/opencode.ts