### PR TITLE
refactor(sse): harden SSE with queue-based writer, backpressure, and directory-aware batching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,11 @@ FROM base AS runner
 
 ARG UV_VERSION=latest
 ARG OPENCODE_VERSION=latest
+# Bump TOOLS_CACHEBUST (e.g. via --build-arg) to force a fresh uv/opencode
+# install without invalidating the rest of the build cache.
+ARG TOOLS_CACHEBUST=0
 
-RUN echo "Installing uv=${UV_VERSION} opencode=${OPENCODE_VERSION}" && \
+RUN echo "Installing uv=${UV_VERSION} opencode=${OPENCODE_VERSION} (cachebust=${TOOLS_CACHEBUST})" && \
     curl -LsSf https://astral.sh/uv/install.sh | UV_NO_MODIFY_PATH=1 sh && \
     mv /root/.local/bin/uv /usr/local/bin/uv && \
     mv /root/.local/bin/uvx /usr/local/bin/uvx && \

--- a/backend/src/routes/sse-writer.ts
+++ b/backend/src/routes/sse-writer.ts
@@ -1,0 +1,63 @@
+export interface QueuedSSEWriterInput {
+  write: (chunk: Uint8Array) => Promise<unknown> | void
+  onError: (error: unknown) => void
+}
+
+export interface QueuedSSEWriter {
+  writeSSE: (event: string, data: string) => void
+  writeFrame: (frame: Uint8Array) => void
+  close: () => void
+}
+
+const sharedEncoder = new TextEncoder()
+const MAX_QUEUED_FRAMES = 1024
+
+export function encodeSSEFrame(event: string, data: string): Uint8Array {
+  const head = event ? `event: ${event}\n` : ''
+  return sharedEncoder.encode(`${head}data: ${data}\n\n`)
+}
+
+export function createQueuedSSEWriter(input: QueuedSSEWriterInput): QueuedSSEWriter {
+  const queue: Uint8Array[] = []
+  let draining = false
+  let closed = false
+
+  const pump = async () => {
+    if (draining || closed) return
+    draining = true
+    try {
+      while (queue.length > 0 && !closed) {
+        const frame = queue.shift() as Uint8Array
+        await input.write(frame)
+      }
+    } catch (error) {
+      if (!closed) {
+        closed = true
+        input.onError(error)
+      }
+    } finally {
+      draining = false
+    }
+  }
+
+  const writeFrame = (frame: Uint8Array) => {
+    if (closed) return
+    if (queue.length >= MAX_QUEUED_FRAMES) {
+      return
+    }
+    queue.push(frame)
+    void pump()
+  }
+
+  const writeSSE = (event: string, data: string) => {
+    if (closed) return
+    writeFrame(encodeSSEFrame(event, data))
+  }
+
+  const close = () => {
+    closed = true
+    queue.length = 0
+  }
+
+  return { writeSSE, writeFrame, close }
+}

--- a/backend/src/routes/sse-writer.ts
+++ b/backend/src/routes/sse-writer.ts
@@ -1,3 +1,5 @@
+import { encodeSSEFrame } from '../utils/sse-frame'
+
 export interface QueuedSSEWriterInput {
   write: (chunk: Uint8Array) => Promise<unknown> | void
   onError: (error: unknown) => void
@@ -9,13 +11,7 @@ export interface QueuedSSEWriter {
   close: () => void
 }
 
-const sharedEncoder = new TextEncoder()
 const MAX_QUEUED_FRAMES = 1024
-
-export function encodeSSEFrame(event: string, data: string): Uint8Array {
-  const head = event ? `event: ${event}\n` : ''
-  return sharedEncoder.encode(`${head}data: ${data}\n\n`)
-}
 
 export function createQueuedSSEWriter(input: QueuedSSEWriterInput): QueuedSSEWriter {
   const queue: Uint8Array[] = []

--- a/backend/src/routes/sse.ts
+++ b/backend/src/routes/sse.ts
@@ -4,6 +4,7 @@ import { sseAggregator } from '../services/sse-aggregator'
 import { SSESubscribeSchema, SSEVisibilitySchema } from '@opencode-manager/shared/schemas'
 import { logger } from '../utils/logger'
 import { DEFAULTS } from '@opencode-manager/shared/config'
+import { createQueuedSSEWriter } from './sse-writer'
 
 const { HEARTBEAT_INTERVAL_MS } = DEFAULTS.SSE
 
@@ -21,42 +22,39 @@ export function createSSERoutes() {
     c.header('X-Accel-Buffering', 'no')
 
     return stream(c, async (writer) => {
-      const encoder = new TextEncoder()
-      const writeSSE = (event: string, data: string) => {
-        const lines = []
-        if (event) lines.push(`event: ${event}`)
-        lines.push(`data: ${data}`)
-        lines.push('')
-        lines.push('')
-        writer.write(encoder.encode(lines.join('\n')))
-      }
+      let cleanup: () => void = () => {}
 
-      const cleanup = sseAggregator.addClient(
+      const queuedWriter = createQueuedSSEWriter({
+        write: (chunk) => writer.write(chunk),
+        onError: (error) => {
+          logger.error(`SSE write failed for ${clientId}:`, error)
+          clearInterval(heartbeatInterval)
+          cleanup()
+        },
+      })
+
+      const heartbeatInterval = setInterval(() => {
+        queuedWriter.writeSSE('heartbeat', JSON.stringify({ timestamp: Date.now() }))
+      }, HEARTBEAT_INTERVAL_MS)
+
+      cleanup = sseAggregator.addClient(
         clientId,
         (event, data) => {
-          writeSSE(event, data)
+          queuedWriter.writeSSE(event, data)
+        },
+        (frame) => {
+          queuedWriter.writeFrame(frame)
         },
         directories
       )
 
-      const heartbeatInterval = setInterval(() => {
-        try {
-          writeSSE('heartbeat', JSON.stringify({ timestamp: Date.now() }))
-        } catch {
-          clearInterval(heartbeatInterval)
-        }
-      }, HEARTBEAT_INTERVAL_MS)
-
       writer.onAbort(() => {
+        queuedWriter.close()
         clearInterval(heartbeatInterval)
         cleanup()
       })
 
-      try {
-        writeSSE('connected', JSON.stringify({ clientId, directories, ...sseAggregator.getConnectionStatus() }))
-      } catch (err) {
-        logger.error(`Failed to send SSE connected event for ${clientId}:`, err)
-      }
+      queuedWriter.writeSSE('connected', JSON.stringify({ clientId, directories, ...sseAggregator.getConnectionStatus() }))
 
       await new Promise(() => {})
     })

--- a/backend/src/services/assistant-mode.ts
+++ b/backend/src/services/assistant-mode.ts
@@ -1090,7 +1090,7 @@ export async function warmAssistantWorkspace(deps: {
       db: deps.db,
       apiBaseUrl: deps.apiBaseUrl,
     })
-    await deps.openCodeClient.getJson('/session', {
+    await deps.openCodeClient.getJson('/api/session?limit=1&order=desc', {
       directory: status.directory,
       signal: AbortSignal.timeout(ASSISTANT_WARMUP_OPENCODE_TIMEOUT_MS),
     })

--- a/backend/src/services/opencode-single-server.ts
+++ b/backend/src/services/opencode-single-server.ts
@@ -29,6 +29,7 @@ import { writeFileContent } from './file-operations'
 const MIN_OPENCODE_VERSION = '1.0.137'
 const MAX_STDERR_SIZE = 10240
 const HEALTH_CHECK_TIMEOUT_MS = 3000
+const PLUGIN_INSTALL_TIMEOUT_MS = 120000
 const DEPRECATED_PLUGIN_PACKAGES = ['opencode-openai-codex-auth', 'opencode-copilot-auth']
 
 type StartupValidationIssue = {
@@ -585,16 +586,21 @@ class OpenCodeServerManager {
 
       await fs.mkdir(installDir, { recursive: true })
       if (!await fs.access(path.join(installDir, 'package.json')).then(() => true).catch(() => false)) {
-        const init = spawnSync('bun', ['init', '-y'], { cwd: installDir, encoding: 'utf8' })
+        const init = spawnSync('bun', ['init', '-y'], { cwd: installDir, encoding: 'utf8', timeout: 30000 })
         if (init.status !== 0) {
           logger.warn(`Failed to initialize OpenCode plugin cache for ${plugin}: ${init.stderr || init.stdout}`)
           continue
         }
       }
 
-      const result = spawnSync('bun', ['add', '--ignore-scripts', installSpec], { cwd: installDir, encoding: 'utf8' })
+      const result = spawnSync('bun', ['add', '--ignore-scripts', installSpec], { cwd: installDir, encoding: 'utf8', timeout: PLUGIN_INSTALL_TIMEOUT_MS })
       if (result.status === 0) {
         logger.info(`Installed OpenCode plugin: ${plugin}`)
+        continue
+      }
+
+      if (result.error) {
+        logger.warn(`Failed to install OpenCode plugin ${plugin}: ${result.error.message}`)
         continue
       }
 

--- a/backend/src/services/sse-aggregator.ts
+++ b/backend/src/services/sse-aggregator.ts
@@ -2,8 +2,9 @@ import { EventSource } from 'eventsource'
 import { logger } from '../utils/logger'
 import { ENV } from '@opencode-manager/shared/config/env'
 import { DEFAULTS } from '@opencode-manager/shared/config'
+import type { SSEEventEnvelope, SSEEventPayload } from '@opencode-manager/shared'
 import { getOpenCodeBasicAuthHeader, type OpenCodePasswordResolver } from './opencode/auth'
-import { encodeSSEFrame } from '../routes/sse-writer'
+import { encodeSSEFrame } from '../utils/sse-frame'
 
 type SSEClientCallback = (event: string, data: string) => void
 type SSEClientFrameWriter = (frame: Uint8Array) => void
@@ -18,17 +19,7 @@ interface SSEClient {
   activeSessionId: string | null
 }
 
-export interface SSEEvent {
-  type: string
-  properties: Record<string, unknown>
-}
-
-interface GlobalEventEnvelope {
-  directory?: string
-  project?: string
-  workspace?: string
-  payload: SSEEvent
-}
+export type SSEEvent = SSEEventPayload
 
 export interface PendingActionsFetcher {
   getJson<T>(path: string, opts?: { directory?: string; signal?: AbortSignal }): Promise<T>
@@ -333,9 +324,9 @@ class SSEAggregator {
   }
 
   private handleUpstreamMessage(data: string): void {
-    let envelope: GlobalEventEnvelope
+    let envelope: SSEEventEnvelope
     try {
-      envelope = JSON.parse(data) as GlobalEventEnvelope
+      envelope = JSON.parse(data) as SSEEventEnvelope
     } catch {
       return
     }

--- a/backend/src/services/sse-aggregator.ts
+++ b/backend/src/services/sse-aggregator.ts
@@ -3,13 +3,16 @@ import { logger } from '../utils/logger'
 import { ENV } from '@opencode-manager/shared/config/env'
 import { DEFAULTS } from '@opencode-manager/shared/config'
 import { getOpenCodeBasicAuthHeader, type OpenCodePasswordResolver } from './opencode/auth'
+import { encodeSSEFrame } from '../routes/sse-writer'
 
 type SSEClientCallback = (event: string, data: string) => void
+type SSEClientFrameWriter = (frame: Uint8Array) => void
 type SSEEventListener = (directory: string, event: SSEEvent) => void
 
 interface SSEClient {
   id: string
   callback: SSEClientCallback
+  writeFrame: SSEClientFrameWriter
   directories: Set<string>
   visible: boolean
   activeSessionId: string | null
@@ -49,6 +52,7 @@ const { RECONNECT_DELAY_MS, MAX_RECONNECT_DELAY_MS } = DEFAULTS.SSE
 class SSEAggregator {
   private static instance: SSEAggregator
   private clients: Map<string, SSEClient> = new Map()
+  private directoryClients: Map<string, Set<string>> = new Map()
   private activeSessions: Map<string, Set<string>> = new Map()
   private eventListeners: Set<SSEEventListener> = new Set()
   private subagentSessions: Map<string, Set<string>> = new Map()
@@ -95,15 +99,22 @@ class SSEAggregator {
     void this.connectUpstream()
   }
 
-  addClient(id: string, callback: SSEClientCallback, directories: string[]): () => void {
+  addClient(id: string, callback: SSEClientCallback, writeFrame: SSEClientFrameWriter, directories: string[]): () => void {
+    const existing = this.clients.get(id)
+    if (existing) {
+      existing.directories.forEach(dir => this.deindexClientDirectory(id, dir))
+    }
+
     const client: SSEClient = {
       id,
       callback,
+      writeFrame,
       directories: new Set(directories),
       visible: false,
       activeSessionId: null
     }
     this.clients.set(id, client)
+    directories.forEach(dir => this.indexClientDirectory(id, dir))
 
     logger.info(`Client ${id} connected with directories: ${directories.length > 0 ? directories.join(', ') : '(none)'}`)
 
@@ -115,6 +126,10 @@ class SSEAggregator {
   }
 
   removeClient(id: string): void {
+    const client = this.clients.get(id)
+    if (client) {
+      client.directories.forEach(dir => this.deindexClientDirectory(id, dir))
+    }
     this.clients.delete(id)
   }
 
@@ -131,6 +146,7 @@ class SSEAggregator {
       }
       client.directories.add(dir)
     })
+    newDirectories.forEach(dir => this.indexClientDirectory(clientId, dir))
     logger.info(`Client ${clientId} subscribed to: ${directories.join(', ')}`)
 
     if (newDirectories.length > 0) {
@@ -146,9 +162,28 @@ class SSEAggregator {
       logger.warn(`removeDirectories: client ${clientId} not found`)
       return false
     }
-    directories.forEach(dir => client.directories.delete(dir))
+    directories.forEach(dir => {
+      client.directories.delete(dir)
+      this.deindexClientDirectory(clientId, dir)
+    })
     logger.info(`Client ${clientId} unsubscribed from: ${directories.join(', ')}`)
     return true
+  }
+
+  private indexClientDirectory(clientId: string, directory: string): void {
+    let set = this.directoryClients.get(directory)
+    if (!set) {
+      set = new Set()
+      this.directoryClients.set(directory, set)
+    }
+    set.add(clientId)
+  }
+
+  private deindexClientDirectory(clientId: string, directory: string): void {
+    const set = this.directoryClients.get(directory)
+    if (!set) return
+    set.delete(clientId)
+    if (set.size === 0) this.directoryClients.delete(directory)
   }
 
   private async replayPendingActionsForClient(clientId: string, directories: string[]): Promise<void> {
@@ -211,7 +246,7 @@ class SSEAggregator {
     if (!client || !client.directories.has(directory)) return
 
     for (const item of items) {
-      const payload = JSON.stringify({ type, properties: item, directory })
+      const payload = JSON.stringify({ directory, payload: { type, properties: item } })
       try {
         client.callback('message', payload)
       } catch (error) {
@@ -316,16 +351,20 @@ class SSEAggregator {
       try { listener(directory, parsed) } catch { /* ignore listener errors */ }
     })
 
-    const clientData = JSON.stringify({ ...parsed, directory })
-    this.clients.forEach((client) => {
-      if (client.directories.has(directory)) {
+    const subscriberIds = this.directoryClients.get(directory)
+    if (subscriberIds && subscriberIds.size > 0) {
+      let frame: Uint8Array | undefined
+      const getFrame = (): Uint8Array => (frame ??= encodeSSEFrame('message', data))
+      for (const clientId of subscriberIds) {
+        const client = this.clients.get(clientId)
+        if (!client) continue
         try {
-          client.callback('message', clientData)
+          client.writeFrame(getFrame())
         } catch (error) {
           logger.error(`Failed to send to client ${client.id}:`, error)
         }
       }
-    })
+    }
   }
 
   private handleEvent(directory: string, event: SSEEvent): void {
@@ -461,6 +500,7 @@ class SSEAggregator {
 
     this.activeSessions.clear()
     this.subagentSessions.clear()
+    this.directoryClients.clear()
     this.clients.clear()
     this.eventListeners.clear()
   }
@@ -478,8 +518,10 @@ export const sseAggregator = SSEAggregator.getInstance()
 
 export function broadcastSSHHostKeyRequest(data: Record<string, unknown>): void {
   const event = JSON.stringify({
-    type: 'ssh.host-key-request',
-    properties: data,
+    payload: {
+      type: 'ssh.host-key-request',
+      properties: data,
+    },
   })
   sseAggregator.broadcastToAll('message', event)
 }

--- a/backend/src/utils/sse-frame.ts
+++ b/backend/src/utils/sse-frame.ts
@@ -1,0 +1,6 @@
+const sharedEncoder = new TextEncoder()
+
+export function encodeSSEFrame(event: string, data: string): Uint8Array {
+  const head = event ? `event: ${event}\n` : ''
+  return sharedEncoder.encode(`${head}data: ${data}\n\n`)
+}

--- a/backend/test/routes/sse-writer.test.ts
+++ b/backend/test/routes/sse-writer.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createQueuedSSEWriter, encodeSSEFrame } from '../../src/routes/sse-writer'
+
+describe('encodeSSEFrame', () => {
+  const decoder = new TextDecoder()
+
+  it('encodes an event frame', () => {
+    expect(decoder.decode(encodeSSEFrame('message', '{"n":1}'))).toBe('event: message\ndata: {"n":1}\n\n')
+  })
+
+  it('omits the event line when event is empty', () => {
+    expect(decoder.decode(encodeSSEFrame('', '{"n":1}'))).toBe('data: {"n":1}\n\n')
+  })
+})
+
+describe('createQueuedSSEWriter', () => {
+  describe('writeFrame', () => {
+    it('writes a pre-encoded frame through the serialized chain', async () => {
+      const writes: Uint8Array[] = []
+      const write = vi.fn((chunk: Uint8Array) => { writes.push(chunk) })
+      const onError = vi.fn()
+
+      const writer = createQueuedSSEWriter({ write, onError })
+      const frame = encodeSSEFrame('message', '{"shared":true}')
+      writer.writeFrame(frame)
+
+      await vi.waitFor(() => expect(write).toHaveBeenCalledTimes(1))
+      expect(writes[0]).toBe(frame)
+      expect(onError).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('serializes frames in enqueue order', () => {
+    it('should not execute second write until first resolves', async () => {
+      let firstWriteResolve!: () => void
+      const writes: Uint8Array[] = []
+      const write = vi.fn((chunk: Uint8Array) => {
+        writes.push(chunk)
+        if (writes.length === 1) {
+          return new Promise<void>((resolve) => {
+            firstWriteResolve = resolve
+          })
+        }
+      })
+      const onError = vi.fn()
+
+      const writer = createQueuedSSEWriter({ write, onError })
+
+      writer.writeSSE('message', '{"n":1}')
+      writer.writeSSE('message', '{"n":2}')
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(write).toHaveBeenCalledTimes(1)
+      expect(onError).not.toHaveBeenCalled()
+
+      firstWriteResolve()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(write).toHaveBeenCalledTimes(2)
+
+      const decoder = new TextDecoder()
+      expect(decoder.decode(writes[0])).toBe('event: message\ndata: {"n":1}\n\n')
+      expect(decoder.decode(writes[1])).toBe('event: message\ndata: {"n":2}\n\n')
+    })
+  })
+
+  describe('stops writing after a write failure', () => {
+    it('should call onError and skip subsequent writes', async () => {
+      const write = vi.fn().mockRejectedValueOnce(new Error('write failed'))
+      const onError = vi.fn()
+
+      const writer = createQueuedSSEWriter({ write, onError })
+
+      writer.writeSSE('message', '{"n":1}')
+
+      await vi.waitFor(() => {
+        expect(onError).toHaveBeenCalledTimes(1)
+      })
+      expect(onError).toHaveBeenCalledWith(new Error('write failed'))
+      expect(write).toHaveBeenCalledTimes(1)
+
+      writer.writeSSE('message', '{"n":2}')
+
+      await vi.waitFor(() => {
+        expect(write).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('FIFO order across many frames', () => {
+    it('preserves FIFO order across many frames', async () => {
+      const order: number[] = []
+      const write = vi.fn((chunk: Uint8Array) => {
+        const decoded = new TextDecoder().decode(chunk)
+        const match = decoded.match(/"n":(\d+)/)
+        if (match) order.push(Number(match[1]))
+      })
+      const onError = vi.fn()
+      const writer = createQueuedSSEWriter({ write, onError })
+
+      for (let i = 1; i <= 50; i++) {
+        writer.writeSSE('message', `{"n":${i}}`)
+      }
+
+      await vi.waitFor(() => {
+        expect(write).toHaveBeenCalledTimes(50)
+      })
+
+      expect(order).toHaveLength(50)
+      for (let i = 0; i < 50; i++) {
+        expect(order[i]).toBe(i + 1)
+      }
+      expect(onError).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('serialization (no overlap)', () => {
+    it('serializes writes (no overlap)', async () => {
+      let concurrent = 0
+      let maxConcurrent = 0
+      const deferreds: (() => void)[] = []
+
+      const write = vi.fn(() => {
+        concurrent++
+        maxConcurrent = Math.max(maxConcurrent, concurrent)
+        return new Promise<void>((resolve) => {
+          deferreds.push(() => {
+            concurrent--
+            resolve()
+          })
+        })
+      })
+      const onError = vi.fn()
+      const writer = createQueuedSSEWriter({ write, onError })
+
+      writer.writeSSE('message', '{"n":1}')
+      writer.writeSSE('message', '{"n":2}')
+      writer.writeSSE('message', '{"n":3}')
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(write).toHaveBeenCalledTimes(1)
+      expect(maxConcurrent).toBe(1)
+
+      deferreds[0]!()
+      await vi.waitFor(() => expect(write).toHaveBeenCalledTimes(2))
+      expect(maxConcurrent).toBe(1)
+
+      deferreds[1]!()
+      await vi.waitFor(() => expect(write).toHaveBeenCalledTimes(3))
+      expect(maxConcurrent).toBe(1)
+
+      expect(onError).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('frame dropping at queue capacity', () => {
+    it('drops frames beyond MAX_QUEUED_FRAMES when write is blocked', async () => {
+      const deferreds: (() => void)[] = []
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const write = vi.fn((_chunk: Uint8Array) => {
+        return new Promise<void>((resolve) => {
+          deferreds.push(resolve)
+        })
+      })
+      const onError = vi.fn()
+      const writer = createQueuedSSEWriter({ write, onError })
+
+      writer.writeSSE('message', '{"n":1}')
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(deferreds).toHaveLength(1)
+
+      for (let i = 2; i <= 1100; i++) {
+        writer.writeSSE('message', `{"n":${i}}`)
+      }
+
+      while (deferreds.length > 0) {
+        deferreds.shift()!()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      }
+
+      expect(write.mock.calls.length).toBeLessThanOrEqual(1025)
+      expect(write.mock.calls.length).toBeLessThan(1100)
+
+      const decoder = new TextDecoder()
+      const calls = write.mock.calls as [Uint8Array][]
+      calls.forEach(([chunk], i) => {
+        expect(decoder.decode(chunk)).toBe(`event: message\ndata: {"n":${i + 1}}\n\n`)
+      })
+      expect(onError).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('close behavior', () => {
+    it('no-ops after close()', async () => {
+      const write = vi.fn()
+      const onError = vi.fn()
+      const writer = createQueuedSSEWriter({ write, onError })
+
+      writer.close()
+      writer.writeSSE('message', '{"n":1}')
+      writer.writeFrame(new Uint8Array([1, 2, 3]))
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(write).not.toHaveBeenCalled()
+      expect(onError).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('write rejection', () => {
+    it('calls onError once on write rejection', async () => {
+      const write = vi.fn().mockRejectedValue(new Error('boom'))
+      const onError = vi.fn()
+      const writer = createQueuedSSEWriter({ write, onError })
+
+      writer.writeSSE('message', '{"n":1}')
+
+      await vi.waitFor(() => {
+        expect(onError).toHaveBeenCalledTimes(1)
+      })
+      expect(onError).toHaveBeenCalledWith(new Error('boom'))
+
+      writer.writeSSE('message', '{"n":2}')
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(write).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/backend/test/routes/sse-writer.test.ts
+++ b/backend/test/routes/sse-writer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
-import { createQueuedSSEWriter, encodeSSEFrame } from '../../src/routes/sse-writer'
+import { createQueuedSSEWriter } from '../../src/routes/sse-writer'
+import { encodeSSEFrame } from '../../src/utils/sse-frame'
 
 describe('encodeSSEFrame', () => {
   const decoder = new TextDecoder()

--- a/backend/test/services/assistant-mode.test.ts
+++ b/backend/test/services/assistant-mode.test.ts
@@ -620,7 +620,7 @@ describe('warmAssistantWorkspace', () => {
   })
   afterEach(async () => { await ws.cleanup() })
 
-  it('provisions the workspace and triggers a directory-scoped session request', async () => {
+  it('provisions the workspace and triggers a bounded directory-scoped session request', async () => {
     const getJsonCalls: Array<{ path: string; directory?: string }> = []
     const client = {
       getJson: async (requestPath: string, opts?: { directory?: string }) => {
@@ -634,7 +634,7 @@ describe('warmAssistantWorkspace', () => {
     const opencodeJson = await readFile(path.join(ws.assistantDir, 'opencode.json'), 'utf8')
     expect(JSON.parse(opencodeJson).default_agent).toBe('assistant')
     expect(getJsonCalls).toHaveLength(1)
-    expect(getJsonCalls[0]?.path).toBe('/session')
+    expect(getJsonCalls[0]?.path).toBe('/api/session?limit=1&order=desc')
     expect(getJsonCalls[0]?.directory).toBe(ws.assistantDir)
   })
 

--- a/backend/test/services/opencode-single-server.test.ts
+++ b/backend/test/services/opencode-single-server.test.ts
@@ -17,6 +17,8 @@ const spawnMock = vi.hoisted(() => vi.fn(() => ({
   on: vi.fn(),
 })))
 
+const spawnSyncMock = vi.hoisted(() => vi.fn())
+
 vi.mock('bun:sqlite', () => ({
   Database: vi.fn(),
 }))
@@ -62,6 +64,7 @@ vi.mock('fs', () => ({
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
   spawn: spawnMock,
+  spawnSync: spawnSyncMock,
 }))
 
 vi.mock('../../src/services/opencode/config-recovery', () => ({
@@ -73,7 +76,7 @@ vi.mock('../../src/services/opencode/client', () => ({
 }))
 
 import { promises as fs } from 'fs'
-import { execSync } from 'child_process'
+import { execSync, spawnSync } from 'child_process'
 import { ConfigReloadError } from '../../src/services/opencode-single-server'
 import { encryptSecret } from '../../src/utils/crypto'
 import { ENV } from '@opencode-manager/shared/config/env'
@@ -89,6 +92,7 @@ vi.mock('../../src/utils/logger', () => ({
 const mkdirMock = fs.mkdir as any
 const accessMock = fs.access as any
 const execSyncMock = execSync as any
+const childSpawnSyncMock = spawnSync as any
 
 // Reset singleton before any tests run to clear any polluted state from previous test files
 beforeAll(async () => {
@@ -412,4 +416,41 @@ describe('OpenCodeServerManager - checkHealth', () => {
     expect(capturedSignal).toBeDefined()
     expect(aborted).toBe(true)
   }, 5000)
+})
+
+describe('OpenCodeServerManager - configured plugin install', () => {
+  beforeEach(async () => {
+    const { OpenCodeServerManager } = await import('../../src/services/opencode-single-server')
+    OpenCodeServerManager.resetInstance()
+    vi.clearAllMocks()
+  })
+
+  afterEach(async () => {
+    const { OpenCodeServerManager } = await import('../../src/services/opencode-single-server')
+    OpenCodeServerManager.resetInstance()
+    vi.clearAllMocks()
+  })
+
+  it('bounds first-run plugin installation with a timeout', async () => {
+    const { opencodeServerManager } = await import('../../src/services/opencode-single-server')
+    const { logger } = await import('../../src/utils/logger')
+
+    accessMock.mockImplementation((filePath: string) => {
+      const error = new Error('Not found') as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      return filePath.includes('package.json') ? Promise.reject(error) : Promise.resolve()
+    })
+    childSpawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: '', stderr: '' })
+      .mockReturnValueOnce({ status: null, stdout: '', stderr: '', error: new Error('spawnSync bun ETIMEDOUT') })
+
+    await (opencodeServerManager as any).installConfiguredPlugins(['test-plugin'])
+
+    expect(childSpawnSyncMock).toHaveBeenCalledWith(
+      'bun',
+      ['add', '--ignore-scripts', 'test-plugin@latest'],
+      expect.objectContaining({ timeout: 120000 }),
+    )
+    expect(logger.warn).toHaveBeenCalledWith('Failed to install OpenCode plugin test-plugin: spawnSync bun ETIMEDOUT')
+  })
 })

--- a/backend/test/services/sse-aggregator.test.ts
+++ b/backend/test/services/sse-aggregator.test.ts
@@ -23,10 +23,15 @@ interface CapturedEvent {
 
 function createCapturingClient() {
   const events: CapturedEvent[] = []
+  const frames: string[] = []
+  const decoder = new TextDecoder()
   const callback = (event: string, data: string) => {
     events.push({ event, data })
   }
-  return { callback, events }
+  const writeFrame = (frame: Uint8Array) => {
+    frames.push(decoder.decode(frame))
+  }
+  return { callback, writeFrame, events, frames }
 }
 
 function makeFetcher(map: Record<string, { permissions?: unknown[]; questions?: unknown[] }>): PendingActionsFetcher {
@@ -69,29 +74,29 @@ describe('SSEAggregator pending replay on connect', () => {
     })
     sseAggregator.setPendingActionsFetcher(fetcher)
 
-    const { callback, events } = createCapturingClient()
-    sseAggregator.addClient('client-1', callback, ['/repo/a', '/repo/b'])
+    const { callback, writeFrame, events } = createCapturingClient()
+    sseAggregator.addClient('client-1', callback, writeFrame, ['/repo/a', '/repo/b'])
 
     await flushReplay()
 
     expect(events).toHaveLength(4)
 
-    const parsed = events.map(e => JSON.parse(e.data) as { type: string; properties: { id: string }; directory: string })
+    const parsed = events.map(e => JSON.parse(e.data) as { directory: string; payload: { type: string; properties: { id: string } } })
 
-    expect(parsed.filter(p => p.type === 'permission.asked' && p.directory === '/repo/a').map(p => p.properties.id)).toEqual([
+    expect(parsed.filter(p => p.payload.type === 'permission.asked' && p.directory === '/repo/a').map(p => p.payload.properties.id)).toEqual([
       'perm-1',
       'perm-2',
     ])
-    expect(parsed.filter(p => p.type === 'question.asked' && p.directory === '/repo/a').map(p => p.properties.id)).toEqual(['q-1'])
-    expect(parsed.filter(p => p.type === 'permission.asked' && p.directory === '/repo/b').map(p => p.properties.id)).toEqual([
+    expect(parsed.filter(p => p.payload.type === 'question.asked' && p.directory === '/repo/a').map(p => p.payload.properties.id)).toEqual(['q-1'])
+    expect(parsed.filter(p => p.payload.type === 'permission.asked' && p.directory === '/repo/b').map(p => p.payload.properties.id)).toEqual([
       'perm-3',
     ])
-    expect(parsed.filter(p => p.type === 'question.asked' && p.directory === '/repo/b')).toHaveLength(0)
+    expect(parsed.filter(p => p.payload.type === 'question.asked' && p.directory === '/repo/b')).toHaveLength(0)
   })
 
   it('does not replay when no fetcher is configured', async () => {
-    const { callback, events } = createCapturingClient()
-    sseAggregator.addClient('client-2', callback, ['/repo/a'])
+    const { callback, writeFrame, events } = createCapturingClient()
+    sseAggregator.addClient('client-2', callback, writeFrame, ['/repo/a'])
 
     await flushReplay()
 
@@ -107,8 +112,8 @@ describe('SSEAggregator pending replay on connect', () => {
     const clientA = createCapturingClient()
     const clientB = createCapturingClient()
 
-    sseAggregator.addClient('a', clientA.callback, ['/repo/a'])
-    sseAggregator.addClient('b', clientB.callback, [])
+    sseAggregator.addClient('a', clientA.callback, clientA.writeFrame, ['/repo/a'])
+    sseAggregator.addClient('b', clientB.callback, clientB.writeFrame, [])
 
     await flushReplay()
 
@@ -123,8 +128,8 @@ describe('SSEAggregator pending replay on connect', () => {
     })
     sseAggregator.setPendingActionsFetcher(fetcher)
 
-    const { callback, events } = createCapturingClient()
-    sseAggregator.addClient('client-3', callback, ['/repo/a'])
+    const { callback, writeFrame, events } = createCapturingClient()
+    sseAggregator.addClient('client-3', callback, writeFrame, ['/repo/a'])
     await flushReplay()
 
     const initialCount = events.length
@@ -134,11 +139,11 @@ describe('SSEAggregator pending replay on connect', () => {
     await flushReplay()
 
     const newEvents = events.slice(initialCount)
-    const parsed = newEvents.map(e => JSON.parse(e.data) as { type: string; directory: string; properties: { id: string } })
+    const parsed = newEvents.map(e => JSON.parse(e.data) as { directory: string; payload: { type: string; properties: { id: string } } })
     expect(parsed).toHaveLength(1)
     const [first] = parsed
     expect(first?.directory).toBe('/repo/b')
-    expect(first?.properties.id).toBe('perm-2')
+    expect(first?.payload.properties.id).toBe('perm-2')
   })
 
   it('survives upstream fetch failures for one directory and still replays the others', async () => {
@@ -155,15 +160,15 @@ describe('SSEAggregator pending replay on connect', () => {
     }
     sseAggregator.setPendingActionsFetcher(fetcher)
 
-    const { callback, events } = createCapturingClient()
-    sseAggregator.addClient('client-4', callback, ['/repo/broken', '/repo/ok'])
+    const { callback, writeFrame, events } = createCapturingClient()
+    sseAggregator.addClient('client-4', callback, writeFrame, ['/repo/broken', '/repo/ok'])
     await flushReplay()
 
-    const parsed = events.map(e => JSON.parse(e.data) as { directory: string; properties: { id: string } })
+    const parsed = events.map(e => JSON.parse(e.data) as { directory: string; payload: { properties: { id: string } } })
     expect(parsed).toHaveLength(1)
     const [first] = parsed
     expect(first?.directory).toBe('/repo/ok')
-    expect(first?.properties.id).toBe('perm-ok')
+    expect(first?.payload.properties.id).toBe('perm-ok')
   })
 
   it('does not deliver replay events to a client that no longer subscribes to that directory', async () => {
@@ -180,8 +185,8 @@ describe('SSEAggregator pending replay on connect', () => {
     }
     sseAggregator.setPendingActionsFetcher(fetcher)
 
-    const { callback, events } = createCapturingClient()
-    sseAggregator.addClient('client-5', callback, ['/repo/a'])
+    const { callback, writeFrame, events } = createCapturingClient()
+    sseAggregator.addClient('client-5', callback, writeFrame, ['/repo/a'])
 
     sseAggregator.removeDirectories('client-5', ['/repo/a'])
     resolvePermissions([{ id: 'late', sessionID: 's' }])
@@ -189,5 +194,80 @@ describe('SSEAggregator pending replay on connect', () => {
     await flushReplay()
 
     expect(events).toHaveLength(0)
+  })
+})
+
+describe('SSEAggregator directory-indexed broadcast', () => {
+  beforeEach(() => {
+    sseAggregator.shutdown()
+  })
+
+  it('delivers only to clients subscribed to the event directory', () => {
+    const clientA = createCapturingClient()
+    const clientB = createCapturingClient()
+    sseAggregator.addClient('index-a', clientA.callback, clientA.writeFrame, ['/a'])
+    sseAggregator.addClient('index-b', clientB.callback, clientB.writeFrame, ['/b'])
+
+    const data = JSON.stringify({ directory: '/a', payload: { type: 'test', properties: {} } })
+    ;(sseAggregator as any).handleUpstreamMessage(data)
+
+    expect(clientA.frames).toHaveLength(1)
+    expect(clientB.frames).toHaveLength(0)
+  })
+
+  it('does not encode a frame when no client subscribes', () => {
+    const clientA = createCapturingClient()
+    sseAggregator.addClient('index-c', clientA.callback, clientA.writeFrame, ['/a'])
+
+    const data = JSON.stringify({ directory: '/z', payload: { type: 'test', properties: {} } })
+    ;(sseAggregator as any).handleUpstreamMessage(data)
+
+    expect(clientA.frames).toHaveLength(0)
+  })
+
+  it('removeClient deindexes', () => {
+    const clientA = createCapturingClient()
+    sseAggregator.addClient('index-d', clientA.callback, clientA.writeFrame, ['/a'])
+    sseAggregator.removeClient('index-d')
+
+    const data = JSON.stringify({ directory: '/a', payload: { type: 'test', properties: {} } })
+    ;(sseAggregator as any).handleUpstreamMessage(data)
+
+    expect(clientA.frames).toHaveLength(0)
+  })
+
+  it('addDirectories then delivery', () => {
+    const clientA = createCapturingClient()
+    sseAggregator.addClient('index-e', clientA.callback, clientA.writeFrame, [])
+    sseAggregator.addDirectories('index-e', ['/a'])
+
+    const data = JSON.stringify({ directory: '/a', payload: { type: 'test', properties: {} } })
+    ;(sseAggregator as any).handleUpstreamMessage(data)
+
+    expect(clientA.frames).toHaveLength(1)
+  })
+
+  it('replacing a client ID deindexes old directories', () => {
+    const clientA = createCapturingClient()
+    const clientB = createCapturingClient()
+
+    // Add client with id 'index-f' subscribed to /a
+    sseAggregator.addClient('index-f', clientA.callback, clientA.writeFrame, ['/a'])
+
+    // Replace same client ID with different directories (no /a)
+    sseAggregator.addClient('index-f', clientB.callback, clientB.writeFrame, ['/b'])
+
+    // Message for /a should NOT reach either client
+    const dataA = JSON.stringify({ directory: '/a', payload: { type: 'test', properties: {} } })
+    ;(sseAggregator as any).handleUpstreamMessage(dataA)
+
+    expect(clientA.frames).toHaveLength(0)
+    expect(clientB.frames).toHaveLength(0)
+
+    // Message for /b should reach clientB
+    const dataB = JSON.stringify({ directory: '/b', payload: { type: 'test', properties: {} } })
+    ;(sseAggregator as any).handleUpstreamMessage(dataB)
+
+    expect(clientB.frames).toHaveLength(1)
   })
 })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        TOOLS_CACHEBUST: ${TOOLS_CACHEBUST:-0}
     container_name: opencode-manager
     ports:
       - "5003:5003"

--- a/frontend/src/components/message/MessageThread.tsx
+++ b/frontend/src/components/message/MessageThread.tsx
@@ -135,8 +135,7 @@ const findLastMessageByRole = (
 
 interface MessageRowProps {
   msgWithParts: MessageWithParts
-  index: number
-  messages: MessageWithParts[]
+  nextAssistantMessage: MessageWithParts | undefined
   pendingAssistantId: string | undefined
   lastUserMessageId: string | undefined
   isSessionBusy: boolean
@@ -157,8 +156,7 @@ interface MessageRowProps {
 
 const MessageRow = memo(function MessageRow({
   msgWithParts,
-  index,
-  messages,
+  nextAssistantMessage,
   pendingAssistantId,
   lastUserMessageId,
   isSessionBusy,
@@ -183,7 +181,6 @@ const MessageRow = memo(function MessageRow({
   const isLastUserMessage = msg.role === 'user' && msg.id === lastUserMessageId
   const messageTextContent = getMessageTextContent(parts)
 
-  const nextAssistantMessage = messages.slice(index + 1).find(m => m.info.role === 'assistant')
   const nextAssistantMsg = nextAssistantMessage?.info
   const isUserBeforeAssistant = msg.role === 'user' && nextAssistantMessage
   const canEditUserMessage = isLastUserMessage && isUserBeforeAssistant && !isSessionBusy
@@ -352,6 +349,20 @@ export const MessageThread = memo(function MessageThread({
     return findLastMessageByRole(messages, 'user')
   }, [messages])
 
+  const nextAssistantByMessageId = useMemo(() => {
+    const map = new Map<string, MessageWithParts | undefined>()
+    if (!messages) return map
+    let next: MessageWithParts | undefined
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i]
+      map.set(msg.info.id, next)
+      if (msg.info.role === 'assistant') {
+        next = msg
+      }
+    }
+    return map
+  }, [messages])
+
   const isSessionBusy = !!pendingAssistantId || isSessionInRetry(sessionStatus)
   const setSessionTodos = useSessionTodos((state) => state.setTodos)
 
@@ -415,12 +426,11 @@ export const MessageThread = memo(function MessageThread({
 
   return (
     <div className="flex flex-col space-y-2 p-2 overflow-x-hidden">
-      {messages.map((msgWithParts, index) => (
+      {messages.map((msgWithParts) => (
         <MessageRow
           key={msgWithParts.info.id}
           msgWithParts={msgWithParts}
-          index={index}
-          messages={messages}
+          nextAssistantMessage={nextAssistantByMessageId.get(msgWithParts.info.id)}
           pendingAssistantId={pendingAssistantId}
           lastUserMessageId={lastUserMessageId}
           isSessionBusy={isSessionBusy}

--- a/frontend/src/hooks/useAutoScroll.test.tsx
+++ b/frontend/src/hooks/useAutoScroll.test.tsx
@@ -131,6 +131,9 @@ describe('useAutoScroll', () => {
         contentVersion: newMessages.length,
         onScrollStateChange,
       })
+    })
+
+    act(() => {
       vi.advanceTimersByTime(100)
     })
 
@@ -162,6 +165,7 @@ describe('useAutoScroll', () => {
         contentVersion: messages.length + 1,
         onScrollStateChange,
       })
+      vi.advanceTimersByTime(100)
     })
 
     expect(containerHarness.getScrollTop()).toBe(containerHarness.div.scrollHeight - containerHarness.div.clientHeight)
@@ -221,6 +225,29 @@ describe('useAutoScroll', () => {
       containerHarness.div.dispatchEvent(
         new PointerEvent('pointerdown', {
           clientY: 200,
+          bubbles: true,
+        })
+      )
+      containerHarness.setScrollTop(userPosition)
+      vi.runOnlyPendingTimers()
+    })
+
+    expect(containerHarness.getScrollTop()).toBe(userPosition)
+  })
+
+  it('cancels pending bottom scroll when user wheel-scrolls up before pending frames complete', () => {
+    const messages = [createMessage('1', 'user'), createMessage('2', 'assistant')]
+    const { renderResult, containerHarness } = setupHook(messages)
+
+    act(() => {
+      renderResult.result.current.scrollToBottom()
+    })
+
+    const userPosition = 150
+    act(() => {
+      containerHarness.div.dispatchEvent(
+        new WheelEvent('wheel', {
+          deltaY: -50,
           bubbles: true,
         })
       )
@@ -431,6 +458,10 @@ describe('useAutoScroll', () => {
       })
     })
 
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
     expect(containerHarness.getScrollTop()).toBe(containerHarness.div.scrollHeight - containerHarness.div.clientHeight)
   })
 
@@ -457,6 +488,10 @@ describe('useAutoScroll', () => {
         contentVersion: newMessages.length,
         onScrollStateChange: vi.fn(),
       })
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(100)
     })
 
     expect(containerHarness.getScrollTop()).toBe(containerHarness.div.scrollHeight - containerHarness.div.clientHeight)

--- a/frontend/src/hooks/useAutoScroll.ts
+++ b/frontend/src/hooks/useAutoScroll.ts
@@ -46,17 +46,13 @@ export function useAutoScroll({
     isScrollButtonVisibleRef.current = false
     const scrollRequestId = scrollRequestIdRef.current + 1
     scrollRequestIdRef.current = scrollRequestId
-    const scroll = () => {
-      if (!containerRef?.current) return
-      containerRef.current.scrollTop = containerRef.current.scrollHeight
-    }
 
-    scroll()
     let frameCount = 0
     const scrollAfterLayout = () => {
       if (scrollRequestIdRef.current !== scrollRequestId) return
+      if (!containerRef?.current) return
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
       frameCount += 1
-      scroll()
       if (frameCount < SCROLL_TO_BOTTOM_FRAME_COUNT) {
         requestAnimationFrame(scrollAfterLayout)
       }

--- a/frontend/src/hooks/useOpenCode.ts
+++ b/frontend/src/hooks/useOpenCode.ts
@@ -13,7 +13,7 @@ import { parseNetworkError } from "../lib/opencode-errors";
 import { showToast } from "../lib/toast";
 import { useSessionStatus } from "../stores/sessionStatusStore";
 import { useSendErrorStore } from "../stores/sendErrorStore";
-import { invalidateSessionListCaches } from "../lib/queryInvalidation";
+import { invalidateSessionListCaches, messagesQueryKey } from "../lib/queryInvalidation";
 
 type AssistantMessage = components["schemas"]["AssistantMessage"];
 
@@ -140,7 +140,7 @@ export const useMessages = (opcodeUrl: string | null | undefined, sessionID: str
   const client = useOpenCodeClient(opcodeUrl, directory);
 
   return useQuery({
-    queryKey: ["opencode", "messages", opcodeUrl, sessionID, directory],
+    queryKey: messagesQueryKey(opcodeUrl, sessionID, directory),
     queryFn: async () => {
       const response = await client!.listMessages(sessionID!)
       return response as MessageWithParts[]
@@ -404,15 +404,15 @@ export const useSendPrompt = (opcodeUrl: string | null | undefined, directory?: 
       );
       const userMessageInfo = createOptimisticUserMessageInfo(sessionID, optimisticUserID, model, agent, variant);
 
-      const messagesQueryKey = ["opencode", "messages", opcodeUrl, sessionID, directory];
-      await queryClient.cancelQueries({ queryKey: messagesQueryKey });
+      const queryKey = messagesQueryKey(opcodeUrl, sessionID, directory);
+      await queryClient.cancelQueries({ queryKey });
 
       const optimisticMessageWithParts: MessageWithParts = {
         info: userMessageInfo,
         parts: userMessageParts,
       }
       queryClient.setQueryData<MessageWithParts[]>(
-        messagesQueryKey,
+        queryKey,
         (old) => [...(old || []), optimisticMessageWithParts],
       );
 
@@ -483,11 +483,11 @@ export const useSendPrompt = (opcodeUrl: string | null | undefined, directory?: 
     },
     onError: (error, variables) => {
       const { sessionID } = variables;
-      const messagesQueryKey = ["opencode", "messages", opcodeUrl, sessionID, directory];
+      const queryKey = messagesQueryKey(opcodeUrl, sessionID, directory);
 
       setSessionStatus(sessionID, { type: "idle" });
       queryClient.setQueryData<MessageWithParts[]>(
-        messagesQueryKey,
+        queryKey,
         (old) => old?.filter((msgWithParts) => !msgWithParts.info.id.startsWith("optimistic_")),
       );
       
@@ -509,17 +509,17 @@ export const useSendPrompt = (opcodeUrl: string | null | undefined, directory?: 
     onSuccess: async (data, variables) => {
       const { sessionID } = variables;
       const { response } = data;
-      const messagesQueryKey = ["opencode", "messages", opcodeUrl, sessionID, directory];
+      const queryKey = messagesQueryKey(opcodeUrl, sessionID, directory);
 
       useSendErrorStore.getState().clearError(sessionID);
 
       if (data.queued || !response) {
-        queryClient.invalidateQueries({ queryKey: messagesQueryKey });
+        queryClient.invalidateQueries({ queryKey });
         return;
       }
 
       queryClient.setQueryData<MessageWithParts[]>(
-        messagesQueryKey,
+        queryKey,
         (old) => {
           if (!old) return old;
 
@@ -553,7 +553,7 @@ export const useAbortSession = (
   const retryCountRef = useRef(0);
 
   const forceCompleteMessages = useCallback((targetSessionID: string) => {
-    const queryKey = ["opencode", "messages", opcodeUrl, targetSessionID, directory];
+    const queryKey = messagesQueryKey(opcodeUrl, targetSessionID, directory);
     const now = Date.now();
     
     queryClient.setQueryData<MessageWithParts[]>(queryKey, (old) => {
@@ -616,7 +616,7 @@ export const useAbortSession = (
   }, []);
 
   const isSessionComplete = useCallback((targetSessionID: string) => {
-    const queryKey = ["opencode", "messages", opcodeUrl, targetSessionID, directory];
+    const queryKey = messagesQueryKey(opcodeUrl, targetSessionID, directory);
     const messages = queryClient.getQueryData<MessageWithParts[]>(queryKey);
     
     const hasIncompleteMessages = messages?.some(msgWithParts => {
@@ -632,7 +632,7 @@ export const useAbortSession = (
     if (!sessionID) return;
 
     const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
-      const queryKey = ["opencode", "messages", opcodeUrl, sessionID, directory];
+      const queryKey = messagesQueryKey(opcodeUrl, sessionID, directory);
       if (event.query.queryKey.join(",") === queryKey.join(",")) {
         if (isSessionComplete(sessionID) && retryIntervalRef.current) {
           stopRetrying();
@@ -716,15 +716,15 @@ export const useSendShell = (opcodeUrl: string | null | undefined, directory?: s
       );
       const userMessageInfo = createOptimisticUserMessageInfo(sessionID, optimisticUserID);
 
-      const messagesQueryKey = ["opencode", "messages", opcodeUrl, sessionID, directory];
-      await queryClient.cancelQueries({ queryKey: messagesQueryKey });
+      const queryKey = messagesQueryKey(opcodeUrl, sessionID, directory);
+      await queryClient.cancelQueries({ queryKey });
 
       const optimisticMessageWithParts: MessageWithParts = {
         info: userMessageInfo,
         parts: userMessageParts,
       }
       queryClient.setQueryData<MessageWithParts[]>(
-        messagesQueryKey,
+        queryKey,
         (old) => [...(old || []), optimisticMessageWithParts],
       );
 
@@ -739,7 +739,7 @@ export const useSendShell = (opcodeUrl: string | null | undefined, directory?: s
       const { sessionID } = variables;
       setSessionStatus(sessionID, { type: "idle" });
       queryClient.setQueryData<MessageWithParts[]>(
-        ["opencode", "messages", opcodeUrl, sessionID, directory],
+        messagesQueryKey(opcodeUrl, sessionID, directory),
         (old) => {
           if (!old) return old;
           return old.filter((msgWithParts) => !msgWithParts.info.id.startsWith("optimistic_"));
@@ -753,7 +753,7 @@ export const useSendShell = (opcodeUrl: string | null | undefined, directory?: s
       const { optimisticUserID } = data;
 
       queryClient.setQueryData<MessageWithParts[]>(
-        ["opencode", "messages", opcodeUrl, sessionID, directory],
+        messagesQueryKey(opcodeUrl, sessionID, directory),
         (old) => {
           if (!old) return old;
           return old.filter((msgWithParts) => msgWithParts.info.id !== optimisticUserID);
@@ -810,7 +810,7 @@ export const useLoadSkill = (
       setSessionStatus(sessionID, { type: "busy" });
 
       const optimisticUserID = `optimistic_user_${Date.now()}_${Math.random()}`;
-      const messagesQueryKey = ["opencode", "messages", opcodeUrl, sessionID, directory];
+      const queryKey = messagesQueryKey(opcodeUrl, sessionID, directory);
 
       const userMessageParts = createOptimisticUserMessageParts(
         sessionID,
@@ -823,9 +823,9 @@ export const useLoadSkill = (
         parts: userMessageParts,
       };
 
-      await queryClient.cancelQueries({ queryKey: messagesQueryKey });
+      await queryClient.cancelQueries({ queryKey });
       queryClient.setQueryData<MessageWithParts[]>(
-        messagesQueryKey,
+        queryKey,
         (old) => [...(old || []), optimisticMessageWithParts],
       );
 
@@ -834,10 +834,10 @@ export const useLoadSkill = (
     },
     onError: (error) => {
       if (sessionID) {
-        const messagesQueryKey = ["opencode", "messages", opcodeUrl, sessionID, directory];
+        const queryKey = messagesQueryKey(opcodeUrl, sessionID, directory);
         setSessionStatus(sessionID!, { type: "idle" });
         queryClient.setQueryData<MessageWithParts[]>(
-          messagesQueryKey,
+          queryKey,
           (old) => old?.filter((m) => !m.info.id.startsWith("optimistic_")),
         );
       }
@@ -845,10 +845,10 @@ export const useLoadSkill = (
     },
     onSuccess: (data) => {
       const { response } = data;
-      const messagesQueryKey = ["opencode", "messages", opcodeUrl, sessionID, directory];
+      const queryKey = messagesQueryKey(opcodeUrl, sessionID, directory);
 
       queryClient.setQueryData<MessageWithParts[]>(
-        messagesQueryKey,
+        queryKey,
         (old) => {
           if (!old) return old;
 

--- a/frontend/src/hooks/useRemoveMessage.ts
+++ b/frontend/src/hooks/useRemoveMessage.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createOpenCodeClient } from '@/api/opencode'
 import { showToast } from '@/lib/toast'
+import { messagesQueryKey } from '@/lib/queryInvalidation'
 import type { Message, Part, MessageWithParts } from '@/api/types'
 import { useSessionStatus } from '@/stores/sessionStatusStore'
 
@@ -25,7 +26,7 @@ export function useRemoveMessage({ opcodeUrl, sessionId, directory }: UseRemoveM
       return client.revertMessage(sessionId, { messageID, partID })
     },
     onMutate: async ({ messageID }) => {
-      const queryKey = ['opencode', 'messages', opcodeUrl, sessionId, directory]
+      const queryKey = messagesQueryKey(opcodeUrl, sessionId, directory)
       
       await queryClient.cancelQueries({ queryKey })
       
@@ -44,7 +45,7 @@ export function useRemoveMessage({ opcodeUrl, sessionId, directory }: UseRemoveM
     onError: (_error, _variables, _context: RemoveMessageContext | undefined) => {
       if (_context?.previousMessages) {
         queryClient.setQueryData(
-          ['opencode', 'messages', opcodeUrl, sessionId, directory],
+          messagesQueryKey(opcodeUrl, sessionId, directory),
           _context.previousMessages
         )
       }
@@ -53,7 +54,7 @@ export function useRemoveMessage({ opcodeUrl, sessionId, directory }: UseRemoveM
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['opencode', 'messages', opcodeUrl, sessionId, directory]
+        queryKey: messagesQueryKey(opcodeUrl, sessionId, directory)
       })
       queryClient.invalidateQueries({
         queryKey: ['opencode', 'session', opcodeUrl, sessionId, directory]
@@ -115,7 +116,7 @@ export function useRefreshMessage({ opcodeUrl, sessionId, directory }: UseRefres
       }
 
       queryClient.setQueryData<MessageWithParts[]>(
-        ['opencode', 'messages', opcodeUrl, sessionId, directory],
+        messagesQueryKey(opcodeUrl, sessionId, directory),
         (old) => [...(old || []), optimisticMessageWithParts]
       )
       
@@ -146,7 +147,7 @@ export function useRefreshMessage({ opcodeUrl, sessionId, directory }: UseRefres
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['opencode', 'messages', opcodeUrl, sessionId, directory]
+        queryKey: messagesQueryKey(opcodeUrl, sessionId, directory)
       })
       queryClient.invalidateQueries({
         queryKey: ['opencode', 'session', opcodeUrl, sessionId, directory]
@@ -156,7 +157,7 @@ export function useRefreshMessage({ opcodeUrl, sessionId, directory }: UseRefres
       void variables
       setSessionStatus(sessionId, { type: 'idle' })
       queryClient.setQueryData<MessageWithParts[]>(
-        ['opencode', 'messages', opcodeUrl, sessionId, directory],
+        messagesQueryKey(opcodeUrl, sessionId, directory),
         (old) => {
           const messages = old || []
           const optimisticIndex = messages.findIndex((m) => m.info.id.startsWith('optimistic_user_'))

--- a/frontend/src/hooks/useSSE.test.tsx
+++ b/frontend/src/hooks/useSSE.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSSE } from './useSSE'
 import { useSessionStatus } from '../stores/sessionStatusStore'
+import type { Part, MessageWithParts } from '@/api/types'
 
 const mocks = vi.hoisted(() => ({
   getSessionStatuses: vi.fn(),
@@ -274,4 +275,181 @@ describe('useSSE', () => {
 
     unmount()
   })
+
+  it('routes streamed part deltas to the event directory in multi-directory subscriptions', async () => {
+    const origRAF = window.requestAnimationFrame
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    }) as typeof window.requestAnimationFrame
+
+    try {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      })
+
+      // Seed both directory caches before rendering the hook
+      queryClient.setQueryData(
+        ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo-a'],
+        [{
+          ...assistantMessage('session-1', 'message-1'),
+          parts: [textPart('session-1', 'message-1', 'part-1', 'A')],
+        }],
+      )
+      queryClient.setQueryData(
+        ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo-b'],
+        [{
+          ...assistantMessage('session-1', 'message-1'),
+          parts: [textPart('session-1', 'message-1', 'part-1', 'B')],
+        }],
+      )
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      // Use stable reference to avoid re-render loop with inline array
+      const directories = ['/repo-a', '/repo-b']
+      const { result, unmount } = renderHook(
+        () => useSSE('http://localhost:5551', directories, 'session-1'),
+        { wrapper },
+      )
+
+      await waitFor(() => {
+        expect(MockEventSource.instances.length).toBeGreaterThanOrEqual(1)
+      })
+
+      const eventSource = MockEventSource.instances[MockEventSource.instances.length - 1]
+
+      act(() => {
+        eventSource.emit('connected', { clientId: 'client-1' })
+      })
+
+      await waitFor(() => expect(result.current.isConnected).toBe(true))
+
+      act(() => {
+        eventSource.emit('message', {
+          type: 'message.part.delta',
+          directory: '/repo-b',
+          properties: {
+            sessionID: 'session-1',
+            messageID: 'message-1',
+            partID: 'part-1',
+            field: 'text',
+            delta: ' + streamed',
+          },
+        })
+      })
+
+      const repoBData = queryClient.getQueryData<MessageWithParts[]>([
+        'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo-b',
+      ])
+      expect(repoBData![0].parts[0]).toHaveProperty('text', 'B + streamed')
+
+      const repoAData = queryClient.getQueryData<MessageWithParts[]>([
+        'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo-a',
+      ])
+      expect(repoAData![0].parts[0]).toHaveProperty('text', 'A')
+
+      unmount()
+    } finally {
+      window.requestAnimationFrame = origRAF
+    }
+  })
+
+  it('processes part deltas when directory transitions from undefined to a real value', async () => {
+    const origRAF = window.requestAnimationFrame
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    }) as typeof window.requestAnimationFrame
+
+    try {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      })
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      // Seed cache with an empty part
+      queryClient.setQueryData(
+        ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+        [{
+          ...assistantMessage('session-1', 'message-1'),
+          parts: [textPart('session-1', 'message-1', 'part-1', '')],
+        }],
+      )
+
+      // Initial render with directory=undefined — batcher should be created eagerly
+      const { rerender, unmount } = renderHook(
+        ({ directory }) => useSSE('http://localhost:5551', directory, 'session-1'),
+        { wrapper, initialProps: { directory: undefined as string | undefined } },
+      )
+
+      // No SSE subscription yet because directoriesList is empty
+      expect(MockEventSource.instances).toHaveLength(0)
+
+      // Re-render with a real directory to start the SSE subscription
+      rerender({ directory: '/repo' })
+
+      await waitFor(() => expect(MockEventSource.instances).toHaveLength(1))
+      const eventSource = MockEventSource.instances[0]
+
+      act(() => {
+        eventSource.emit('connected', { clientId: 'client-1' })
+      })
+
+      // Emit a part delta — the batcher was created on the initial mount,
+      // so it should process the event even though directory was undefined at mount time
+      act(() => {
+        eventSource.emit('message', {
+          type: 'message.part.delta',
+          directory: '/repo',
+          properties: {
+            sessionID: 'session-1',
+            messageID: 'message-1',
+            partID: 'part-1',
+            field: 'text',
+            delta: 'streamed content',
+          },
+        })
+      })
+
+      await waitFor(() => {
+        const data = queryClient.getQueryData<MessageWithParts[]>([
+          'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo',
+        ])
+        expect(data![0].parts[0]).toHaveProperty('text', 'streamed content')
+      })
+
+      unmount()
+    } finally {
+      window.requestAnimationFrame = origRAF
+    }
+  })
 })
+
+function assistantMessage(sessionID: string, messageID: string): MessageWithParts {
+  return {
+    info: {
+      id: messageID,
+      sessionID,
+      role: 'assistant',
+      time: { created: Date.now() },
+      parentID: '',
+      modelID: 'test-model',
+      providerID: 'test-provider',
+      mode: 'test',
+      agent: 'test-agent',
+      path: { cwd: '/test', root: '/test' },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts: [],
+  }
+}
+
+function textPart(sessionID: string, messageID: string, partID: string, text: string): Part {
+  return { id: partID, sessionID, messageID, type: 'text', text } as Part
+}

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -73,19 +73,21 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
   const batcherRef = useRef<ReturnType<typeof createPartsBatcher> | null>(null)
 
   useEffect(() => {
-    if (!opcodeUrl || !primaryDirectory) {
+    if (!opcodeUrl) {
       batcherRef.current?.destroy()
       batcherRef.current = null
       return
     }
 
-    batcherRef.current = createPartsBatcher(queryClient, opcodeUrl, primaryDirectory)
+    if (!batcherRef.current) {
+      batcherRef.current = createPartsBatcher(queryClient, opcodeUrl)
+    }
 
     return () => {
       batcherRef.current?.destroy()
       batcherRef.current = null
     }
-  }, [queryClient, opcodeUrl, primaryDirectory])
+  }, [queryClient, opcodeUrl])
 
   const resolveCacheDirectory = useCallback(
     (eventDirectory: string | undefined): string | undefined => {
@@ -134,14 +136,14 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
       case 'messagev2.part.updated': {
         if (!('part' in event.properties)) break
         const { part } = event.properties
-        batcherRef.current?.queuePartUpdate(part.sessionID, part)
+        batcherRef.current?.queuePartUpdate(part.sessionID, part, cacheDirectory)
         break
       }
 
       case 'message.part.delta': {
         if (!('sessionID' in event.properties && 'messageID' in event.properties && 'partID' in event.properties && 'field' in event.properties && 'delta' in event.properties)) break
         const { sessionID, messageID, partID, field, delta } = event.properties
-        batcherRef.current?.queuePartDelta(sessionID, messageID, partID, field, delta)
+        batcherRef.current?.queuePartDelta(sessionID, messageID, partID, field, delta, cacheDirectory)
         break
       }
 
@@ -166,15 +168,15 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
             ? currentData.filter(msgWithParts => !msgWithParts.info.id.startsWith('optimistic_'))
             : currentData
           queryClient.setQueryData(messagesQueryKey, [...filteredData, { info, parts: [] }])
-          return
+        } else {
+          const updated = currentData.map(msgWithParts => {
+            if (msgWithParts.info.id !== info.id) return msgWithParts
+            return { ...msgWithParts, info: { ...info } }
+          })
+          queryClient.setQueryData(messagesQueryKey, updated)
         }
         
-        const updated = currentData.map(msgWithParts => {
-          if (msgWithParts.info.id !== info.id) return msgWithParts
-          return { ...msgWithParts, info: { ...info } }
-        })
-        
-        queryClient.setQueryData(messagesQueryKey, updated)
+        batcherRef.current?.flush({ sessionID, directory: cacheDirectory })
         break
       }
 
@@ -200,7 +202,7 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
         
         const { sessionID, messageID, partID } = event.properties
         
-        batcherRef.current?.queuePartRemoval(sessionID, messageID, partID)
+        batcherRef.current?.queuePartRemoval(sessionID, messageID, partID, cacheDirectory)
         break
       }
 
@@ -224,11 +226,14 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
         
         setSessionStatus(sessionID, { type: 'idle' })
         
-        batcherRef.current?.flush()
+        batcherRef.current?.flush({ sessionID, directory: cacheDirectory })
         
         const messagesQueryKey = ['opencode', 'messages', opcodeUrl, sessionID, cacheDirectory]
         const currentData = queryClient.getQueryData<MessageWithParts[]>(messagesQueryKey)
-        if (!currentData) break
+        if (!currentData) {
+          queryClient.invalidateQueries({ queryKey: messagesQueryKey })
+          break
+        }
         
         const now = Date.now()
         const updated = currentData.map(msgWithParts => {

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useOpenCodeClient } from './useOpenCode'
-import { invalidateSessionListCaches, invalidateSessionListCachesDebounced } from '@/lib/queryInvalidation'
+import { invalidateSessionListCaches, invalidateSessionListCachesDebounced, messagesQueryKey } from '@/lib/queryInvalidation'
 import type { SSEEvent, MessageWithParts } from '@/api/types'
 import { showToast } from '@/lib/toast'
 import { settingsApi } from '@/api/settings'
@@ -154,10 +154,10 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
         const { info } = event.properties
         const sessionID = info.sessionID
         
-        const messagesQueryKey = ['opencode', 'messages', opcodeUrl, sessionID, cacheDirectory]
-        const currentData = queryClient.getQueryData<MessageWithParts[]>(messagesQueryKey)
+        const queryKey = messagesQueryKey(opcodeUrl, sessionID, cacheDirectory)
+        const currentData = queryClient.getQueryData<MessageWithParts[]>(queryKey)
         if (!currentData) {
-          queryClient.invalidateQueries({ queryKey: messagesQueryKey })
+          queryClient.invalidateQueries({ queryKey })
           return
         }
         
@@ -167,13 +167,13 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
           const filteredData = info.role === 'user' 
             ? currentData.filter(msgWithParts => !msgWithParts.info.id.startsWith('optimistic_'))
             : currentData
-          queryClient.setQueryData(messagesQueryKey, [...filteredData, { info, parts: [] }])
+          queryClient.setQueryData(queryKey, [...filteredData, { info, parts: [] }])
         } else {
           const updated = currentData.map(msgWithParts => {
             if (msgWithParts.info.id !== info.id) return msgWithParts
             return { ...msgWithParts, info: { ...info } }
           })
-          queryClient.setQueryData(messagesQueryKey, updated)
+          queryClient.setQueryData(queryKey, updated)
         }
         
         batcherRef.current?.flush({ sessionID, directory: cacheDirectory })
@@ -187,7 +187,7 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
         const { sessionID, messageID } = event.properties
         
         queryClient.setQueryData<MessageWithParts[]>(
-          ['opencode', 'messages', opcodeUrl, sessionID, cacheDirectory],
+          messagesQueryKey(opcodeUrl, sessionID, cacheDirectory),
           (old) => {
             if (!old) return old
             return old.filter(msgWithParts => msgWithParts.info.id !== messageID)
@@ -214,7 +214,7 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
         showToast.dismiss(`compact-${sessionID}`)
         showToast.success('Session compacted')
         queryClient.invalidateQueries({ 
-          queryKey: ['opencode', 'messages', opcodeUrl, sessionID, cacheDirectory] 
+          queryKey: messagesQueryKey(opcodeUrl, sessionID, cacheDirectory) 
         })
         break
       }
@@ -228,10 +228,10 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
         
         batcherRef.current?.flush({ sessionID, directory: cacheDirectory })
         
-        const messagesQueryKey = ['opencode', 'messages', opcodeUrl, sessionID, cacheDirectory]
-        const currentData = queryClient.getQueryData<MessageWithParts[]>(messagesQueryKey)
+        const queryKey = messagesQueryKey(opcodeUrl, sessionID, cacheDirectory)
+        const currentData = queryClient.getQueryData<MessageWithParts[]>(queryKey)
         if (!currentData) {
-          queryClient.invalidateQueries({ queryKey: messagesQueryKey })
+          queryClient.invalidateQueries({ queryKey })
           break
         }
         
@@ -271,7 +271,7 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
           }
         })
         
-        queryClient.setQueryData(messagesQueryKey, updated)
+        queryClient.setQueryData(queryKey, updated)
         break
       }
 
@@ -329,7 +329,7 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
         if (!('sessionID' in event.properties)) break
         const { sessionID } = event.properties
         queryClient.invalidateQueries({ 
-          queryKey: ['opencode', 'messages', opcodeUrl, sessionID, cacheDirectory] 
+          queryKey: messagesQueryKey(opcodeUrl, sessionID, cacheDirectory) 
         })
         break
       }
@@ -363,7 +363,7 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
       queryKey: ['opencode', 'session', opcodeUrl, sessionId, primaryDirectory],
     })
     queryClient.invalidateQueries({
-      queryKey: ['opencode', 'messages', opcodeUrl, sessionId, primaryDirectory],
+      queryKey: messagesQueryKey(opcodeUrl, sessionId, primaryDirectory),
     })
     queryClient.invalidateQueries({
       queryKey: ['opencode', 'pending-actions', opcodeUrl, sessionId, primaryDirectory],

--- a/frontend/src/hooks/useSessionAgent.ts
+++ b/frontend/src/hooks/useSessionAgent.ts
@@ -91,7 +91,7 @@ export function useSessionAgent(
       return { agent: defaultAgent, model: undefined, variant: undefined, fromMessage: false }
     }
 
-    if (messagesLoading && (!messages || messages.length === 0)) {
+    if (messagesLoading && !messages) {
       return resolveFallback()
     }
 

--- a/frontend/src/hooks/useUndoMessage.ts
+++ b/frontend/src/hooks/useUndoMessage.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createOpenCodeClient } from '@/api/opencode'
 import { showToast } from '@/lib/toast'
+import { messagesQueryKey } from '@/lib/queryInvalidation'
 import type { MessageWithParts } from '@/api/types'
 
 interface UseUndoMessageOptions {
@@ -31,7 +32,7 @@ export function useUndoMessage({
       return messageContent
     },
     onMutate: async ({ messageID }) => {
-      const queryKey = ['opencode', 'messages', opcodeUrl, sessionId, directory]
+      const queryKey = messagesQueryKey(opcodeUrl, sessionId, directory)
       
       await queryClient.cancelQueries({ queryKey })
       
@@ -50,7 +51,7 @@ export function useUndoMessage({
     onError: (_error, _variables, _context: UndoMessageContext | undefined) => {
       if (_context?.previousMessages) {
         queryClient.setQueryData(
-          ['opencode', 'messages', opcodeUrl, sessionId, directory],
+          messagesQueryKey(opcodeUrl, sessionId, directory),
           _context.previousMessages
         )
       }
@@ -59,7 +60,7 @@ export function useUndoMessage({
     },
     onSuccess: (restoredPrompt) => {
       queryClient.invalidateQueries({
-        queryKey: ['opencode', 'messages', opcodeUrl, sessionId, directory]
+        queryKey: messagesQueryKey(opcodeUrl, sessionId, directory)
       })
       queryClient.invalidateQueries({
         queryKey: ['opencode', 'session', opcodeUrl, sessionId, directory]

--- a/frontend/src/lib/opencode-event-stream/__tests__/openCodeEventStream.test.ts
+++ b/frontend/src/lib/opencode-event-stream/__tests__/openCodeEventStream.test.ts
@@ -19,7 +19,7 @@ describe('OpenCodeEventStream', () => {
     stream.subscribeGlobalMonitor({ directories: ['/repo'], onEvent })
     transport.openConnection()
     transport.connected()
-    transport.message({ type: 'permission.asked', properties: { sessionID: 'session-1' }, directory: '/repo' })
+    transport.message({ directory: '/repo', payload: { type: 'permission.asked', properties: { sessionID: 'session-1' } } })
 
     expect(onEvent).toHaveBeenCalledWith({
       type: 'permission.asked',
@@ -77,6 +77,56 @@ describe('OpenCodeEventStream', () => {
       path: '/api/sse/unsubscribe',
       body: { clientId: 'client-1', directories: ['/repo-a'] },
     })
+  })
+
+  it('opens the initial EventSource URL with first subscriber directories', () => {
+    const transport = new TestEventStreamTransport()
+    const stream = new OpenCodeEventStream({ transport })
+
+    stream.subscribeGlobalMonitor({ directories: ['/repo'], onEvent: vi.fn() })
+
+    expect(transport.openedUrls).toHaveLength(1)
+    const url = transport.openedUrls[0]
+    expect(url).toContain('/api/sse/stream')
+    expect(url).toContain(encodeURIComponent('/repo'))
+  })
+
+  it('opens the initial EventSource URL with all first subscriber directories', () => {
+    const transport = new TestEventStreamTransport()
+    const stream = new OpenCodeEventStream({ transport })
+
+    stream.subscribeGlobalMonitor({ directories: ['/repo-a', '/repo-b'], onEvent: vi.fn() })
+
+    expect(transport.openedUrls).toHaveLength(1)
+    const url = transport.openedUrls[0]
+    expect(url).toContain('/api/sse/stream')
+    expect(url).toContain(encodeURIComponent('/repo-a'))
+    expect(url).toContain(encodeURIComponent('/repo-b'))
+  })
+
+  it('marks health unhealthy when backend connected event reports no upstream connection', () => {
+    const transport = new TestEventStreamTransport()
+    const stream = new OpenCodeEventStream({ transport })
+    const healthStates: EventStreamHealthState[] = []
+
+    stream.subscribeGlobalMonitor({
+      directories: [],
+      onEvent: vi.fn(),
+      onHealthChange: (health) => healthStates.push(health),
+    })
+
+    transport.openConnection()
+    transport.connectedPayload({ clientId: 'client-1', connected: 0, total: 1 })
+
+    const unhealthyState = healthStates.at(-1)
+    expect(unhealthyState?.isConnected).toBe(true)
+    expect(unhealthyState?.isHealthy).toBe(false)
+
+    transport.connectedPayload({ clientId: 'client-1', connected: 1, total: 1 })
+
+    const healthyState = healthStates.at(-1)
+    expect(healthyState?.isConnected).toBe(true)
+    expect(healthyState?.isHealthy).toBe(true)
   })
 
   it('reports visibility through the transport adapter', async () => {

--- a/frontend/src/lib/opencode-event-stream/openCodeEventStream.ts
+++ b/frontend/src/lib/opencode-event-stream/openCodeEventStream.ts
@@ -1,4 +1,5 @@
 import { DEFAULTS } from '@opencode-manager/shared/config'
+import type { SSEEventEnvelope } from '@opencode-manager/shared'
 import { createBrowserEventStreamTransport } from './browserTransport'
 import type {
   EventStreamHealthState,
@@ -422,7 +423,7 @@ function flattenEventEnvelope(parsed: unknown): unknown {
     (parsed as { payload: unknown }).payload !== null &&
     typeof (parsed as { payload: unknown }).payload === 'object'
   ) {
-    const { payload, directory } = parsed as { payload: object; directory?: unknown }
+    const { payload, directory } = parsed as SSEEventEnvelope
     return { ...payload, directory }
   }
   return parsed

--- a/frontend/src/lib/opencode-event-stream/openCodeEventStream.ts
+++ b/frontend/src/lib/opencode-event-stream/openCodeEventStream.ts
@@ -35,6 +35,8 @@ export class OpenCodeEventStream {
   private clientId: string | null = null
   private lastEventAt: number | null = null
   private watchdogTimer: ReturnType<typeof setInterval> | null = null
+  private upstreamConnectedCount: number | null = null
+  private upstreamTotalCount: number | null = null
 
   constructor(options: OpenCodeEventStreamOptions = {}) {
     this.transport = options.transport ?? createBrowserEventStreamTransport()
@@ -46,8 +48,7 @@ export class OpenCodeEventStream {
     onStatusChange?: EventStreamStatusHandler
     onHealthChange?: (state: EventStreamHealthState) => void
   }): GlobalMonitorSubscription {
-    const id = this.addSubscriber(input.onEvent, input.onStatusChange, input.onHealthChange)
-    this.updateSubscriberDirectories(id, input.directories)
+    const id = this.addSubscriber(input.onEvent, input.onStatusChange, input.onHealthChange, input.directories)
 
     return {
       updateDirectories: (directories) => this.updateSubscriberDirectories(id, directories),
@@ -65,14 +66,31 @@ export class OpenCodeEventStream {
     onEvent: OpenCodeEventHandler,
     onStatusChange?: EventStreamStatusHandler,
     onHealthChange?: (state: EventStreamHealthState) => void,
+    directories: string[] = [],
   ): string {
     const id = `sub_${++this.subscriberIdCounter}`
+
+    const initialDirectories = new Set(directories.filter(Boolean))
+    const newDirectories: string[] = []
+
+    for (const directory of initialDirectories) {
+      const currentCount = this.directoryRefCounts.get(directory) ?? 0
+      this.directoryRefCounts.set(directory, currentCount + 1)
+      if (currentCount === 0) {
+        if (this.clientId && this.connected) {
+          newDirectories.push(directory)
+        } else {
+          this.pendingDirectories.add(directory)
+        }
+      }
+    }
+
     this.subscribers.set(id, {
       id,
       onEvent,
       onStatusChange,
       onHealthChange,
-      directories: new Set(),
+      directories: initialDirectories,
     })
 
     onStatusChange?.(this.connected)
@@ -80,6 +98,8 @@ export class OpenCodeEventStream {
 
     if (this.subscribers.size === 1) {
       this.connect()
+    } else if (newDirectories.length > 0) {
+      void this.subscribeToRemoteDirectories(newDirectories)
     }
 
     return id
@@ -186,6 +206,8 @@ export class OpenCodeEventStream {
   private handleError(): void {
     this.connected = false
     this.clientId = null
+    this.upstreamConnectedCount = null
+    this.upstreamTotalCount = null
     this.stopWatchdog()
     this.lastEventAt = null
 
@@ -205,7 +227,7 @@ export class OpenCodeEventStream {
   private handleMessage(data: string): void {
     try {
       this.markActivity()
-      this.broadcast(JSON.parse(data))
+      this.broadcast(flattenEventEnvelope(JSON.parse(data)))
     } catch {
       this.markActivity()
     }
@@ -213,9 +235,15 @@ export class OpenCodeEventStream {
 
   private handleConnected(data: string): void {
     try {
-      const parsed = JSON.parse(data) as { clientId?: unknown }
+      const parsed = JSON.parse(data) as { clientId?: unknown; connected?: unknown; total?: unknown }
       if (typeof parsed.clientId === 'string') {
         this.clientId = parsed.clientId
+      }
+      if (typeof parsed.connected === 'number') {
+        this.upstreamConnectedCount = parsed.connected
+      }
+      if (typeof parsed.total === 'number') {
+        this.upstreamTotalCount = parsed.total
       }
     } catch {
       this.clientId = null
@@ -239,6 +267,8 @@ export class OpenCodeEventStream {
     this.connection = null
     this.connected = false
     this.clientId = null
+    this.upstreamConnectedCount = null
+    this.upstreamTotalCount = null
     this.lastEventAt = null
     this.pendingDirectories.clear()
     this.notifyHealth()
@@ -263,6 +293,8 @@ export class OpenCodeEventStream {
     this.connection = null
     this.connected = false
     this.clientId = null
+    this.upstreamConnectedCount = null
+    this.upstreamTotalCount = null
     this.lastEventAt = null
     this.pendingDirectories = new Set(this.directoryRefCounts.keys())
     this.notifyStatusChange(false)
@@ -308,9 +340,10 @@ export class OpenCodeEventStream {
 
   private buildHealth(): EventStreamHealthState {
     const isStalled = this.connected && this.lastEventAt != null && Date.now() - this.lastEventAt > STALL_THRESHOLD_MS
+    const upstreamDisconnected = this.upstreamTotalCount != null && this.upstreamTotalCount > 0 && this.upstreamConnectedCount === 0
     return {
       isConnected: this.connected,
-      isHealthy: this.connected && this.lastEventAt != null && !isStalled,
+      isHealthy: this.connected && this.lastEventAt != null && !isStalled && !upstreamDisconnected,
       lastEventAt: this.lastEventAt,
       isStalled,
     }
@@ -379,6 +412,20 @@ export class OpenCodeEventStream {
       activeSessionId: activeSessionId ?? null,
     })
   }
+}
+
+function flattenEventEnvelope(parsed: unknown): unknown {
+  if (
+    parsed !== null &&
+    typeof parsed === 'object' &&
+    'payload' in parsed &&
+    (parsed as { payload: unknown }).payload !== null &&
+    typeof (parsed as { payload: unknown }).payload === 'object'
+  ) {
+    const { payload, directory } = parsed as { payload: object; directory?: unknown }
+    return { ...payload, directory }
+  }
+  return parsed
 }
 
 export const openCodeEventStream = new OpenCodeEventStream()

--- a/frontend/src/lib/opencode-event-stream/testTransport.ts
+++ b/frontend/src/lib/opencode-event-stream/testTransport.ts
@@ -2,11 +2,13 @@ import type { EventStreamConnection, EventStreamTransport, EventStreamTransportH
 
 export class TestEventStreamTransport implements EventStreamTransport {
   readonly posts: Array<{ path: string; body: unknown }> = []
+  readonly openedUrls: string[] = []
   closeCount = 0
   private handlers: EventStreamTransportHandlers | null = null
   private connection: EventStreamConnection | null = null
 
-  open(_url: string, handlers: EventStreamTransportHandlers): EventStreamConnection {
+  open(url: string, handlers: EventStreamTransportHandlers): EventStreamConnection {
+    this.openedUrls.push(url)
     this.handlers = handlers
     this.connection = {
       close: () => {
@@ -29,7 +31,11 @@ export class TestEventStreamTransport implements EventStreamTransport {
   }
 
   connected(clientId = 'test-client'): void {
-    this.handlers?.onConnected(JSON.stringify({ clientId }))
+    this.connectedPayload({ clientId })
+  }
+
+  connectedPayload(payload: unknown): void {
+    this.handlers?.onConnected(JSON.stringify(payload))
   }
 
   message(data: unknown): void {

--- a/frontend/src/lib/partsBatcher.test.ts
+++ b/frontend/src/lib/partsBatcher.test.ts
@@ -1,0 +1,305 @@
+import { QueryClient } from '@tanstack/react-query'
+import { describe, it, expect, vi } from 'vitest'
+import { createPartsBatcher } from './partsBatcher'
+import type { Part, MessageWithParts } from '@/api/types'
+
+function assistantMessage(sessionID: string, messageID: string): MessageWithParts {
+  return {
+    info: {
+      id: messageID,
+      sessionID,
+      role: 'assistant',
+      time: { created: Date.now() },
+      parentID: '',
+      modelID: 'test-model',
+      providerID: 'test-provider',
+      mode: 'test',
+      agent: 'test-agent',
+      path: { cwd: '/test', root: '/test' },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts: [],
+  }
+}
+
+function textPart(sessionID: string, messageID: string, partID: string, text: string): Part {
+  return { id: partID, sessionID, messageID, type: 'text', text } as Part
+}
+
+function createManyCachedMessages(count: number, sessionID: string): MessageWithParts[] {
+  const messages: MessageWithParts[] = []
+  for (let i = 0; i < count; i++) {
+    const msg = assistantMessage(sessionID, `msg-${i}`)
+    msg.parts = [textPart(sessionID, `msg-${i}`, `part-${i}`, `base text ${i}`)]
+    messages.push(msg)
+  }
+  return messages
+}
+
+describe('createPartsBatcher', () => {
+  it('invalidates when part deltas arrive before message cache exists and applies a later authoritative upsert', () => {
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
+
+    batcher.queuePartDelta('session-1', 'message-1', 'part-1', 'text', 'Hello', '/repo')
+    batcher.flush()
+
+    expect(
+      queryClient.getQueryData(['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo']),
+    ).toBeUndefined()
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+    })
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+      [assistantMessage('session-1', 'message-1')],
+    )
+
+    batcher.queuePartUpdate('session-1', textPart('session-1', 'message-1', 'part-1', 'Hello world'), '/repo')
+    batcher.flush()
+
+    const data = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo',
+    ])
+    expect(data).toHaveLength(1)
+    expect(data![0].parts).toHaveLength(1)
+    expect(data![0].parts[0]).toHaveProperty('text', 'Hello world')
+  })
+
+  it('does not replay stale deltas after authoritative upsert resolves the part', () => {
+    const queryClient = new QueryClient()
+    const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
+
+    batcher.queuePartDelta('session-1', 'message-1', 'part-1', 'text', 'stale delta ', '/repo')
+    batcher.flush()
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+      [assistantMessage('session-1', 'message-1')],
+    )
+
+    batcher.queuePartUpdate('session-1', textPart('session-1', 'message-1', 'part-1', 'authoritative text'), '/repo')
+    batcher.flush()
+
+    const data = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo',
+    ])
+    expect(data![0].parts).toHaveLength(1)
+    expect(data![0].parts[0]).toHaveProperty('text', 'authoritative text')
+
+    batcher.flush()
+    const data2 = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo',
+    ])
+    expect(data2![0].parts[0]).toHaveProperty('text', 'authoritative text')
+  })
+
+  it('does not replay unapplied deltas onto refetched authoritative data', () => {
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+      [assistantMessage('session-1', 'message-1')],
+    )
+
+    batcher.queuePartDelta('session-1', 'message-1', 'part-1', 'text', ' stale', '/repo')
+    batcher.flush()
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+    })
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+      [{ ...assistantMessage('session-1', 'message-1'), parts: [textPart('session-1', 'message-1', 'part-1', 'fresh')] }],
+    )
+
+    batcher.flush()
+
+    const data = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo',
+    ])
+    expect(data![0].parts[0]).toHaveProperty('text', 'fresh')
+  })
+
+  it('applies deltas queued after an authoritative upsert in the same batch', () => {
+    const queryClient = new QueryClient()
+    const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+      [assistantMessage('session-1', 'message-1')],
+    )
+
+    batcher.queuePartUpdate('session-1', textPart('session-1', 'message-1', 'part-1', 'snapshot'), '/repo')
+    batcher.queuePartDelta('session-1', 'message-1', 'part-1', 'text', ' later', '/repo')
+    batcher.flush()
+
+    const data = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo',
+    ])
+    expect(data![0].parts).toHaveLength(1)
+    expect(data![0].parts[0]).toHaveProperty('text', 'snapshot later')
+  })
+
+  it('applies many queued part deltas with one cache write and no invalidation storm', () => {
+    const queryClient = new QueryClient()
+    const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
+
+    const sessionID = 'session-1'
+    const directory = '/repo'
+    const messageCount = 1000
+    const deltaCount = 500
+
+    const messages = createManyCachedMessages(messageCount, sessionID)
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', sessionID, directory],
+      messages,
+    )
+
+    const setQueryDataSpy = vi.spyOn(queryClient, 'setQueryData')
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    for (let i = 0; i < deltaCount; i++) {
+      batcher.queuePartDelta(sessionID, `msg-${i}`, `part-${i}`, 'text', ` delta ${i}`, directory)
+    }
+
+    batcher.flush()
+
+    expect(invalidateSpy).not.toHaveBeenCalled()
+
+    const data = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', sessionID, directory,
+    ])
+    expect(data).toHaveLength(messageCount)
+
+    for (let i = 0; i < deltaCount; i++) {
+      expect(data![i].parts[0]).toHaveProperty('text', `base text ${i} delta ${i}`)
+    }
+
+    for (let i = deltaCount; i < messageCount; i++) {
+      expect(data![i].parts[0]).toHaveProperty('text', `base text ${i}`)
+    }
+
+    const setQueryDataCalls = setQueryDataSpy.mock.calls.filter(
+      ([key]) => JSON.stringify(key).includes('opencode'),
+    )
+    expect(setQueryDataCalls.length).toBe(1)
+  })
+
+  it('does not apply same-batch deltas for removed parts to shifted parts', () => {
+    const queryClient = new QueryClient()
+    const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+      [{
+        ...assistantMessage('session-1', 'message-1'),
+        parts: [
+          textPart('session-1', 'message-1', 'part-1', 'first'),
+          textPart('session-1', 'message-1', 'part-2', 'second'),
+        ],
+      }],
+    )
+
+    batcher.queuePartRemoval('session-1', 'message-1', 'part-1', '/repo')
+    batcher.queuePartDelta('session-1', 'message-1', 'part-1', 'text', ' stale', '/repo')
+    batcher.flush()
+
+    const data = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo',
+    ])
+
+    expect(data![0].parts).toHaveLength(1)
+    expect(data![0].parts[0]).toHaveProperty('id', 'part-2')
+    expect(data![0].parts[0]).toHaveProperty('text', 'second')
+  })
+
+  it('targeted flush leaves other session groups pending', () => {
+    const queryClient = new QueryClient()
+    const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-a', '/repo-a'],
+      [{ ...assistantMessage('session-a', 'msg-1'), parts: [textPart('session-a', 'msg-1', 'part-1', 'A1')] }],
+    )
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-b', '/repo-b'],
+      [{ ...assistantMessage('session-b', 'msg-2'), parts: [textPart('session-b', 'msg-2', 'part-2', 'B1')] }],
+    )
+
+    batcher.queuePartDelta('session-a', 'msg-1', 'part-1', 'text', ' delta A', '/repo-a')
+    batcher.queuePartDelta('session-b', 'msg-2', 'part-2', 'text', ' delta B', '/repo-b')
+
+    batcher.flush({ sessionID: 'session-a', directory: '/repo-a' })
+
+    const dataA = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-a', '/repo-a',
+    ])
+    expect(dataA![0].parts[0]).toHaveProperty('text', 'A1 delta A')
+
+    const dataB = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-b', '/repo-b',
+    ])
+    expect(dataB![0].parts[0]).toHaveProperty('text', 'B1')
+
+    batcher.flush()
+
+    const dataB2 = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-b', '/repo-b',
+    ])
+    expect(dataB2![0].parts[0]).toHaveProperty('text', 'B1 delta B')
+  })
+
+  it('empty group is dropped without invalidate', () => {
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+      [{ ...assistantMessage('session-1', 'msg-1'), parts: [textPart('session-1', 'msg-1', 'part-1', 'text')] }],
+    )
+
+    batcher.queuePartDelta('session-1', 'msg-1', 'part-1', 'text', ' updated', '/repo')
+    batcher.flush({ sessionID: 'session-1', directory: '/repo' })
+
+    invalidateSpy.mockClear()
+    batcher.flush()
+
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+
+  it('applies deltas to the directory they were queued for', () => {
+    const queryClient = new QueryClient()
+    const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo-a'],
+      [assistantMessage('session-1', 'message-1')],
+    )
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo-b'],
+      [{ ...assistantMessage('session-1', 'message-1'), parts: [textPart('session-1', 'message-1', 'part-1', 'B')] }],
+    )
+
+    batcher.queuePartDelta('session-1', 'message-1', 'part-1', 'text', ' + chunk', '/repo-b')
+    batcher.flush()
+
+    const repoBData = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo-b',
+    ])
+    expect(repoBData![0].parts[0]).toHaveProperty('text', 'B + chunk')
+
+    const repoAData = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo-a',
+    ])
+    expect(repoAData![0].parts).toHaveLength(0)
+  })
+})

--- a/frontend/src/lib/partsBatcher.ts
+++ b/frontend/src/lib/partsBatcher.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query'
 import type { Part, MessageWithParts } from '@/api/types'
+import { messagesQueryKey } from '@/lib/queryInvalidation'
 
 interface PartsBatcher {
   queuePartUpdate: (sessionID: string, part: Part, directory?: string) => void
@@ -57,7 +58,7 @@ export function createPartsBatcher(
       }
 
       const { sessionID, directory } = group
-      const queryKey = ['opencode', 'messages', opcodeUrl, sessionID, directory]
+      const queryKey = messagesQueryKey(opcodeUrl, sessionID, directory)
       const currentData = queryClient.getQueryData<MessageWithParts[]>(queryKey)
 
       if (!currentData) {

--- a/frontend/src/lib/partsBatcher.ts
+++ b/frontend/src/lib/partsBatcher.ts
@@ -2,10 +2,10 @@ import type { QueryClient } from '@tanstack/react-query'
 import type { Part, MessageWithParts } from '@/api/types'
 
 interface PartsBatcher {
-  queuePartUpdate: (sessionID: string, part: Part) => void
-  queuePartDelta: (sessionID: string, messageID: string, partID: string, field: string, delta: string) => void
-  queuePartRemoval: (sessionID: string, messageID: string, partID: string) => void
-  flush: () => void
+  queuePartUpdate: (sessionID: string, part: Part, directory?: string) => void
+  queuePartDelta: (sessionID: string, messageID: string, partID: string, field: string, delta: string, directory?: string) => void
+  queuePartRemoval: (sessionID: string, messageID: string, partID: string, directory?: string) => void
+  flush: (target?: { sessionID?: string; directory?: string }) => void
   destroy: () => void
 }
 
@@ -14,12 +14,21 @@ type PartOperation =
   | { type: 'delta'; messageID: string; partID: string; field: string; delta: string }
   | { type: 'remove'; messageID: string; partID: string }
 
+type OperationGroup = {
+  sessionID: string
+  directory?: string
+  operations: PartOperation[]
+}
+
+function groupKey(sessionID: string, directory?: string): string {
+  return `${directory ?? ''}\0${sessionID}`
+}
+
 export function createPartsBatcher(
   queryClient: QueryClient,
   opcodeUrl: string,
-  directory?: string
 ): PartsBatcher {
-  const pendingOperations = new Map<string, PartOperation[]>()
+  const pendingOperations = new Map<string, OperationGroup>()
   let pendingFrameId: number | null = null
 
   const scheduleFlush = () => {
@@ -30,78 +39,185 @@ export function createPartsBatcher(
     })
   }
 
-  const flush = () => {
+  const flush = (target?: { sessionID?: string; directory?: string }) => {
     if (pendingOperations.size === 0) return
 
-    for (const [sessionID, operations] of pendingOperations.entries()) {
+    const groupsToDelete: string[] = []
+    const invalidatedGroupKeys = new Set<string>()
+
+    for (const [key, group] of pendingOperations.entries()) {
+      if (target) {
+        if (target.sessionID !== undefined && group.sessionID !== target.sessionID) continue
+        if (target.directory !== undefined && group.directory !== target.directory) continue
+      }
+
+      if (group.operations.length === 0) {
+        groupsToDelete.push(key)
+        continue
+      }
+
+      const { sessionID, directory } = group
       const queryKey = ['opencode', 'messages', opcodeUrl, sessionID, directory]
       const currentData = queryClient.getQueryData<MessageWithParts[]>(queryKey)
 
-      if (!currentData) continue
-
-      let updatedData = [...currentData]
-
-      for (const operation of operations) {
-        updatedData = updatedData.map((msgWithParts) => {
-          if (operation.type === 'upsert') {
-            if (msgWithParts.info.id !== operation.part.messageID) return msgWithParts
-
-            const existingIdx = msgWithParts.parts.findIndex((part) => part.id === operation.part.id)
-            const parts = [...msgWithParts.parts]
-            if (existingIdx >= 0) {
-              parts[existingIdx] = operation.part
-            } else {
-              parts.push(operation.part)
-            }
-
-            return { ...msgWithParts, parts }
-          }
-
-          if (msgWithParts.info.id !== operation.messageID) return msgWithParts
-
-          if (operation.type === 'remove') {
-            return {
-              ...msgWithParts,
-              parts: msgWithParts.parts.filter((part) => part.id !== operation.partID),
-            }
-          }
-
-          return {
-            ...msgWithParts,
-            parts: msgWithParts.parts.map((part) => {
-              if (part.id !== operation.partID) return part
-
-              const currentValue = (part as Record<string, unknown>)[operation.field]
-              const nextValue = `${typeof currentValue === 'string' ? currentValue : ''}${operation.delta}`
-              return { ...part, [operation.field]: nextValue } as Part
-            }),
-          }
-        })
+      if (!currentData) {
+        if (!invalidatedGroupKeys.has(key)) {
+          invalidatedGroupKeys.add(key)
+          queryClient.invalidateQueries({ queryKey })
+        }
+        groupsToDelete.push(key)
+        continue
       }
 
-      queryClient.setQueryData(queryKey, updatedData)
+      let updatedData = currentData
+      let dataMutated = false
+      const unapplied: PartOperation[] = []
+      const supersededPartIDs = new Set<string>()
+
+      const messageIdxById = new Map<string, number>()
+      for (let i = 0; i < currentData.length; i++) {
+        messageIdxById.set(currentData[i].info.id, i)
+      }
+
+      const partIdxCache = new Map<number, Map<string, number>>()
+
+      const ensurePartIdx = (msgIdx: number, parts: Part[]): Map<string, number> => {
+        let cache = partIdxCache.get(msgIdx)
+        if (!cache) {
+          cache = new Map()
+          for (let i = 0; i < parts.length; i++) {
+            cache.set(parts[i].id, i)
+          }
+          partIdxCache.set(msgIdx, cache)
+        }
+        return cache
+      }
+
+      for (const operation of group.operations) {
+        if (operation.type === 'upsert') {
+          const msgIdx = messageIdxById.get(operation.part.messageID)
+          if (msgIdx === undefined) {
+            unapplied.push(operation)
+            continue
+          }
+          if (!dataMutated) {
+            updatedData = [...currentData]
+            dataMutated = true
+          }
+          const msg = updatedData[msgIdx]
+          const pIdx = ensurePartIdx(msgIdx, msg.parts)
+          const existingPartIdx = pIdx.get(operation.part.id)
+          let nextParts: Part[]
+          if (existingPartIdx !== undefined) {
+            nextParts = [...msg.parts]
+            nextParts[existingPartIdx] = operation.part
+          } else {
+            nextParts = [...msg.parts, operation.part]
+            pIdx.set(operation.part.id, nextParts.length - 1)
+          }
+          updatedData[msgIdx] = { ...msg, parts: nextParts }
+          supersededPartIDs.add(operation.part.id)
+          continue
+        }
+
+        if (operation.type === 'remove') {
+          const msgIdx = messageIdxById.get(operation.messageID)
+          if (msgIdx === undefined) {
+            unapplied.push(operation)
+            continue
+          }
+          if (!dataMutated) {
+            updatedData = [...currentData]
+            dataMutated = true
+          }
+          const msg = updatedData[msgIdx]
+          const pIdx = ensurePartIdx(msgIdx, msg.parts)
+          if (pIdx.get(operation.partID) === undefined) {
+            unapplied.push(operation)
+            continue
+          }
+          const nextParts = msg.parts.filter((part) => part.id !== operation.partID)
+          updatedData[msgIdx] = { ...msg, parts: nextParts }
+          partIdxCache.delete(msgIdx)
+          supersededPartIDs.add(operation.partID)
+          continue
+        }
+
+        const msgIdx = messageIdxById.get(operation.messageID)
+        if (msgIdx === undefined) {
+          unapplied.push(operation)
+          continue
+        }
+        if (!dataMutated) {
+          updatedData = [...currentData]
+          dataMutated = true
+        }
+        const msg = updatedData[msgIdx]
+        const pIdx = ensurePartIdx(msgIdx, msg.parts)
+        const pIdxResult = pIdx.get(operation.partID)
+        if (pIdxResult === undefined) {
+          unapplied.push(operation)
+          continue
+        }
+        const targetPart = msg.parts[pIdxResult]
+        if (!targetPart) {
+          unapplied.push(operation)
+          continue
+        }
+        const nextParts = [...msg.parts]
+        const currentValue = (targetPart as Record<string, unknown>)[operation.field]
+        const nextValue = `${typeof currentValue === 'string' ? currentValue : ''}${operation.delta}`
+        nextParts[pIdxResult] = { ...targetPart, [operation.field]: nextValue } as Part
+        updatedData[msgIdx] = { ...msg, parts: nextParts }
+      }
+
+      if (dataMutated) {
+        queryClient.setQueryData(queryKey, updatedData)
+      }
+
+      const filteredUnapplied = unapplied.filter((op) => {
+        if (op.type === 'delta' || op.type === 'remove') {
+          return !supersededPartIDs.has(op.partID)
+        }
+        return true
+      })
+
+      if (filteredUnapplied.length > 0) {
+        if (!invalidatedGroupKeys.has(key)) {
+          invalidatedGroupKeys.add(key)
+          queryClient.invalidateQueries({ queryKey })
+        }
+      }
+
+      groupsToDelete.push(key)
     }
 
-    pendingOperations.clear()
+    for (const key of groupsToDelete) {
+      pendingOperations.delete(key)
+    }
   }
 
-  const queueOperation = (sessionID: string, operation: PartOperation) => {
-    const operations = pendingOperations.get(sessionID) ?? []
-    operations.push(operation)
-    pendingOperations.set(sessionID, operations)
+  const queueOperation = (sessionID: string, operation: PartOperation, directory?: string) => {
+    const key = groupKey(sessionID, directory)
+    let group = pendingOperations.get(key)
+    if (!group) {
+      group = { sessionID, directory, operations: [] }
+      pendingOperations.set(key, group)
+    }
+    group.operations.push(operation)
     scheduleFlush()
   }
 
-  const queuePartUpdate = (sessionID: string, part: Part) => {
-    queueOperation(sessionID, { type: 'upsert', part })
+  const queuePartUpdate = (sessionID: string, part: Part, directory?: string) => {
+    queueOperation(sessionID, { type: 'upsert', part }, directory)
   }
 
-  const queuePartDelta = (sessionID: string, messageID: string, partID: string, field: string, delta: string) => {
-    queueOperation(sessionID, { type: 'delta', messageID, partID, field, delta })
+  const queuePartDelta = (sessionID: string, messageID: string, partID: string, field: string, delta: string, directory?: string) => {
+    queueOperation(sessionID, { type: 'delta', messageID, partID, field, delta }, directory)
   }
 
-  const queuePartRemoval = (sessionID: string, messageID: string, partID: string) => {
-    queueOperation(sessionID, { type: 'remove', messageID, partID })
+  const queuePartRemoval = (sessionID: string, messageID: string, partID: string, directory?: string) => {
+    queueOperation(sessionID, { type: 'remove', messageID, partID }, directory)
   }
 
   const destroy = () => {

--- a/frontend/src/lib/queryInvalidation.ts
+++ b/frontend/src/lib/queryInvalidation.ts
@@ -1,5 +1,13 @@
 import type { QueryClient } from '@tanstack/react-query'
 
+export function messagesQueryKey(
+  opcodeUrl: string | null | undefined,
+  sessionID: string | null | undefined,
+  directory: string | null | undefined,
+) {
+  return ['opencode', 'messages', opcodeUrl, sessionID, directory]
+}
+
 export function invalidateProviderCaches(queryClient: QueryClient) {
   queryClient.invalidateQueries({ queryKey: ['provider-credentials'] })
   queryClient.invalidateQueries({ queryKey: ['provider-auth-methods'] })

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -32,6 +32,7 @@ import { useEffect, useRef, useCallback, useMemo } from "react";
 import { MessageSkeleton } from "@/components/message/MessageSkeleton";
 import { exportSession, downloadMarkdown } from "@/lib/exportSession";
 import type { MessageWithParts } from "@/api/types";
+import { getMessagesContentVersion } from "./sessionContentVersion";
 import { showToast } from "@/lib/toast";
 import { getRepoDisplayName } from "@/lib/utils";
 import { RepoMcpDialog } from "@/components/repo/RepoMcpDialog";
@@ -61,21 +62,6 @@ const compareMessageIds = (id1: string, id2: string): number => {
 
 const PENDING_ACTION_SYNC_INTERVAL_MS = 30000
 const PROMPT_OVERLAY_CLEARANCE_PX = 16
-
-const getMessagesContentVersion = (messages?: MessageWithParts[]): number => {
-  if (!messages) return 0
-  return messages.reduce((sum, message) => {
-    return sum + message.parts.reduce((partSum, part) => {
-      if ('text' in part && typeof part.text === 'string') {
-        return partSum + part.text.length
-      }
-      if (part.type === 'tool') {
-        return partSum + JSON.stringify(part.state).length
-      }
-      return partSum + 1
-    }, 0)
-  }, messages.length)
-}
 
 export function SessionDetail() {
   const { id, sessionId } = useParams<{ id: string; sessionId: string }>();
@@ -164,11 +150,13 @@ export function SessionDetail() {
     return messages
   }, [messages])
 
+  const messagesContentVersion = useMemo(() => getMessagesContentVersion(messages), [messages]);
+
   const { scrollToBottom } = useAutoScroll({
     containerRef: messageContainerRef,
     messages: messages?.map(m => m.info),
     sessionId,
-    contentVersion: getMessagesContentVersion(messages),
+    contentVersion: messagesContentVersion,
     onScrollStateChange: setShowScrollButton
   });
   const abortSession = useAbortSession(opcodeUrl, repoDirectory, sessionId);

--- a/frontend/src/pages/__tests__/SessionDetail.contentVersion.test.ts
+++ b/frontend/src/pages/__tests__/SessionDetail.contentVersion.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest'
+import { getMessagesContentVersion } from '../sessionContentVersion'
+import type { MessageWithParts } from '@/api/types'
+
+const baseMessage: Pick<MessageWithParts['info'], 'id' | 'role' | 'time'> = {
+  id: 'msg-1',
+  role: 'assistant',
+  time: { start: 1000 },
+}
+
+function makeMessage(parts: MessageWithParts['parts']): MessageWithParts {
+  return { info: { ...baseMessage, id: 'msg-1' }, parts }
+}
+
+describe('getMessagesContentVersion', () => {
+  it('returns 0 for undefined', () => {
+    expect(getMessagesContentVersion(undefined)).toBe(0)
+  })
+
+  it('returns 0 for empty array', () => {
+    expect(getMessagesContentVersion([])).toBe(0)
+  })
+
+  it('is stable across two calls with the same input', () => {
+    const msgs = [makeMessage([
+      { type: 'text', id: 'p1', sessionID: 's1', messageID: 'm1', text: 'hello' },
+    ])]
+    const v1 = getMessagesContentVersion(msgs)
+    const v2 = getMessagesContentVersion(msgs)
+    expect(v1).toBe(v2)
+  })
+
+  it('changes when a text part text is extended', () => {
+    const msgs = [makeMessage([
+      { type: 'text', id: 'p1', sessionID: 's1', messageID: 'm1', text: 'hello' },
+    ])]
+    const v1 = getMessagesContentVersion(msgs)
+
+    const msgs2 = [makeMessage([
+      { type: 'text', id: 'p1', sessionID: 's1', messageID: 'm1', text: 'hello world' },
+    ])]
+    const v2 = getMessagesContentVersion(msgs2)
+
+    expect(v2).not.toBe(v1)
+  })
+
+  it('changes when a tool part output changes', () => {
+    const msgs = [makeMessage([
+      {
+        type: 'tool', id: 'p1', sessionID: 's1', messageID: 'm1',
+        callID: 'c1', tool: 'read',
+        state: { status: 'completed' as const, input: {}, output: 'foo', title: 't', metadata: {}, time: { start: 1000, end: 2000 } },
+      },
+    ])]
+    const v1 = getMessagesContentVersion(msgs)
+
+    const msgs2 = [makeMessage([
+      {
+        type: 'tool', id: 'p1', sessionID: 's1', messageID: 'm1',
+        callID: 'c1', tool: 'read',
+        state: { status: 'completed' as const, input: {}, output: 'foobar', title: 't', metadata: {}, time: { start: 1000, end: 2000 } },
+      },
+    ])]
+    const v2 = getMessagesContentVersion(msgs2)
+
+    expect(v2).not.toBe(v1)
+  })
+
+  it('changes when a tool part status transitions', () => {
+    const pendingMsgs = [makeMessage([
+      {
+        type: 'tool', id: 'p1', sessionID: 's1', messageID: 'm1',
+        callID: 'c1', tool: 'read',
+        state: { status: 'pending' as const, input: {}, raw: '{}' },
+      },
+    ])]
+    const vPending = getMessagesContentVersion(pendingMsgs)
+
+    const runningMsgs = [makeMessage([
+      {
+        type: 'tool', id: 'p1', sessionID: 's1', messageID: 'm1',
+        callID: 'c1', tool: 'read',
+        state: { status: 'running' as const, input: {}, time: { start: 1000 } },
+      },
+    ])]
+    const vRunning = getMessagesContentVersion(runningMsgs)
+
+    expect(vRunning).not.toBe(vPending)
+  })
+
+  it('changes when a tool part has an error', () => {
+    const msgsOk = [makeMessage([
+      {
+        type: 'tool', id: 'p1', sessionID: 's1', messageID: 'm1',
+        callID: 'c1', tool: 'read',
+        state: { status: 'completed' as const, input: {}, output: '', title: 't', metadata: {}, time: { start: 1000, end: 2000 } },
+      },
+    ])]
+    const vOk = getMessagesContentVersion(msgsOk)
+
+    const msgsError = [makeMessage([
+      {
+        type: 'tool', id: 'p1', sessionID: 's1', messageID: 'm1',
+        callID: 'c1', tool: 'read',
+        state: { status: 'error' as const, input: {}, error: 'Failed to read', metadata: {}, time: { start: 1000, end: 2000 } },
+      },
+    ])]
+    const vError = getMessagesContentVersion(msgsError)
+
+    expect(vError).not.toBe(vOk)
+  })
+
+  it('accounts for reasoning part text length', () => {
+    const msgs = [makeMessage([
+      { type: 'reasoning', id: 'p1', sessionID: 's1', messageID: 'm1', text: 'thinking...' },
+    ])]
+    expect(getMessagesContentVersion(msgs)).toBeGreaterThan(0)
+  })
+
+  it('changes when tool status transitions between same-length strings', () => {
+    // 'pending' and 'running' are both 7 characters – length-only
+    // versioning would miss this.
+    const pendingMsgs = [makeMessage([
+      {
+        type: 'tool', id: 'p1', sessionID: 's1', messageID: 'm1',
+        callID: 'c1', tool: 'read',
+        state: { status: 'pending' as const, input: {} },
+      },
+    ])]
+    const vPending = getMessagesContentVersion(pendingMsgs)
+
+    const runningMsgs = [makeMessage([
+      {
+        type: 'tool', id: 'p1', sessionID: 's1', messageID: 'm1',
+        callID: 'c1', tool: 'read',
+        state: { status: 'running' as const, input: {} },
+      },
+    ])]
+    const vRunning = getMessagesContentVersion(runningMsgs)
+
+    expect(vRunning).not.toBe(vPending)
+  })
+
+  it('changes when tool output changes to different text of the same length', () => {
+    const msgsFoo = [makeMessage([
+      {
+        type: 'tool', id: 'p1', sessionID: 's1', messageID: 'm1',
+        callID: 'c1', tool: 'read',
+        state: { status: 'completed' as const, input: {}, output: 'foo', metadata: {}, time: { start: 1000, end: 2000 } },
+      },
+    ])]
+    const vFoo = getMessagesContentVersion(msgsFoo)
+
+    const msgsBar = [makeMessage([
+      {
+        type: 'tool', id: 'p1', sessionID: 's1', messageID: 'm1',
+        callID: 'c1', tool: 'read',
+        state: { status: 'completed' as const, input: {}, output: 'bar', metadata: {}, time: { start: 1000, end: 2000 } },
+      },
+    ])]
+    const vBar = getMessagesContentVersion(msgsBar)
+
+    expect(vBar).not.toBe(vFoo)
+  })
+})

--- a/frontend/src/pages/sessionContentVersion.ts
+++ b/frontend/src/pages/sessionContentVersion.ts
@@ -1,0 +1,47 @@
+import type { MessageWithParts } from "@/api/types";
+
+/**
+ * Cheap bounded hash for a string value.
+ *
+ * Combines length with the character codes of the first 128 chars so that
+ * same-length strings ("pending" → "running", "foo" → "bar") produce
+ * different hash values.  The iteration is capped at 128 characters so
+ * the cost is bounded even for very long tool outputs.
+ */
+function hashString(s: string): number {
+  let h = s.length;
+  const max = Math.min(s.length, 128);
+  for (let i = 0; i < max; i++) {
+    h = ((h << 5) - h) + s.charCodeAt(i);
+    h |= 0; // keep 32-bit
+  }
+  return h;
+}
+
+/**
+ * Computes a version number that changes when message content changes.
+ *
+ * Used to trigger autoscroll on streamed deltas. This function avoids
+ * expensive operations like JSON.stringify so it can be called on every
+ * render without impacting performance.
+ */
+export function getMessagesContentVersion(messages?: MessageWithParts[]): number {
+  if (!messages) return 0;
+  return messages.reduce((sum, message) => {
+    return sum + message.parts.reduce((partSum, part) => {
+      if ("text" in part && typeof part.text === "string") {
+        return partSum + hashString(part.text);
+      }
+      if (part.type === "tool") {
+        const state = part.state as Record<string, unknown>;
+        let v = 0;
+        if (typeof state.status === "string") v += hashString(state.status);
+        if (typeof state.output === "string") v += hashString(state.output);
+        if (typeof state.error === "string") v += hashString(state.error);
+        if (typeof state.raw === "string") v += hashString(state.raw);
+        return partSum + v;
+      }
+      return partSum + 1;
+    }, 0);
+  }, messages.length);
+}

--- a/frontend/src/stores/modelStore.test.ts
+++ b/frontend/src/stores/modelStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useModelStore, modelExists, modelStorePartialize, modelStoreMigrate } from '@/stores/modelStore'
 import type { Provider } from '@/api/providers'
 
@@ -293,6 +293,29 @@ describe('variants', () => {
   it('clearVariant is idempotent', () => {
     const model = { providerID: 'openai', modelID: 'gpt-4o' }
     expect(() => useModelStore.getState().clearVariant(model)).not.toThrow()
+  })
+
+  it('clearVariant does not notify subscribers when variant is already absent', () => {
+    const model = { providerID: 'openai', modelID: 'gpt-4o' }
+    const listener = vi.fn()
+    const unsubscribe = useModelStore.subscribe(listener)
+
+    useModelStore.getState().clearVariant(model)
+
+    unsubscribe()
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('setVariant does not notify subscribers when variant is unchanged', () => {
+    const model = { providerID: 'openai', modelID: 'gpt-4o' }
+    useModelStore.getState().setVariant(model, 'gpt-4o-2024-05-13')
+    const listener = vi.fn()
+    const unsubscribe = useModelStore.subscribe(listener)
+
+    useModelStore.getState().setVariant(model, 'gpt-4o-2024-05-13')
+
+    unsubscribe()
+    expect(listener).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/src/stores/modelStore.ts
+++ b/frontend/src/stores/modelStore.ts
@@ -69,6 +69,18 @@ export function modelStoreMigrate(persistedState: unknown): unknown {
   return next
 }
 
+function mergeVariants(
+  current: Record<string, string | undefined>,
+  incoming: Record<string, string | undefined>
+): Record<string, string | undefined> | undefined {
+  const next = { ...incoming, ...current }
+  const currentKeys = Object.keys(current)
+  const nextKeys = Object.keys(next)
+
+  if (currentKeys.length !== nextKeys.length) return next
+  return nextKeys.some((key) => current[key] !== next[key]) ? next : undefined
+}
+
 export const useModelStore = create<ModelStore>()(
   persist(
     (set, get) => ({
@@ -100,12 +112,10 @@ export const useModelStore = create<ModelStore>()(
     },
 
     syncModelState: (modelState) => {
-      set((state) => ({
-        variants: {
-          ...modelState.variant,
-          ...state.variants,
-        },
-      }))
+      const variants = mergeVariants(get().variants, modelState.variant)
+      if (variants) {
+        set({ variants })
+      }
     },
 
     syncFromConfig: (configModel: string | undefined, force = false) => {
@@ -153,8 +163,10 @@ export const useModelStore = create<ModelStore>()(
     },
 
     setVariant: (model: ModelSelection, variant: string | undefined) => {
+      const key = `${model.providerID}/${model.modelID}`
+      if (get().variants[key] === variant) return
+
       set((state) => {
-        const key = `${model.providerID}/${model.modelID}`
         return {
           variants: {
             ...state.variants,
@@ -171,8 +183,10 @@ export const useModelStore = create<ModelStore>()(
     },
 
     clearVariant: (model: ModelSelection) => {
+      const key = `${model.providerID}/${model.modelID}`
+      if (!(key in get().variants)) return
+
       set((state) => {
-        const key = `${model.providerID}/${model.modelID}`
         const newVariants = { ...state.variants }
         delete newVariants[key]
         return {

--- a/scripts/docker-upgrade.sh
+++ b/scripts/docker-upgrade.sh
@@ -13,9 +13,35 @@ fi
 
 NO_PULL=false
 SHOW_LOGS=false
+MODE="cached"   # cached | tools | full
+
+usage() {
+  cat <<EOF
+Usage: $0 [--tools | --full] [--no-pull] [--logs]
+
+Rebuild modes (pick one):
+  (default)   Cached build. Reuses pnpm install + tool install layers.
+              Only changed source (and the frontend build) rerun. ~1-2 min.
+  --tools     Cached build, but force a fresh uv/opencode install.
+              Keeps the expensive pnpm install cached. ~17 min.
+  --full      Full --no-cache rebuild of everything. ~25 min.
+
+Other flags:
+  --no-pull   Skip 'git pull'.
+  --logs      Follow container logs after starting.
+EOF
+}
 
 while [[ $# -gt 0 ]]; do
   case $1 in
+    --tools)
+      MODE="tools"
+      shift
+      ;;
+    --full)
+      MODE="full"
+      shift
+      ;;
     --no-pull)
       NO_PULL=true
       shift
@@ -24,8 +50,12 @@ while [[ $# -gt 0 ]]; do
       SHOW_LOGS=true
       shift
       ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
     *)
-      echo "Usage: $0 [--no-pull] [--logs]"
+      usage
       exit 1
       ;;
   esac
@@ -39,8 +69,20 @@ fi
 echo -e "${YELLOW}Stopping container...${NC}"
 $DOCKER_COMPOSE down
 
-echo -e "${YELLOW}Rebuilding image with no cache...${NC}"
-$DOCKER_COMPOSE build --no-cache
+case "$MODE" in
+  cached)
+    echo -e "${YELLOW}Rebuilding image (cached, source-only)...${NC}"
+    $DOCKER_COMPOSE build || exit 1
+    ;;
+  tools)
+    echo -e "${YELLOW}Rebuilding image (cached + fresh uv/opencode)...${NC}"
+    TOOLS_CACHEBUST="$(date +%s)" $DOCKER_COMPOSE build || exit 1
+    ;;
+  full)
+    echo -e "${YELLOW}Rebuilding image with no cache (full)...${NC}"
+    $DOCKER_COMPOSE build --no-cache || exit 1
+    ;;
+esac
 
 echo -e "${YELLOW}Starting container...${NC}"
 $DOCKER_COMPOSE up -d

--- a/shared/src/schemas/sse.ts
+++ b/shared/src/schemas/sse.ts
@@ -13,3 +13,15 @@ export const SSEVisibilitySchema = z.object({
 
 export type SSESubscribeRequest = z.infer<typeof SSESubscribeSchema>;
 export type SSEVisibilityRequest = z.infer<typeof SSEVisibilitySchema>;
+
+export interface SSEEventPayload {
+  type: string;
+  properties: Record<string, unknown>;
+}
+
+export interface SSEEventEnvelope {
+  directory?: string;
+  project?: string;
+  workspace?: string;
+  payload: SSEEventPayload;
+}


### PR DESCRIPTION
Replace promise-chaining SSE writer with a queue-based pump with MAX_QUEUED_FRAMES backpressure for reliable ordering under load. Make the frontend parts batcher directory-aware, grouping operations by (sessionID, directory) composite key, and decouple the batcher lifecycle from directory dependencies. Add session content versioning for reliable content change detection. Improve Docker build caching with TOOLS_CACHEBUST arg and docker-upgrade.sh modes (cached/tools/full). Fix plugin install timeout/spawn errors and assistant session endpoint path.

Changes:
- Replace promise-chaining SSE writer with queue-based pump with MAX_QUEUED_FRAMES backpressure and error isolation
- Make frontend parts batcher directory-aware with (sessionID, directory) composite key; flush() accepts optional target filter
- Add session content versioning for reliable content change detection
- Add TOOLS_CACHEBUST build arg for selective Docker cache invalidation
- Add docker-upgrade.sh modes: cached (default), tools (fresh uv/opencode install), full (--no-cache)
- Fix plugin install timeout and spawn error handling in opencode-single-server
- Fix assistant session endpoint path and add ordering params

## Files
- backend/src/routes/sse-writer.ts
- backend/src/routes/sse.ts
- backend/src/services/sse-aggregator.ts
- backend/src/services/assistant-mode.ts
- backend/src/services/opencode-single-server.ts
- backend/test/routes/sse-writer.test.ts
- backend/test/services/sse-aggregator.test.ts
- backend/test/services/assistant-mode.test.ts
- backend/test/services/opencode-single-server.test.ts
- frontend/src/lib/partsBatcher.ts
- frontend/src/lib/partsBatcher.test.ts
- frontend/src/hooks/useSSE.ts
- frontend/src/hooks/useSSE.test.tsx
- frontend/src/hooks/useAutoScroll.ts
- frontend/src/hooks/useAutoScroll.test.tsx
- frontend/src/pages/sessionContentVersion.ts
- frontend/src/pages/SessionDetail.tsx
- frontend/src/pages/__tests__/SessionDetail.contentVersion.test.ts
- frontend/src/components/message/MessageThread.tsx
- frontend/src/lib/opencode-event-stream/openCodeEventStream.ts
- frontend/src/lib/opencode-event-stream/testTransport.ts
- frontend/src/lib/opencode-event-stream/__tests__/openCodeEventStream.test.ts
- Dockerfile
- docker-compose.yml
- scripts/docker-upgrade.sh