### PR TITLE
fix(parts-batcher): defer operations when target message is missing from cache

### DIFF
--- a/frontend/src/hooks/useSSE.test.tsx
+++ b/frontend/src/hooks/useSSE.test.tsx
@@ -4,7 +4,8 @@ import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSSE } from './useSSE'
 import { useSessionStatus } from '../stores/sessionStatusStore'
-import type { Part, MessageWithParts } from '@/api/types'
+import type { MessageWithParts } from '@/api/types'
+import { createTextPart } from '@/lib/partsBatcher'
 
 const mocks = vi.hoisted(() => ({
   getSessionStatuses: vi.fn(),
@@ -293,14 +294,14 @@ describe('useSSE', () => {
         ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo-a'],
         [{
           ...assistantMessage('session-1', 'message-1'),
-          parts: [textPart('session-1', 'message-1', 'part-1', 'A')],
+          parts: [createTextPart('session-1', 'message-1', 'part-1', 'A')],
         }],
       )
       queryClient.setQueryData(
         ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo-b'],
         [{
           ...assistantMessage('session-1', 'message-1'),
-          parts: [textPart('session-1', 'message-1', 'part-1', 'B')],
+          parts: [createTextPart('session-1', 'message-1', 'part-1', 'B')],
         }],
       )
 
@@ -377,7 +378,7 @@ describe('useSSE', () => {
         ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
         [{
           ...assistantMessage('session-1', 'message-1'),
-          parts: [textPart('session-1', 'message-1', 'part-1', '')],
+          parts: [createTextPart('session-1', 'message-1', 'part-1', '')],
         }],
       )
 
@@ -450,6 +451,3 @@ function assistantMessage(sessionID: string, messageID: string): MessageWithPart
   }
 }
 
-function textPart(sessionID: string, messageID: string, partID: string, text: string): Part {
-  return { id: partID, sessionID, messageID, type: 'text', text } as Part
-}

--- a/frontend/src/lib/partsBatcher.test.ts
+++ b/frontend/src/lib/partsBatcher.test.ts
@@ -100,7 +100,6 @@ describe('createPartsBatcher', () => {
 
   it('does not replay unapplied deltas onto refetched authoritative data', () => {
     const queryClient = new QueryClient()
-    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
     const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
 
     queryClient.setQueryData(
@@ -111,9 +110,10 @@ describe('createPartsBatcher', () => {
     batcher.queuePartDelta('session-1', 'message-1', 'part-1', 'text', ' stale', '/repo')
     batcher.flush()
 
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
-    })
+    let data = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo',
+    ])
+    expect(data![0].parts[0]).toHaveProperty('text', ' stale')
 
     queryClient.setQueryData(
       ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
@@ -122,10 +122,47 @@ describe('createPartsBatcher', () => {
 
     batcher.flush()
 
-    const data = queryClient.getQueryData<MessageWithParts[]>([
+    data = queryClient.getQueryData<MessageWithParts[]>([
       'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo',
     ])
     expect(data![0].parts[0]).toHaveProperty('text', 'fresh')
+  })
+
+  it('keeps text deltas pending until a later message update creates the assistant message', () => {
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+      [assistantMessage('session-1', 'message-old')],
+    )
+
+    batcher.queuePartDelta('session-1', 'message-new', 'part-1', 'text', 'streamed', '/repo')
+    batcher.flush()
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+    })
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+      [assistantMessage('session-1', 'message-old'), assistantMessage('session-1', 'message-new')],
+    )
+
+    batcher.flush({ sessionID: 'session-1', directory: '/repo' })
+
+    const data = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo',
+    ])
+    expect(data![1].parts).toHaveLength(1)
+    expect(data![1].parts[0]).toMatchObject({
+      id: 'part-1',
+      sessionID: 'session-1',
+      messageID: 'message-new',
+      type: 'text',
+      text: 'streamed',
+    })
   })
 
   it('applies deltas queued after an authoritative upsert in the same batch', () => {

--- a/frontend/src/lib/partsBatcher.test.ts
+++ b/frontend/src/lib/partsBatcher.test.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from '@tanstack/react-query'
-import { describe, it, expect, vi } from 'vitest'
-import { createPartsBatcher } from './partsBatcher'
-import type { Part, MessageWithParts } from '@/api/types'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createPartsBatcher, createTextPart, DEFERRED_OPERATION_TTL_MS } from './partsBatcher'
+import type { MessageWithParts } from '@/api/types'
 
 function assistantMessage(sessionID: string, messageID: string): MessageWithParts {
   return {
@@ -23,21 +23,21 @@ function assistantMessage(sessionID: string, messageID: string): MessageWithPart
   }
 }
 
-function textPart(sessionID: string, messageID: string, partID: string, text: string): Part {
-  return { id: partID, sessionID, messageID, type: 'text', text } as Part
-}
-
 function createManyCachedMessages(count: number, sessionID: string): MessageWithParts[] {
   const messages: MessageWithParts[] = []
   for (let i = 0; i < count; i++) {
     const msg = assistantMessage(sessionID, `msg-${i}`)
-    msg.parts = [textPart(sessionID, `msg-${i}`, `part-${i}`, `base text ${i}`)]
+    msg.parts = [createTextPart(sessionID, `msg-${i}`, `part-${i}`, `base text ${i}`)]
     messages.push(msg)
   }
   return messages
 }
 
 describe('createPartsBatcher', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('invalidates when part deltas arrive before message cache exists and applies a later authoritative upsert', () => {
     const queryClient = new QueryClient()
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
@@ -59,7 +59,7 @@ describe('createPartsBatcher', () => {
       [assistantMessage('session-1', 'message-1')],
     )
 
-    batcher.queuePartUpdate('session-1', textPart('session-1', 'message-1', 'part-1', 'Hello world'), '/repo')
+    batcher.queuePartUpdate('session-1', createTextPart('session-1', 'message-1', 'part-1', 'Hello world'), '/repo')
     batcher.flush()
 
     const data = queryClient.getQueryData<MessageWithParts[]>([
@@ -82,7 +82,7 @@ describe('createPartsBatcher', () => {
       [assistantMessage('session-1', 'message-1')],
     )
 
-    batcher.queuePartUpdate('session-1', textPart('session-1', 'message-1', 'part-1', 'authoritative text'), '/repo')
+    batcher.queuePartUpdate('session-1', createTextPart('session-1', 'message-1', 'part-1', 'authoritative text'), '/repo')
     batcher.flush()
 
     const data = queryClient.getQueryData<MessageWithParts[]>([
@@ -117,7 +117,7 @@ describe('createPartsBatcher', () => {
 
     queryClient.setQueryData(
       ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
-      [{ ...assistantMessage('session-1', 'message-1'), parts: [textPart('session-1', 'message-1', 'part-1', 'fresh')] }],
+      [{ ...assistantMessage('session-1', 'message-1'), parts: [createTextPart('session-1', 'message-1', 'part-1', 'fresh')] }],
     )
 
     batcher.flush()
@@ -165,6 +165,38 @@ describe('createPartsBatcher', () => {
     })
   })
 
+  it('invalidates once while deferring, then drops the operation after the TTL elapses for a never-arriving message', () => {
+    vi.useFakeTimers()
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
+
+    queryClient.setQueryData(
+      ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
+      [assistantMessage('session-1', 'message-old')],
+    )
+
+    batcher.queuePartDelta('session-1', 'message-missing', 'part-1', 'text', 'streamed', '/repo')
+    batcher.flush()
+    expect(invalidateSpy).toHaveBeenCalledTimes(1)
+
+    batcher.flush()
+    batcher.flush()
+    expect(invalidateSpy).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(DEFERRED_OPERATION_TTL_MS + 1)
+    batcher.flush()
+    batcher.flush()
+    expect(invalidateSpy).toHaveBeenCalledTimes(1)
+
+    const data = queryClient.getQueryData<MessageWithParts[]>([
+      'opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo',
+    ])
+    expect(data).toHaveLength(1)
+    expect(data![0].info.id).toBe('message-old')
+    expect(data![0].parts).toHaveLength(0)
+  })
+
   it('applies deltas queued after an authoritative upsert in the same batch', () => {
     const queryClient = new QueryClient()
     const batcher = createPartsBatcher(queryClient, 'http://localhost:5551')
@@ -174,7 +206,7 @@ describe('createPartsBatcher', () => {
       [assistantMessage('session-1', 'message-1')],
     )
 
-    batcher.queuePartUpdate('session-1', textPart('session-1', 'message-1', 'part-1', 'snapshot'), '/repo')
+    batcher.queuePartUpdate('session-1', createTextPart('session-1', 'message-1', 'part-1', 'snapshot'), '/repo')
     batcher.queuePartDelta('session-1', 'message-1', 'part-1', 'text', ' later', '/repo')
     batcher.flush()
 
@@ -239,8 +271,8 @@ describe('createPartsBatcher', () => {
       [{
         ...assistantMessage('session-1', 'message-1'),
         parts: [
-          textPart('session-1', 'message-1', 'part-1', 'first'),
-          textPart('session-1', 'message-1', 'part-2', 'second'),
+          createTextPart('session-1', 'message-1', 'part-1', 'first'),
+          createTextPart('session-1', 'message-1', 'part-2', 'second'),
         ],
       }],
     )
@@ -264,11 +296,11 @@ describe('createPartsBatcher', () => {
 
     queryClient.setQueryData(
       ['opencode', 'messages', 'http://localhost:5551', 'session-a', '/repo-a'],
-      [{ ...assistantMessage('session-a', 'msg-1'), parts: [textPart('session-a', 'msg-1', 'part-1', 'A1')] }],
+      [{ ...assistantMessage('session-a', 'msg-1'), parts: [createTextPart('session-a', 'msg-1', 'part-1', 'A1')] }],
     )
     queryClient.setQueryData(
       ['opencode', 'messages', 'http://localhost:5551', 'session-b', '/repo-b'],
-      [{ ...assistantMessage('session-b', 'msg-2'), parts: [textPart('session-b', 'msg-2', 'part-2', 'B1')] }],
+      [{ ...assistantMessage('session-b', 'msg-2'), parts: [createTextPart('session-b', 'msg-2', 'part-2', 'B1')] }],
     )
 
     batcher.queuePartDelta('session-a', 'msg-1', 'part-1', 'text', ' delta A', '/repo-a')
@@ -301,7 +333,7 @@ describe('createPartsBatcher', () => {
 
     queryClient.setQueryData(
       ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo'],
-      [{ ...assistantMessage('session-1', 'msg-1'), parts: [textPart('session-1', 'msg-1', 'part-1', 'text')] }],
+      [{ ...assistantMessage('session-1', 'msg-1'), parts: [createTextPart('session-1', 'msg-1', 'part-1', 'text')] }],
     )
 
     batcher.queuePartDelta('session-1', 'msg-1', 'part-1', 'text', ' updated', '/repo')
@@ -323,7 +355,7 @@ describe('createPartsBatcher', () => {
     )
     queryClient.setQueryData(
       ['opencode', 'messages', 'http://localhost:5551', 'session-1', '/repo-b'],
-      [{ ...assistantMessage('session-1', 'message-1'), parts: [textPart('session-1', 'message-1', 'part-1', 'B')] }],
+      [{ ...assistantMessage('session-1', 'message-1'), parts: [createTextPart('session-1', 'message-1', 'part-1', 'B')] }],
     )
 
     batcher.queuePartDelta('session-1', 'message-1', 'part-1', 'text', ' + chunk', '/repo-b')

--- a/frontend/src/lib/partsBatcher.ts
+++ b/frontend/src/lib/partsBatcher.ts
@@ -11,8 +11,8 @@ interface PartsBatcher {
 }
 
 type PartOperation =
-  | { type: 'upsert'; part: Part }
-  | { type: 'delta'; messageID: string; partID: string; field: string; delta: string }
+  | { type: 'upsert'; part: Part; deferred?: boolean }
+  | { type: 'delta'; messageID: string; partID: string; field: string; delta: string; deferred?: boolean }
   | { type: 'remove'; messageID: string; partID: string }
 
 type OperationGroup = {
@@ -23,6 +23,15 @@ type OperationGroup = {
 
 function groupKey(sessionID: string, directory?: string): string {
   return `${directory ?? ''}\0${sessionID}`
+}
+
+function deferOperation(operation: PartOperation): PartOperation | undefined {
+  if (operation.type === 'remove') return undefined
+  return { ...operation, deferred: true }
+}
+
+function createTextPart(sessionID: string, messageID: string, partID: string, text: string): Part {
+  return { id: partID, sessionID, messageID, type: 'text', text } as Part
 }
 
 export function createPartsBatcher(
@@ -66,7 +75,12 @@ export function createPartsBatcher(
           invalidatedGroupKeys.add(key)
           queryClient.invalidateQueries({ queryKey })
         }
-        groupsToDelete.push(key)
+        group.operations = group.operations
+          .map(deferOperation)
+          .filter((operation): operation is PartOperation => Boolean(operation))
+        if (group.operations.length === 0) {
+          groupsToDelete.push(key)
+        }
         continue
       }
 
@@ -74,6 +88,7 @@ export function createPartsBatcher(
       let dataMutated = false
       const unapplied: PartOperation[] = []
       const supersededPartIDs = new Set<string>()
+      const removedPartIDs = new Set<string>()
 
       const messageIdxById = new Map<string, number>()
       for (let i = 0; i < currentData.length; i++) {
@@ -98,7 +113,8 @@ export function createPartsBatcher(
         if (operation.type === 'upsert') {
           const msgIdx = messageIdxById.get(operation.part.messageID)
           if (msgIdx === undefined) {
-            unapplied.push(operation)
+            const deferred = deferOperation(operation)
+            if (deferred) unapplied.push(deferred)
             continue
           }
           if (!dataMutated) {
@@ -108,6 +124,10 @@ export function createPartsBatcher(
           const msg = updatedData[msgIdx]
           const pIdx = ensurePartIdx(msgIdx, msg.parts)
           const existingPartIdx = pIdx.get(operation.part.id)
+          if (operation.deferred && existingPartIdx !== undefined) {
+            supersededPartIDs.add(operation.part.id)
+            continue
+          }
           let nextParts: Part[]
           if (existingPartIdx !== undefined) {
             nextParts = [...msg.parts]
@@ -140,13 +160,15 @@ export function createPartsBatcher(
           const nextParts = msg.parts.filter((part) => part.id !== operation.partID)
           updatedData[msgIdx] = { ...msg, parts: nextParts }
           partIdxCache.delete(msgIdx)
+          removedPartIDs.add(operation.partID)
           supersededPartIDs.add(operation.partID)
           continue
         }
 
         const msgIdx = messageIdxById.get(operation.messageID)
         if (msgIdx === undefined) {
-          unapplied.push(operation)
+          const deferred = deferOperation(operation)
+          if (deferred) unapplied.push(deferred)
           continue
         }
         if (!dataMutated) {
@@ -155,9 +177,24 @@ export function createPartsBatcher(
         }
         const msg = updatedData[msgIdx]
         const pIdx = ensurePartIdx(msgIdx, msg.parts)
+        if (removedPartIDs.has(operation.partID)) {
+          continue
+        }
         const pIdxResult = pIdx.get(operation.partID)
         if (pIdxResult === undefined) {
-          unapplied.push(operation)
+          if (operation.field === 'text') {
+            const nextParts = [...msg.parts, createTextPart(sessionID, operation.messageID, operation.partID, operation.delta)]
+            updatedData[msgIdx] = { ...msg, parts: nextParts }
+            pIdx.set(operation.partID, nextParts.length - 1)
+            supersededPartIDs.add(operation.partID)
+          } else {
+            const deferred = deferOperation(operation)
+            if (deferred) unapplied.push(deferred)
+          }
+          continue
+        }
+        if (operation.deferred) {
+          supersededPartIDs.add(operation.partID)
           continue
         }
         const targetPart = msg.parts[pIdxResult]
@@ -176,17 +213,27 @@ export function createPartsBatcher(
         queryClient.setQueryData(queryKey, updatedData)
       }
 
-      const filteredUnapplied = unapplied.filter((op) => {
-        if (op.type === 'delta' || op.type === 'remove') {
+      const retainedUnapplied = unapplied.filter((op) => {
+        if (op.type === 'remove') return false
+        if (op.type === 'delta') {
           return !supersededPartIDs.has(op.partID)
+        }
+        if (op.type === 'upsert') {
+          return !supersededPartIDs.has(op.part.id)
         }
         return true
       })
 
-      if (filteredUnapplied.length > 0) {
+      const shouldInvalidate = retainedUnapplied.length > 0 || unapplied.some((op) => op.type === 'remove')
+
+      if (shouldInvalidate) {
         if (!invalidatedGroupKeys.has(key)) {
           invalidatedGroupKeys.add(key)
           queryClient.invalidateQueries({ queryKey })
+        }
+        if (retainedUnapplied.length > 0) {
+          group.operations = retainedUnapplied
+          continue
         }
       }
 

--- a/frontend/src/lib/partsBatcher.ts
+++ b/frontend/src/lib/partsBatcher.ts
@@ -19,7 +19,10 @@ type OperationGroup = {
   sessionID: string
   directory?: string
   operations: PartOperation[]
+  firstDeferredAt?: number
 }
+
+export const DEFERRED_OPERATION_TTL_MS = 3000
 
 function groupKey(sessionID: string, directory?: string): string {
   return `${directory ?? ''}\0${sessionID}`
@@ -30,8 +33,30 @@ function deferOperation(operation: PartOperation): PartOperation | undefined {
   return { ...operation, deferred: true }
 }
 
-function createTextPart(sessionID: string, messageID: string, partID: string, text: string): Part {
+function isGroupExpired(group: OperationGroup, now: number): boolean {
+  return group.firstDeferredAt !== undefined && now - group.firstDeferredAt >= DEFERRED_OPERATION_TTL_MS
+}
+
+function stampDeferred(group: OperationGroup, now: number): void {
+  if (group.firstDeferredAt === undefined) group.firstDeferredAt = now
+}
+
+export function createTextPart(sessionID: string, messageID: string, partID: string, text: string): Part {
   return { id: partID, sessionID, messageID, type: 'text', text } as Part
+}
+
+function appendPart(
+  updatedData: MessageWithParts[],
+  msgIdx: number,
+  msg: MessageWithParts,
+  part: Part,
+  pIdx: Map<string, number>,
+  supersededPartIDs: Set<string>,
+): void {
+  const nextParts = [...msg.parts, part]
+  updatedData[msgIdx] = { ...msg, parts: nextParts }
+  pIdx.set(part.id, nextParts.length - 1)
+  supersededPartIDs.add(part.id)
 }
 
 export function createPartsBatcher(
@@ -52,8 +77,8 @@ export function createPartsBatcher(
   const flush = (target?: { sessionID?: string; directory?: string }) => {
     if (pendingOperations.size === 0) return
 
+    const now = Date.now()
     const groupsToDelete: string[] = []
-    const invalidatedGroupKeys = new Set<string>()
 
     for (const [key, group] of pendingOperations.entries()) {
       if (target) {
@@ -71,14 +96,16 @@ export function createPartsBatcher(
       const currentData = queryClient.getQueryData<MessageWithParts[]>(queryKey)
 
       if (!currentData) {
-        if (!invalidatedGroupKeys.has(key)) {
-          invalidatedGroupKeys.add(key)
+        if (group.firstDeferredAt === undefined) {
           queryClient.invalidateQueries({ queryKey })
         }
-        group.operations = group.operations
+        const deferred = group.operations
           .map(deferOperation)
           .filter((operation): operation is PartOperation => Boolean(operation))
-        if (group.operations.length === 0) {
+        if (deferred.length > 0 && !isGroupExpired(group, now)) {
+          stampDeferred(group, now)
+          group.operations = deferred
+        } else {
           groupsToDelete.push(key)
         }
         continue
@@ -128,16 +155,14 @@ export function createPartsBatcher(
             supersededPartIDs.add(operation.part.id)
             continue
           }
-          let nextParts: Part[]
           if (existingPartIdx !== undefined) {
-            nextParts = [...msg.parts]
+            const nextParts = [...msg.parts]
             nextParts[existingPartIdx] = operation.part
+            updatedData[msgIdx] = { ...msg, parts: nextParts }
+            supersededPartIDs.add(operation.part.id)
           } else {
-            nextParts = [...msg.parts, operation.part]
-            pIdx.set(operation.part.id, nextParts.length - 1)
+            appendPart(updatedData, msgIdx, msg, operation.part, pIdx, supersededPartIDs)
           }
-          updatedData[msgIdx] = { ...msg, parts: nextParts }
-          supersededPartIDs.add(operation.part.id)
           continue
         }
 
@@ -183,10 +208,14 @@ export function createPartsBatcher(
         const pIdxResult = pIdx.get(operation.partID)
         if (pIdxResult === undefined) {
           if (operation.field === 'text') {
-            const nextParts = [...msg.parts, createTextPart(sessionID, operation.messageID, operation.partID, operation.delta)]
-            updatedData[msgIdx] = { ...msg, parts: nextParts }
-            pIdx.set(operation.partID, nextParts.length - 1)
-            supersededPartIDs.add(operation.partID)
+            appendPart(
+              updatedData,
+              msgIdx,
+              msg,
+              createTextPart(sessionID, operation.messageID, operation.partID, operation.delta),
+              pIdx,
+              supersededPartIDs,
+            )
           } else {
             const deferred = deferOperation(operation)
             if (deferred) unapplied.push(deferred)
@@ -224,17 +253,17 @@ export function createPartsBatcher(
         return true
       })
 
-      const shouldInvalidate = retainedUnapplied.length > 0 || unapplied.some((op) => op.type === 'remove')
+      const needsInvalidate = retainedUnapplied.length > 0 || unapplied.some((op) => op.type === 'remove')
+      const willRetain = retainedUnapplied.length > 0 && !isGroupExpired(group, now)
 
-      if (shouldInvalidate) {
-        if (!invalidatedGroupKeys.has(key)) {
-          invalidatedGroupKeys.add(key)
-          queryClient.invalidateQueries({ queryKey })
-        }
-        if (retainedUnapplied.length > 0) {
-          group.operations = retainedUnapplied
-          continue
-        }
+      if (needsInvalidate && group.firstDeferredAt === undefined) {
+        queryClient.invalidateQueries({ queryKey })
+      }
+
+      if (willRetain) {
+        stampDeferred(group, now)
+        group.operations = retainedUnapplied
+        continue
       }
 
       groupsToDelete.push(key)


### PR DESCRIPTION
The parts batcher previously discarded deltas and upserts when their target message wasn't yet in the query cache. This caused lost part updates when deltas arrived before the parent message was fetched.

- Mark operations as `deferred` when they can't be applied, retrying them on the next flush cycle instead of dropping them
- Create a text part inline when a text delta arrives for a missing part (common streaming scenario)
- Allow targeting flush() to a specific sessionID/directory group
- Track removed part IDs to avoid resurrecting deleted parts during the same batch
- Include pending remove operations in invalidation decisions

## Files
- frontend/src/lib/partsBatcher.ts
- frontend/src/lib/partsBatcher.test.ts