### PR TITLE
refactor: move assistant workspace install before OpenCode server start

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -45,7 +45,7 @@ import { createOpenCodeClient } from './services/opencode/client'
 import { NotificationService } from './services/notification'
 import { ScheduleRunner, ScheduleService } from './services/schedules'
 import { migrateGlobalSkills } from './services/skills'
-import { warmAssistantWorkspace } from './services/assistant-mode'
+import { installAssistantWorkspace } from './services/assistant-mode'
 import { getOpenCodeImportStatus, syncOpenCodeImport } from './services/opencode-import'
 import { OpenCodeSupervisor } from './services/opencode-supervisor'
 import { OpenCodeConfigSchema } from '@opencode-manager/shared/schemas'
@@ -263,6 +263,12 @@ try {
 
   await migrateGlobalSkills()
 
+  await installAssistantWorkspace({
+    db,
+    apiBaseUrl: `http://localhost:${PORT}/api/internal`,
+  })
+  logger.info('Assistant workspace installed')
+
   ipcServer = await createIPCServer(process.env.STORAGE_PATH || undefined)
   await gitAuthService.initialize(ipcServer, db)
   logger.info(`Git IPC server running at ${ipcServer.ipcHandlePath}`)
@@ -273,11 +279,6 @@ try {
   const openCodeStatus = await openCodeSupervisor.start()
   if (openCodeStatus.healthy) {
     logger.info(`OpenCode server running on port ${openCodeStatus.port}`)
-    void warmAssistantWorkspace({
-      db,
-      apiBaseUrl: `http://localhost:${PORT}/api/internal`,
-      openCodeClient,
-    })
   } else {
     logger.warn(`OpenCode server unavailable after startup recovery: ${openCodeStatus.lastError ?? openCodeStatus.state}`)
   }

--- a/backend/src/services/assistant-mode.ts
+++ b/backend/src/services/assistant-mode.ts
@@ -17,10 +17,7 @@ import { ASSISTANT_REPO_ID, ASSISTANT_REPO_PATH } from '@opencode-manager/shared
 import { getReposPath, ENV } from '@opencode-manager/shared/config/env'
 import type { Database } from 'bun:sqlite'
 import { getOrCreateInternalToken } from './internal-token'
-import type { OpenCodeClient } from './opencode/client'
-import { logger } from '../utils/logger'
 
-const ASSISTANT_WARMUP_OPENCODE_TIMEOUT_MS = 90000
 
 const ASSISTANT_MODE_DIR = ASSISTANT_REPO_PATH
 const ASSISTANT_MODE_RELATIVE_PATH = 'repos/assistant'
@@ -1080,22 +1077,12 @@ export async function getAssistantModeStatus(repo: Repo): Promise<AssistantModeS
   }
 }
 
-export async function warmAssistantWorkspace(deps: {
+export async function installAssistantWorkspace(deps: {
   db: Database
   apiBaseUrl: string
-  openCodeClient: OpenCodeClient
-}): Promise<void> {
-  try {
-    const status = await ensureAssistantMode(buildAssistantRepo(), {
-      db: deps.db,
-      apiBaseUrl: deps.apiBaseUrl,
-    })
-    await deps.openCodeClient.getJson('/api/session?limit=1&order=desc', {
-      directory: status.directory,
-      signal: AbortSignal.timeout(ASSISTANT_WARMUP_OPENCODE_TIMEOUT_MS),
-    })
-    logger.info('Assistant workspace warmed')
-  } catch (error) {
-    logger.warn('Assistant workspace warmup failed (non-fatal):', error)
-  }
+}): Promise<AssistantModeStatus> {
+  return ensureAssistantMode(buildAssistantRepo(), {
+    db: deps.db,
+    apiBaseUrl: deps.apiBaseUrl,
+  })
 }

--- a/backend/test/routes/repos.test.ts
+++ b/backend/test/routes/repos.test.ts
@@ -163,6 +163,8 @@ describe('Repo Routes', () => {
       const body = await res.json() as typeof mockStatus
       expect(body.repoId).toBe(1)
       expect(body.relativePath).toBe('repos/assistant')
+
+      expect(ensureAssistantMode).not.toHaveBeenCalled()
     })
   })
 
@@ -217,6 +219,17 @@ describe('Repo Routes', () => {
       })
 
       expect(res.status).toBe(200)
+
+      const body = await res.json() as typeof mockStatus
+      expect(body).toEqual(mockStatus)
+
+      expect(ensureAssistantMode).toHaveBeenCalledTimes(1)
+      expect(ensureAssistantMode).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 1, localPath: 'repos/test-repo' }),
+        expect.objectContaining({ db: mockDb, apiBaseUrl: 'http://localhost:5003/api/internal' }),
+        expect.objectContaining({ overwriteAgentsMd: true }),
+      )
+
       expect(opencodeServerManager.clearStartupError).not.toHaveBeenCalled()
       expect(opencodeServerManager.restart).not.toHaveBeenCalled()
     })

--- a/backend/test/services/assistant-mode.test.ts
+++ b/backend/test/services/assistant-mode.test.ts
@@ -2,9 +2,8 @@ import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
 import path from 'path'
 import { readFile, stat, writeFile } from 'fs/promises'
 import { Hono } from 'hono'
-import { ensureAssistantMode, getAssistantModeStatus, buildSchedulesSkill, buildReposSkill, buildSettingsSkill, buildAssistantDefaultAgentMd, buildAssistantOpenCodeConfig, buildAssistantRepo, warmAssistantWorkspace } from '../../src/services/assistant-mode'
+import { ensureAssistantMode, getAssistantModeStatus, buildSchedulesSkill, buildReposSkill, buildSettingsSkill, buildAssistantDefaultAgentMd, buildAssistantOpenCodeConfig, buildAssistantRepo, installAssistantWorkspace } from '../../src/services/assistant-mode'
 import { createTempAssistantWorkspace, createTestDb, mockRepo } from '../helpers/assistant-workspace'
-import type { OpenCodeClient } from '../../src/services/opencode/client'
 import { createInternalRoutes } from '../../src/routes/internal'
 import { ScheduleService } from '../../src/services/schedules'
 import { NotificationService } from '../../src/services/notification'
@@ -609,7 +608,7 @@ describe('buildAssistantRepo', () => {
   })
 })
 
-describe('warmAssistantWorkspace', () => {
+describe('installAssistantWorkspace', () => {
   let ws: Awaited<ReturnType<typeof createTempAssistantWorkspace>>
   let db: ReturnType<typeof createTestDb>
   const apiBaseUrl = 'http://localhost:5003/api/internal'
@@ -620,34 +619,50 @@ describe('warmAssistantWorkspace', () => {
   })
   afterEach(async () => { await ws.cleanup() })
 
-  it('provisions the workspace and triggers a bounded directory-scoped session request', async () => {
-    const getJsonCalls: Array<{ path: string; directory?: string }> = []
-    const client = {
-      getJson: async (requestPath: string, opts?: { directory?: string }) => {
-        getJsonCalls.push({ path: requestPath, directory: opts?.directory })
-        return []
-      },
-    } as unknown as OpenCodeClient
-
-    await warmAssistantWorkspace({ db, apiBaseUrl, openCodeClient: client })
+  it('provisions the assistant workspace files without contacting OpenCode', async () => {
+    const result = await installAssistantWorkspace({ db, apiBaseUrl })
 
     const opencodeJson = await readFile(path.join(ws.assistantDir, 'opencode.json'), 'utf8')
     expect(JSON.parse(opencodeJson).default_agent).toBe('assistant')
-    expect(getJsonCalls).toHaveLength(1)
-    expect(getJsonCalls[0]?.path).toBe('/api/session?limit=1&order=desc')
-    expect(getJsonCalls[0]?.directory).toBe(ws.assistantDir)
+
+    const agentsMd = await readFile(path.join(ws.assistantDir, 'AGENTS.md'), 'utf8')
+    expect(agentsMd).toContain('Assistant Mode Workspace')
+
+    const assistantAgent = await readFile(path.join(ws.assistantDir, '.opencode/agents/assistant.md'), 'utf8')
+    expect(assistantAgent).toContain('mode: primary')
+
+    expect(result.files.opencodeJson?.exists).toBe(true)
+    expect(result.files.agentsMd?.exists).toBe(true)
+    expect(result.defaultAgent?.exists).toBe(true)
   })
 
-  it('does not throw and still provisions the workspace when the session request fails', async () => {
-    const client = {
-      getJson: async () => { throw new Error('opencode unavailable') },
-    } as unknown as OpenCodeClient
+  it('is idempotent — second call does not recreate files and content is unchanged', async () => {
+    await installAssistantWorkspace({ db, apiBaseUrl })
 
-    await expect(
-      warmAssistantWorkspace({ db, apiBaseUrl, openCodeClient: client })
-    ).resolves.toBeUndefined()
+    const opencodeJsonPath = path.join(ws.assistantDir, 'opencode.json')
+    const agentsMdPath = path.join(ws.assistantDir, 'AGENTS.md')
+    const assistantAgentPath = path.join(ws.assistantDir, '.opencode/agents/assistant.md')
 
-    const opencodeJson = await stat(path.join(ws.assistantDir, 'opencode.json'))
-    expect(opencodeJson.isFile()).toBe(true)
+    const firstContent = {
+      opencodeJson: await readFile(opencodeJsonPath, 'utf8'),
+      agentsMd: await readFile(agentsMdPath, 'utf8'),
+      assistantAgent: await readFile(assistantAgentPath, 'utf8'),
+    }
+
+    const result = await installAssistantWorkspace({ db, apiBaseUrl })
+
+    const secondContent = {
+      opencodeJson: await readFile(opencodeJsonPath, 'utf8'),
+      agentsMd: await readFile(agentsMdPath, 'utf8'),
+      assistantAgent: await readFile(assistantAgentPath, 'utf8'),
+    }
+
+    expect(secondContent.opencodeJson).toBe(firstContent.opencodeJson)
+    expect(secondContent.agentsMd).toBe(firstContent.agentsMd)
+    expect(secondContent.assistantAgent).toBe(firstContent.assistantAgent)
+
+    expect(result.files.opencodeJson?.created).toBe(false)
+    expect(result.files.agentsMd?.created).toBe(false)
+    expect(result.defaultAgent?.created).toBe(false)
   })
 })

--- a/frontend/src/hooks/useAssistantSessionLauncher.test.tsx
+++ b/frontend/src/hooks/useAssistantSessionLauncher.test.tsx
@@ -2,18 +2,18 @@ import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useAssistantSessionLauncher } from './useAssistantSessionLauncher'
 import { OpenCodeClient } from '@/api/opencode'
-import { initializeAssistantMode } from '@/api/repos'
+import { getAssistantModeStatus } from '@/api/repos'
 
 const mocks = vi.hoisted(() => ({
   listSessions: vi.fn(),
   listSessionsPage: vi.fn(),
   createSession: vi.fn(),
   sendPromptAsync: vi.fn(),
-  initializeAssistantMode: vi.fn(),
+  getAssistantModeStatus: vi.fn(),
 }))
 
 vi.mock('@/api/repos', () => ({
-  initializeAssistantMode: mocks.initializeAssistantMode,
+  getAssistantModeStatus: mocks.getAssistantModeStatus,
 }))
 
 vi.mock('@/api/opencode', () => ({
@@ -33,7 +33,14 @@ describe('useAssistantSessionLauncher', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
-    mocks.initializeAssistantMode.mockResolvedValue({ directory: '/assistant' })
+    mocks.getAssistantModeStatus.mockResolvedValue({
+      directory: '/assistant',
+      files: {
+        agentsMd: { path: '/assistant/AGENTS.md', exists: true, created: true },
+        opencodeJson: { path: '/assistant/.opencode.json', exists: true, created: true },
+      },
+      defaultAgent: { name: 'assistant', path: '/assistant/.opencode/agents/assistant.md', exists: true, created: true },
+    })
   })
 
   it('opens the latest root session in the assistant directory', async () => {
@@ -56,7 +63,7 @@ describe('useAssistantSessionLauncher', () => {
       await result.current.openAssistant()
     })
 
-    expect(initializeAssistantMode).toHaveBeenCalledWith(123)
+    expect(getAssistantModeStatus).toHaveBeenCalledWith(123)
     expect(OpenCodeClient).toHaveBeenCalledWith('http://localhost:5551', '/assistant')
     expect(mocks.listSessionsPage).toHaveBeenCalledWith({ limit: 25, order: 'desc' })
     expect(mocks.listSessions).not.toHaveBeenCalled()
@@ -97,8 +104,13 @@ describe('useAssistantSessionLauncher', () => {
   })
 
   it('notifies an existing assistant session when some generated updates were preserved', async () => {
-    mocks.initializeAssistantMode.mockResolvedValue({
+    mocks.getAssistantModeStatus.mockResolvedValue({
       directory: '/assistant',
+      files: {
+        agentsMd: { path: '/assistant/AGENTS.md', exists: true, created: true },
+        opencodeJson: { path: '/assistant/.opencode.json', exists: true, created: true },
+      },
+      defaultAgent: { name: 'assistant', path: '/assistant/.opencode/agents/assistant.md', exists: true, created: true },
       warnings: [
         {
           code: 'assistant-agents-md-preserved',
@@ -227,5 +239,83 @@ describe('useAssistantSessionLauncher', () => {
 
     expect(onNavigate).toHaveBeenCalledWith('created')
     expect(mocks.sendPromptAsync).toHaveBeenCalled()
+  })
+
+  it('rejects with readiness error when agentMd is missing', async () => {
+    mocks.getAssistantModeStatus.mockResolvedValue({
+      directory: '/assistant',
+      files: {
+        agentsMd: { path: '/assistant/AGENTS.md', exists: false, created: false },
+        opencodeJson: { path: '/assistant/.opencode.json', exists: true, created: true },
+      },
+      defaultAgent: { name: 'assistant', path: '/assistant/.opencode/agents/assistant.md', exists: true, created: true },
+    })
+    const onNavigate = vi.fn()
+    const { result } = renderHook(() => useAssistantSessionLauncher({
+      repoId: 123,
+      opcodeUrl: 'http://localhost:5551',
+      onNavigate,
+    }))
+
+    await act(async () => {
+      await expect(result.current.openAssistant()).rejects.toThrow('Assistant workspace is not ready')
+    })
+
+    expect(OpenCodeClient).not.toHaveBeenCalled()
+    expect(mocks.listSessionsPage).not.toHaveBeenCalled()
+    expect(mocks.createSession).not.toHaveBeenCalled()
+    expect(onNavigate).not.toHaveBeenCalled()
+  })
+
+  it('rejects with readiness error when opencodeJson is missing', async () => {
+    mocks.getAssistantModeStatus.mockResolvedValue({
+      directory: '/assistant',
+      files: {
+        agentsMd: { path: '/assistant/AGENTS.md', exists: true, created: true },
+        opencodeJson: { path: '/assistant/.opencode.json', exists: false, created: false },
+      },
+      defaultAgent: { name: 'assistant', path: '/assistant/.opencode/agents/assistant.md', exists: true, created: true },
+    })
+    const onNavigate = vi.fn()
+    const { result } = renderHook(() => useAssistantSessionLauncher({
+      repoId: 123,
+      opcodeUrl: 'http://localhost:5551',
+      onNavigate,
+    }))
+
+    await act(async () => {
+      await expect(result.current.openAssistant()).rejects.toThrow('Assistant workspace is not ready')
+    })
+
+    expect(OpenCodeClient).not.toHaveBeenCalled()
+    expect(mocks.listSessionsPage).not.toHaveBeenCalled()
+    expect(mocks.createSession).not.toHaveBeenCalled()
+    expect(onNavigate).not.toHaveBeenCalled()
+  })
+
+  it('rejects with readiness error when defaultAgent is missing', async () => {
+    mocks.getAssistantModeStatus.mockResolvedValue({
+      directory: '/assistant',
+      files: {
+        agentsMd: { path: '/assistant/AGENTS.md', exists: true, created: true },
+        opencodeJson: { path: '/assistant/.opencode.json', exists: true, created: true },
+      },
+      defaultAgent: undefined,
+    })
+    const onNavigate = vi.fn()
+    const { result } = renderHook(() => useAssistantSessionLauncher({
+      repoId: 123,
+      opcodeUrl: 'http://localhost:5551',
+      onNavigate,
+    }))
+
+    await act(async () => {
+      await expect(result.current.openAssistant()).rejects.toThrow('Assistant workspace is not ready')
+    })
+
+    expect(OpenCodeClient).not.toHaveBeenCalled()
+    expect(mocks.listSessionsPage).not.toHaveBeenCalled()
+    expect(mocks.createSession).not.toHaveBeenCalled()
+    expect(onNavigate).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/hooks/useAssistantSessionLauncher.test.tsx
+++ b/frontend/src/hooks/useAssistantSessionLauncher.test.tsx
@@ -2,18 +2,12 @@ import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useAssistantSessionLauncher } from './useAssistantSessionLauncher'
 import { OpenCodeClient } from '@/api/opencode'
-import { getAssistantModeStatus } from '@/api/repos'
 
 const mocks = vi.hoisted(() => ({
   listSessions: vi.fn(),
   listSessionsPage: vi.fn(),
   createSession: vi.fn(),
   sendPromptAsync: vi.fn(),
-  getAssistantModeStatus: vi.fn(),
-}))
-
-vi.mock('@/api/repos', () => ({
-  getAssistantModeStatus: mocks.getAssistantModeStatus,
 }))
 
 vi.mock('@/api/opencode', () => ({
@@ -33,14 +27,6 @@ describe('useAssistantSessionLauncher', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
-    mocks.getAssistantModeStatus.mockResolvedValue({
-      directory: '/assistant',
-      files: {
-        agentsMd: { path: '/assistant/AGENTS.md', exists: true, created: true },
-        opencodeJson: { path: '/assistant/.opencode.json', exists: true, created: true },
-      },
-      defaultAgent: { name: 'assistant', path: '/assistant/.opencode/agents/assistant.md', exists: true, created: true },
-    })
   })
 
   it('opens the latest root session in the assistant directory', async () => {
@@ -56,6 +42,7 @@ describe('useAssistantSessionLauncher', () => {
     const { result } = renderHook(() => useAssistantSessionLauncher({
       repoId: 123,
       opcodeUrl: 'http://localhost:5551',
+      directory: '/assistant',
       onNavigate,
     }))
 
@@ -63,7 +50,6 @@ describe('useAssistantSessionLauncher', () => {
       await result.current.openAssistant()
     })
 
-    expect(getAssistantModeStatus).toHaveBeenCalledWith(123)
     expect(OpenCodeClient).toHaveBeenCalledWith('http://localhost:5551', '/assistant')
     expect(mocks.listSessionsPage).toHaveBeenCalledWith({ limit: 25, order: 'desc' })
     expect(mocks.listSessions).not.toHaveBeenCalled()
@@ -90,6 +76,7 @@ describe('useAssistantSessionLauncher', () => {
     const { result } = renderHook(() => useAssistantSessionLauncher({
       repoId: 123,
       opcodeUrl: 'http://localhost:5551',
+      directory: '/assistant',
       onNavigate,
     }))
 
@@ -103,31 +90,13 @@ describe('useAssistantSessionLauncher', () => {
     expect(onNavigate).toHaveBeenCalledWith('newest')
   })
 
-  it('notifies an existing assistant session when some generated updates were preserved', async () => {
-    mocks.getAssistantModeStatus.mockResolvedValue({
-      directory: '/assistant',
-      files: {
-        agentsMd: { path: '/assistant/AGENTS.md', exists: true, created: true },
-        opencodeJson: { path: '/assistant/.opencode.json', exists: true, created: true },
-      },
-      defaultAgent: { name: 'assistant', path: '/assistant/.opencode/agents/assistant.md', exists: true, created: true },
-      warnings: [
-        {
-          code: 'assistant-agents-md-preserved',
-          path: '/assistant/AGENTS.md',
-          message: 'Some Assistant Mode instruction updates were not applied because AGENTS.md appears to contain customized legacy assistant instructions. To regenerate the default workspace explanation, manually delete AGENTS.md and initialize Assistant Mode again.',
-        },
-      ],
-    })
-    mocks.listSessionsPage.mockResolvedValue({
-      items: [
-        { id: 'existing', directory: '/assistant', time: { updated: 10 } },
-      ],
-    })
+  it('navigates directly to the cached assistant session without querying OpenCode', async () => {
+    localStorage.setItem('ocm:assistant:last-session:123:/assistant', 'cached')
     const onNavigate = vi.fn()
     const { result } = renderHook(() => useAssistantSessionLauncher({
       repoId: 123,
       opcodeUrl: 'http://localhost:5551',
+      directory: '/assistant',
       onNavigate,
     }))
 
@@ -135,18 +104,11 @@ describe('useAssistantSessionLauncher', () => {
       await result.current.openAssistant()
     })
 
-    expect(onNavigate).toHaveBeenCalledWith('existing')
-    expect(mocks.listSessionsPage).toHaveBeenCalledWith({ limit: 25, order: 'desc' })
-    expect(mocks.sendPromptAsync).toHaveBeenCalledWith('existing', {
-      parts: [
-        expect.objectContaining({
-          type: 'text',
-          text: expect.stringContaining('some generated instruction changes were not applied'),
-        }),
-      ],
-    })
-    const promptText = mocks.sendPromptAsync.mock.calls[0][1].parts[0].text as string
-    expect(promptText).toContain('manually delete AGENTS.md')
+    expect(onNavigate).toHaveBeenCalledWith('cached')
+    expect(OpenCodeClient).not.toHaveBeenCalled()
+    expect(mocks.listSessionsPage).not.toHaveBeenCalled()
+    expect(mocks.createSession).not.toHaveBeenCalled()
+    expect(mocks.sendPromptAsync).not.toHaveBeenCalled()
   })
 
   it('creates a session when the assistant directory has no root sessions', async () => {
@@ -160,6 +122,7 @@ describe('useAssistantSessionLauncher', () => {
     const { result } = renderHook(() => useAssistantSessionLauncher({
       repoId: 123,
       opcodeUrl: 'http://localhost:5551',
+      directory: '/assistant',
       onNavigate,
     }))
 
@@ -203,6 +166,7 @@ describe('useAssistantSessionLauncher', () => {
     const { result } = renderHook(() => useAssistantSessionLauncher({
       repoId: 123,
       opcodeUrl: 'http://localhost:5551',
+      directory: '/assistant',
       onNavigate,
     }))
 
@@ -230,6 +194,7 @@ describe('useAssistantSessionLauncher', () => {
     const { result } = renderHook(() => useAssistantSessionLauncher({
       repoId: 123,
       opcodeUrl: 'http://localhost:5551',
+      directory: '/assistant',
       onNavigate,
     }))
 
@@ -241,15 +206,7 @@ describe('useAssistantSessionLauncher', () => {
     expect(mocks.sendPromptAsync).toHaveBeenCalled()
   })
 
-  it('rejects with readiness error when agentMd is missing', async () => {
-    mocks.getAssistantModeStatus.mockResolvedValue({
-      directory: '/assistant',
-      files: {
-        agentsMd: { path: '/assistant/AGENTS.md', exists: false, created: false },
-        opencodeJson: { path: '/assistant/.opencode.json', exists: true, created: true },
-      },
-      defaultAgent: { name: 'assistant', path: '/assistant/.opencode/agents/assistant.md', exists: true, created: true },
-    })
+  it('rejects when the assistant directory is unavailable', async () => {
     const onNavigate = vi.fn()
     const { result } = renderHook(() => useAssistantSessionLauncher({
       repoId: 123,
@@ -258,59 +215,7 @@ describe('useAssistantSessionLauncher', () => {
     }))
 
     await act(async () => {
-      await expect(result.current.openAssistant()).rejects.toThrow('Assistant workspace is not ready')
-    })
-
-    expect(OpenCodeClient).not.toHaveBeenCalled()
-    expect(mocks.listSessionsPage).not.toHaveBeenCalled()
-    expect(mocks.createSession).not.toHaveBeenCalled()
-    expect(onNavigate).not.toHaveBeenCalled()
-  })
-
-  it('rejects with readiness error when opencodeJson is missing', async () => {
-    mocks.getAssistantModeStatus.mockResolvedValue({
-      directory: '/assistant',
-      files: {
-        agentsMd: { path: '/assistant/AGENTS.md', exists: true, created: true },
-        opencodeJson: { path: '/assistant/.opencode.json', exists: false, created: false },
-      },
-      defaultAgent: { name: 'assistant', path: '/assistant/.opencode/agents/assistant.md', exists: true, created: true },
-    })
-    const onNavigate = vi.fn()
-    const { result } = renderHook(() => useAssistantSessionLauncher({
-      repoId: 123,
-      opcodeUrl: 'http://localhost:5551',
-      onNavigate,
-    }))
-
-    await act(async () => {
-      await expect(result.current.openAssistant()).rejects.toThrow('Assistant workspace is not ready')
-    })
-
-    expect(OpenCodeClient).not.toHaveBeenCalled()
-    expect(mocks.listSessionsPage).not.toHaveBeenCalled()
-    expect(mocks.createSession).not.toHaveBeenCalled()
-    expect(onNavigate).not.toHaveBeenCalled()
-  })
-
-  it('rejects with readiness error when defaultAgent is missing', async () => {
-    mocks.getAssistantModeStatus.mockResolvedValue({
-      directory: '/assistant',
-      files: {
-        agentsMd: { path: '/assistant/AGENTS.md', exists: true, created: true },
-        opencodeJson: { path: '/assistant/.opencode.json', exists: true, created: true },
-      },
-      defaultAgent: undefined,
-    })
-    const onNavigate = vi.fn()
-    const { result } = renderHook(() => useAssistantSessionLauncher({
-      repoId: 123,
-      opcodeUrl: 'http://localhost:5551',
-      onNavigate,
-    }))
-
-    await act(async () => {
-      await expect(result.current.openAssistant()).rejects.toThrow('Assistant workspace is not ready')
+      await expect(result.current.openAssistant()).rejects.toThrow('Assistant workspace directory is unavailable')
     })
 
     expect(OpenCodeClient).not.toHaveBeenCalled()

--- a/frontend/src/hooks/useAssistantSessionLauncher.ts
+++ b/frontend/src/hooks/useAssistantSessionLauncher.ts
@@ -1,12 +1,11 @@
 import { useCallback } from 'react'
-import { getAssistantModeStatus } from '@/api/repos'
 import { OpenCodeClient } from '@/api/opencode'
-import type { AssistantModeStatus } from '@opencode-manager/shared/types'
 import type { components } from '@/api/opencode-types'
 
 interface UseAssistantSessionLauncherOptions {
   repoId: number
   opcodeUrl: string
+  directory?: string
   onNavigate: (sessionId: string) => void
 }
 
@@ -25,6 +24,14 @@ function setCachedAssistantSessionId(repoId: number, directory: string, sessionI
     localStorage.setItem(getLastAssistantSessionKey(repoId, directory), sessionId)
   } catch {
     return
+  }
+}
+
+function getCachedAssistantSessionId(repoId: number, directory: string): string | undefined {
+  try {
+    return localStorage.getItem(getLastAssistantSessionKey(repoId, directory)) ?? undefined
+  } catch {
+    return undefined
   }
 }
 
@@ -71,79 +78,48 @@ AGENTS.md explains the assistant workspace directory and points to the files Ope
 
 Take your time exploring and customizing these settings. Let me know when you're ready to start coding, or if you have any questions about getting set up!`
 
-function buildAssistantModeWarningsPrompt(assistant: AssistantModeStatus): string | undefined {
-  if (!assistant.warnings?.length) return undefined
-
-  return [
-    'Assistant Mode was updated, but some generated instruction changes were not applied.',
-    '',
-    ...assistant.warnings.map((warning) => `- ${warning.message}`),
-  ].join('\n')
-}
-
-function buildAssistantWelcomePrompt(assistant: AssistantModeStatus): string {
-  const warningsPrompt = buildAssistantModeWarningsPrompt(assistant)
-  return warningsPrompt
-    ? `${ASSISTANT_WELCOME_PROMPT}\n\n${warningsPrompt}`
-    : ASSISTANT_WELCOME_PROMPT
-}
-
-async function sendAssistantWelcomePrompt(client: OpenCodeClient, sessionId: string, assistant: AssistantModeStatus): Promise<void> {
+async function sendAssistantWelcomePrompt(client: OpenCodeClient, sessionId: string): Promise<void> {
   await client.sendPromptAsync(sessionId, {
     parts: [
       {
         type: 'text',
-        text: buildAssistantWelcomePrompt(assistant),
+        text: ASSISTANT_WELCOME_PROMPT,
       },
     ],
   }).catch(() => undefined)
-}
-
-async function sendAssistantModeWarningsPrompt(client: OpenCodeClient, sessionId: string, assistant: AssistantModeStatus): Promise<void> {
-  const warningsPrompt = buildAssistantModeWarningsPrompt(assistant)
-  if (!warningsPrompt) return
-
-  await client.sendPromptAsync(sessionId, {
-    parts: [
-      {
-        type: 'text',
-        text: warningsPrompt,
-      },
-    ],
-  }).catch(() => undefined)
-}
-
-function assertAssistantReady(assistant: AssistantModeStatus): void {
-  if (!assistant.files.agentsMd.exists || !assistant.files.opencodeJson.exists || !assistant.defaultAgent?.exists) {
-    throw new Error('Assistant workspace is not ready. Restart the server to run Assistant setup.')
-  }
 }
 
 export function useAssistantSessionLauncher({
   repoId,
   opcodeUrl,
+  directory,
   onNavigate,
 }: UseAssistantSessionLauncherOptions) {
   const openAssistant = useCallback(async () => {
-    const assistant = await getAssistantModeStatus(repoId)
-    assertAssistantReady(assistant)
+    if (!directory) {
+      throw new Error('Assistant workspace directory is unavailable')
+    }
 
-    const client = new OpenCodeClient(opcodeUrl, assistant.directory)
-    const assistantDirectory = assistant.directory
+    const cachedSessionId = getCachedAssistantSessionId(repoId, directory)
+    if (cachedSessionId) {
+      onNavigate(cachedSessionId)
+      return
+    }
 
-    const newest = await getLatestAssistantSession(client, assistantDirectory)
+    const client = new OpenCodeClient(opcodeUrl, directory)
+
+    const newest = await getLatestAssistantSession(client, directory)
 
     if (newest) {
-      setCachedAssistantSessionId(repoId, assistantDirectory, newest.id)
+      setCachedAssistantSessionId(repoId, directory, newest.id)
       onNavigate(newest.id)
-      void sendAssistantModeWarningsPrompt(client, newest.id, assistant)
     } else {
       const session = await client.createSession({ title: 'Assistant' })
-      setCachedAssistantSessionId(repoId, assistantDirectory, session.id)
+      setCachedAssistantSessionId(repoId, directory, session.id)
       onNavigate(session.id)
-      void sendAssistantWelcomePrompt(client, session.id, assistant)
+      void sendAssistantWelcomePrompt(client, session.id)
     }
-  }, [repoId, opcodeUrl, onNavigate])
+  }, [repoId, opcodeUrl, directory, onNavigate])
 
   return { openAssistant }
 }

--- a/frontend/src/hooks/useAssistantSessionLauncher.ts
+++ b/frontend/src/hooks/useAssistantSessionLauncher.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { initializeAssistantMode } from '@/api/repos'
+import { getAssistantModeStatus } from '@/api/repos'
 import { OpenCodeClient } from '@/api/opencode'
 import type { AssistantModeStatus } from '@opencode-manager/shared/types'
 import type { components } from '@/api/opencode-types'
@@ -113,13 +113,21 @@ async function sendAssistantModeWarningsPrompt(client: OpenCodeClient, sessionId
   }).catch(() => undefined)
 }
 
+function assertAssistantReady(assistant: AssistantModeStatus): void {
+  if (!assistant.files.agentsMd.exists || !assistant.files.opencodeJson.exists || !assistant.defaultAgent?.exists) {
+    throw new Error('Assistant workspace is not ready. Restart the server to run Assistant setup.')
+  }
+}
+
 export function useAssistantSessionLauncher({
   repoId,
   opcodeUrl,
   onNavigate,
 }: UseAssistantSessionLauncherOptions) {
   const openAssistant = useCallback(async () => {
-    const assistant = await initializeAssistantMode(repoId)
+    const assistant = await getAssistantModeStatus(repoId)
+    assertAssistantReady(assistant)
+
     const client = new OpenCodeClient(opcodeUrl, assistant.directory)
     const assistantDirectory = assistant.directory
 

--- a/frontend/src/pages/AssistantRedirect.tsx
+++ b/frontend/src/pages/AssistantRedirect.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react"
-import { useParams, useNavigate, useLocation } from "react-router-dom"
+import { useNavigate, useLocation } from "react-router-dom"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { getRepo, getAssistantModeStatus } from "@/api/repos"
+import { getRepo } from "@/api/repos"
 import { useAssistantSessionLauncher } from "@/hooks/useAssistantSessionLauncher"
 import { useCreateSession } from "@/hooks/useOpenCode"
 import { useDialogParam } from "@/hooks/useDialogParam"
@@ -22,11 +22,10 @@ import { SwitchConfigDialog } from "@/components/repo/SwitchConfigDialog"
 import { Loader2, Plus } from "lucide-react"
 
 export function AssistantRedirect() {
-  const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const location = useLocation()
   const queryClient = useQueryClient()
-  const repoId = Number(id) || 0
+  const repoId = 0
   const showSessionList = new URLSearchParams(location.search).get('view') === 'sessions'
   const [fileBrowserOpen, setFileBrowserOpen] = useDialogParam('files')
   const [mcpDialogOpen, setMcpDialogOpen] = useDialogParam('mcp')
@@ -38,10 +37,9 @@ export function AssistantRedirect() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const opcodeUrl = OPENCODE_API_ENDPOINT
-  const { data: repo } = useQuery({
+  const { data: repo, isLoading: repoLoading, error: repoError } = useQuery({
     queryKey: ["repo", repoId],
     queryFn: () => getRepo(repoId),
-    enabled: showSessionList && repoId !== undefined,
   })
 
   const handleNavigate = useCallback((sessionId: string) => {
@@ -55,16 +53,11 @@ export function AssistantRedirect() {
   const { openAssistant } = useAssistantSessionLauncher({
     repoId,
     opcodeUrl,
+    directory: repo?.fullPath,
     onNavigate: handleNavigate,
   })
 
-  const { data: assistantMode, isLoading: assistantModeLoading, error: assistantModeError } = useQuery({
-    queryKey: ["repo", repoId, "assistant-mode"],
-    queryFn: () => getAssistantModeStatus(repoId),
-    enabled: showSessionList && repoId !== undefined,
-  })
-
-  const assistantDirectory = assistantMode?.directory
+  const assistantDirectory = repo?.fullPath
   const assistantFileBasePath = assistantDirectory?.split('/').filter(Boolean).at(-1)
 
   useSSE(opcodeUrl, assistantDirectory)
@@ -84,14 +77,8 @@ export function AssistantRedirect() {
       try {
         if (showSessionList) return
         setStatus("preparing")
-        if (repoId <= 0) {
-          if (cancelled) return
-          setStatus("creating")
-          await openAssistant()
-          return
-        }
-
-        await getRepo(repoId)
+        if (repoLoading) return
+        if (repoError || !repo?.fullPath) throw new Error("Failed to load Assistant workspace")
         if (cancelled) return
         setStatus("creating")
         await openAssistant()
@@ -107,7 +94,7 @@ export function AssistantRedirect() {
     return () => {
       cancelled = true
     }
-  }, [repoId, openAssistant, navigate, showSessionList, id])
+  }, [repo?.fullPath, repoError, repoLoading, openAssistant, showSessionList])
 
   if (showSessionList) {
     return (
@@ -129,9 +116,9 @@ export function AssistantRedirect() {
           </Header.Actions>
         </Header>
         <div className="flex-1 flex flex-col min-h-0">
-          {assistantModeError ? (
+          {repoError ? (
             <div className="p-4 text-sm text-muted-foreground">Failed to load Assistant sessions</div>
-          ) : assistantModeLoading || !assistantMode ? (
+          ) : repoLoading || !repo?.fullPath ? (
             <div className="p-4 text-sm text-muted-foreground">Loading Assistant sessions...</div>
           ) : (
             <SessionList

--- a/frontend/src/pages/AssistantRedirect.tsx
+++ b/frontend/src/pages/AssistantRedirect.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react"
 import { useParams, useNavigate, useLocation } from "react-router-dom"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { getRepo, initializeAssistantMode } from "@/api/repos"
+import { getRepo, getAssistantModeStatus } from "@/api/repos"
 import { useAssistantSessionLauncher } from "@/hooks/useAssistantSessionLauncher"
 import { useCreateSession } from "@/hooks/useOpenCode"
 import { useDialogParam } from "@/hooks/useDialogParam"
@@ -60,7 +60,7 @@ export function AssistantRedirect() {
 
   const { data: assistantMode, isLoading: assistantModeLoading, error: assistantModeError } = useQuery({
     queryKey: ["repo", repoId, "assistant-mode"],
-    queryFn: () => initializeAssistantMode(repoId),
+    queryFn: () => getAssistantModeStatus(repoId),
     enabled: showSessionList && repoId !== undefined,
   })
 
@@ -204,7 +204,7 @@ export function AssistantRedirect() {
           <>
             <Loader2 className="w-8 h-8 animate-spin text-muted-foreground mx-auto mb-4" />
             <p className="text-muted-foreground">
-              {status === "preparing" && "Preparing Assistant workspace..."}
+              {status === "preparing" && "Opening Assistant..."}
               {status === "creating" && "Opening your last session chat..."}
               {status === "opening" && "Opening your last session chat..."}
             </p>

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useParams, useNavigate, Navigate, useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { getRepo, initializeAssistantMode } from "@/api/repos";
+import { getRepo, getAssistantModeStatus } from "@/api/repos";
 import { MessageThread } from "@/components/message/MessageThread";
 import { PromptInput, type PromptInputHandle } from "@/components/message/PromptInput";
 import { FloatingTTSButton } from '@/components/message/FloatingTTSButton'
@@ -116,7 +116,7 @@ export function SessionDetail() {
 
   const { data: assistantMode, isLoading: assistantModeLoading } = useQuery({
     queryKey: ["repo", repoId, "assistant-mode"],
-    queryFn: () => initializeAssistantMode(repoId),
+    queryFn: () => getAssistantModeStatus(repoId),
     enabled: isAssistantSession,
   });
 

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useParams, useNavigate, Navigate, useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { getRepo, getAssistantModeStatus } from "@/api/repos";
+import { getRepo } from "@/api/repos";
 import { MessageThread } from "@/components/message/MessageThread";
 import { PromptInput, type PromptInputHandle } from "@/components/message/PromptInput";
 import { FloatingTTSButton } from '@/components/message/FloatingTTSButton'
@@ -111,20 +111,14 @@ export function SessionDetail() {
   const { data: repo, isLoading: repoLoading } = useQuery({
     queryKey: ["repo", repoId],
     queryFn: () => getRepo(repoId),
-    enabled: !!repoId,
-  });
-
-  const { data: assistantMode, isLoading: assistantModeLoading } = useQuery({
-    queryKey: ["repo", repoId, "assistant-mode"],
-    queryFn: () => getAssistantModeStatus(repoId),
-    enabled: isAssistantSession,
+    enabled: id !== undefined,
   });
 
   useRepoActivity(repoId, Boolean(repo));
 
   const opcodeUrl = OPENCODE_API_ENDPOINT;
   
-  const repoDirectory = isAssistantSession ? (assistantMode?.directory || repo?.fullPath) : repo?.fullPath;
+  const repoDirectory = repo?.fullPath;
   const sessionRouteSuffix = isAssistantSession ? '?assistant=1' : '';
 
   const { isConnected, isReconnecting } = useSSE(opcodeUrl, repoDirectory, sessionId);
@@ -175,7 +169,7 @@ export function SessionDetail() {
   const latestPlayableAssistant = useMemo(() => getLatestPlayableAssistantMessage(messages), [messages]);
   const hasIncompleteMessages = lastAssistantMessage ? !('completed' in lastAssistantMessage.info.time && lastAssistantMessage.info.time.completed) : false;
   const isStreamingResponse = hasIncompleteMessages && isSessionActive;
-  const assistantFileBasePath = assistantMode?.directory.split('/').filter(Boolean).at(-1);
+  const assistantFileBasePath = repo?.fullPath.split('/').filter(Boolean).at(-1);
   const workspaceBasePath = (isAssistantSession ? assistantFileBasePath : repo?.localPath) ?? repo?.localPath;
 
   useEffect(() => {
@@ -486,7 +480,7 @@ export function SessionDetail() {
 
       <div className="relative flex-1 overflow-hidden flex flex-col">
         <div key={sessionId} ref={messageContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain [mask-image:linear-gradient(to_bottom,transparent,black_16px,black)]" style={{ paddingBottom: promptOverlayHeight + inputBottomOffset + PROMPT_OVERLAY_CLEARANCE_PX }}>
-          {repoLoading || assistantModeLoading || sessionLoading || messagesLoading ? (
+          {repoLoading || sessionLoading || messagesLoading ? (
             <MessageSkeleton />
           ) : opcodeUrl && repoDirectory ? (
             <MessageThread 

--- a/frontend/src/pages/__tests__/SessionDetail.assistant-loading.test.tsx
+++ b/frontend/src/pages/__tests__/SessionDetail.assistant-loading.test.tsx
@@ -117,7 +117,7 @@ vi.mock('@/contexts/EventContext', async (importOriginal) => {
 
 vi.mock('@/api/repos', () => ({
   getRepo: vi.fn(() => Promise.resolve(null)),
-  initializeAssistantMode: vi.fn(() => Promise.resolve({ directory: '/abs/assistant', warnings: [] })),
+  getAssistantModeStatus: vi.fn(() => Promise.resolve({ directory: '/abs/assistant', warnings: [] })),
 }))
 
 vi.mock('@/components/model/ModelSelectDialog', () => ({

--- a/frontend/src/pages/__tests__/SessionDetail.assistant-loading.test.tsx
+++ b/frontend/src/pages/__tests__/SessionDetail.assistant-loading.test.tsx
@@ -116,8 +116,14 @@ vi.mock('@/contexts/EventContext', async (importOriginal) => {
 })
 
 vi.mock('@/api/repos', () => ({
-  getRepo: vi.fn(() => Promise.resolve(null)),
-  getAssistantModeStatus: vi.fn(() => Promise.resolve({ directory: '/abs/assistant', warnings: [] })),
+  getRepo: vi.fn((repoId: number) => Promise.resolve(repoId === 0 ? {
+    id: 0,
+    localPath: 'assistant',
+    fullPath: '/abs/assistant',
+    defaultBranch: 'main',
+    cloneStatus: 'ready',
+    clonedAt: 1,
+  } : null)),
 }))
 
 vi.mock('@/components/model/ModelSelectDialog', () => ({
@@ -236,7 +242,7 @@ describe('SessionDetail assistant loading at repoId=0', () => {
     })
   })
 
-  it('passes directory from assistantMode to RepoSkillsDialog once loaded', async () => {
+  it('passes directory from assistant repo to RepoSkillsDialog once loaded', async () => {
     renderAssistantSession('sess-asst-1')
 
     await waitFor(() => {


### PR DESCRIPTION
The assistant workspace installation was previously deferred to an async warmup after OpenCode server start. This created a window where assistant mode features could be accessed before the workspace was fully provisioned.

Move `installAssistantWorkspace` to a synchronous step during server boot, before the OpenCode supervisor starts. This guarantees the workspace files (opencode.json, AGENTS.md, assistant agent definition) exist before any request can reach assistant mode endpoints.

Changes:
- Rename `warmAssistantWorkspace` to `installAssistantWorkspace` (backend), removing the OpenCode session ping warmup that could silently fail
- Rename `initializeAssistantMode` to `getAssistantModeStatus` (frontend) to accurately reflect it is a read-only status check
- Add `assertAssistantReady()` to verify all required workspace files exist before opening an assistant session
- Move install call to run unconditionally during server boot, before OpenCode supervisor start
- Update all tests and imports across backend and frontend

## Files
- backend/src/index.ts
- backend/src/services/assistant-mode.ts
- backend/test/routes/repos.test.ts
- backend/test/services/assistant-mode.test.ts
- frontend/src/hooks/useAssistantSessionLauncher.test.tsx
- frontend/src/hooks/useAssistantSessionLauncher.ts
- frontend/src/pages/AssistantRedirect.tsx
- frontend/src/pages/SessionDetail.tsx
- frontend/src/pages/__tests__/SessionDetail.assistant-loading.test.tsx