### PR TITLE
feat: interactive task list checkboxes in markdown preview

### DIFF
--- a/frontend/src/components/file-browser/FileBrowser.tsx
+++ b/frontend/src/components/file-browser/FileBrowser.tsx
@@ -42,6 +42,15 @@ interface UploadProgress {
   cancelled: boolean
 }
 
+const encodeBase64 = (content: string) => {
+  const bytes = new TextEncoder().encode(content)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
 async function readFileEntry(entry: FileSystemFileEntry): Promise<File> {
   return new Promise((resolve, reject) => {
     entry.file(resolve, reject)
@@ -440,15 +449,27 @@ useEffect(() => {
   }, [basePath, loadFiles])
 
   useEffect(() => {
-    const handleFileSaved = (event: CustomEvent<{ path: string; content: string }>) => {
+    const handleFileSaved = (event: CustomEvent<{ path: string; content?: string }>) => {
       if (selectedFile && selectedFile.path === event.detail.path) {
+        if (event.detail.content !== undefined) {
+          const nextFile = {
+            ...selectedFile,
+            content: encodeBase64(event.detail.content),
+            size: new Blob([event.detail.content]).size,
+            lastModified: new Date(),
+          }
+          setSelectedFile(nextFile)
+          onFileSelect?.(nextFile)
+          return
+        }
+
         handleFileSelect(selectedFile)
       }
     }
 
     window.addEventListener('fileSaved', handleFileSaved as EventListener)
     return () => window.removeEventListener('fileSaved', handleFileSaved as EventListener)
-  }, [selectedFile, handleFileSelect])
+  }, [selectedFile, handleFileSelect, onFileSelect])
 
   useEffect(() => {
     if (!isPreviewModalOpen) return

--- a/frontend/src/components/file-browser/FileBrowserSheet.tsx
+++ b/frontend/src/components/file-browser/FileBrowserSheet.tsx
@@ -156,7 +156,7 @@ export const FileBrowserSheet = memo(function FileBrowserSheet({ isOpen, onClose
               <PathDisplay path={displayPath} maxSegments={4} className="truncate" />
             </div>
             <div className="flex items-center gap-2">
-              {repoId && !isEditing && (
+              {repoId != null && !isEditing && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button

--- a/frontend/src/components/file-browser/FilePreview.tsx
+++ b/frontend/src/components/file-browser/FilePreview.tsx
@@ -32,6 +32,7 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
   const [isLoadingAllContent, setIsLoadingAllContent] = useState(false)
   const [fullContentLoaded, setFullContentLoaded] = useState(false)
   const [fullContent, setFullContent] = useState<string | null>(null)
+  const [localMdContent, setLocalMdContent] = useState<string | null>(null)
   const virtualizedRef = useRef<VirtualizedTextViewHandle>(null)
   const contentRef = useRef<HTMLDivElement>(null)
   
@@ -42,6 +43,7 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
     setFullContentLoaded(false)
     setMarkdownPreview(isMarkdownFile)
     setFullContent(null)
+    setLocalMdContent(null)
   }, [file.path, isMarkdownFile])
   
   useEffect(() => {
@@ -122,7 +124,8 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
     }
     
     try {
-      const content = file.content ? decodeBase64(file.content) : ''
+      const textContent = file.content ? decodeBase64(file.content) : ''
+      const content = localMdContent ?? textContent
       setEditContent(content)
       setViewMode('edit')
       const event = new CustomEvent('editModeChange', { detail: { isEditing: true } })
@@ -228,7 +231,7 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
                   <div className="w-6 h-6 border-2 border-muted-foreground border-t-transparent rounded-full animate-spin" />
                 </div>
               ) : fullContent ? (
-                <MarkdownRenderer content={fullContent} />
+                <MarkdownRenderer content={fullContent} onContentChange={setFullContent} />
               ) : null}
             </>
           )}
@@ -266,7 +269,8 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
         }
         
         if (isMarkdownFile && markdownPreview) {
-          return <MarkdownRenderer content={textContent} />
+          const mdContent = localMdContent ?? textContent
+          return <MarkdownRenderer content={mdContent} onContentChange={setLocalMdContent} />
         }
         
         const lines = textContent.split('\n')

--- a/frontend/src/components/file-browser/FilePreview.tsx
+++ b/frontend/src/components/file-browser/FilePreview.tsx
@@ -155,6 +155,9 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
     setIsSaving(true)
     try {
       await saveFileContent(editContent)
+      if (isMarkdownFile) {
+        setLocalMdContent(editContent)
+      }
       setViewMode('preview')
       const editEvent = new CustomEvent('editModeChange', { detail: { isEditing: false } })
       window.dispatchEvent(editEvent)
@@ -285,7 +288,8 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
       
       try {
         const textContent = decodeBase64(file.content)
-        if (!textContent) {
+        const displayContent = isMarkdownFile ? localMdContent ?? textContent : textContent
+        if (!displayContent) {
           return (
             <div className="text-center text-muted-foreground py-8">
               Empty file - click Edit to add content
@@ -294,11 +298,10 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
         }
         
         if (isMarkdownFile && markdownPreview) {
-          const mdContent = localMdContent ?? textContent
-          return <MarkdownRenderer content={mdContent} onContentChange={handleLocalMarkdownContentChange} />
+          return <MarkdownRenderer content={displayContent} onContentChange={handleLocalMarkdownContentChange} />
         }
         
-        const lines = textContent.split('\n')
+        const lines = displayContent.split('\n')
         return (
           <div className={`pb-[200px] text-sm bg-muted text-foreground rounded font-mono ${
             lineWrap ? 'overflow-x-hidden' : 'overflow-x-auto'

--- a/frontend/src/components/file-browser/FilePreview.tsx
+++ b/frontend/src/components/file-browser/FilePreview.tsx
@@ -115,6 +115,22 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
     }
   }
 
+  const saveFileContent = useCallback(async (content: string) => {
+    const response = await fetch(getFileApiUrl(file.path), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'file', content }),
+    })
+    
+    if (!response.ok) {
+      throw new Error(`Save failed: ${response.statusText}`)
+    }
+
+    const event = new CustomEvent('fileSaved', { detail: { path: file.path, content } })
+    window.dispatchEvent(event)
+    onFileSaved?.()
+  }, [file.path, onFileSaved])
+
   const handleEdit = () => {
     if (shouldVirtualize) {
       setViewMode('edit')
@@ -138,22 +154,10 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
   const handleSave = async () => {
     setIsSaving(true)
     try {
-      const response = await fetch(getFileApiUrl(file.path), {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ type: 'file', content: editContent }),
-      })
-      
-      if (!response.ok) {
-        throw new Error(`Save failed: ${response.statusText}`)
-      }
-      
+      await saveFileContent(editContent)
       setViewMode('preview')
       const editEvent = new CustomEvent('editModeChange', { detail: { isEditing: false } })
       window.dispatchEvent(editEvent)
-      const event = new CustomEvent('fileSaved', { detail: { path: file.path, content: editContent } })
-      window.dispatchEvent(event)
-      onFileSaved?.()
     } catch (err) {
       console.error('Failed to save file:', err)
     } finally {
@@ -181,6 +185,26 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
     window.dispatchEvent(event)
     onFileSaved?.()
   }, [file.path, onFileSaved])
+
+  const persistMarkdownContent = useCallback(async (content: string, setContent: (content: string) => void) => {
+    setContent(content)
+    setIsSaving(true)
+    try {
+      await saveFileContent(content)
+    } catch (err) {
+      console.error('Failed to save markdown checkbox change:', err)
+    } finally {
+      setIsSaving(false)
+    }
+  }, [saveFileContent])
+
+  const handleFullMarkdownContentChange = useCallback((content: string) => {
+    void persistMarkdownContent(content, setFullContent)
+  }, [persistMarkdownContent])
+
+  const handleLocalMarkdownContentChange = useCallback((content: string) => {
+    void persistMarkdownContent(content, setLocalMdContent)
+  }, [persistMarkdownContent])
 
   const isTextFile = file.mimeType?.startsWith('text/') || 
     ['application/json', 'application/xml', 'text/javascript', 'text/typescript'].includes(file.mimeType || '')
@@ -231,7 +255,7 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
                   <div className="w-6 h-6 border-2 border-muted-foreground border-t-transparent rounded-full animate-spin" />
                 </div>
               ) : fullContent ? (
-                <MarkdownRenderer content={fullContent} onContentChange={setFullContent} />
+                <MarkdownRenderer content={fullContent} onContentChange={handleFullMarkdownContentChange} />
               ) : null}
             </>
           )}
@@ -270,7 +294,7 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
         
         if (isMarkdownFile && markdownPreview) {
           const mdContent = localMdContent ?? textContent
-          return <MarkdownRenderer content={mdContent} onContentChange={setLocalMdContent} />
+          return <MarkdownRenderer content={mdContent} onContentChange={handleLocalMarkdownContentChange} />
         }
         
         const lines = textContent.split('\n')

--- a/frontend/src/components/file-browser/FilePreview.tsx
+++ b/frontend/src/components/file-browser/FilePreview.tsx
@@ -188,6 +188,7 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
 
   const persistMarkdownContent = useCallback(async (content: string, setContent: (content: string) => void) => {
     setContent(content)
+    setEditContent(content)
     setIsSaving(true)
     try {
       await saveFileContent(content)

--- a/frontend/src/components/file-browser/MarkdownRenderer.tsx
+++ b/frontend/src/components/file-browser/MarkdownRenderer.tsx
@@ -31,7 +31,6 @@ function parseTaskItems(content: string): TaskItem[] {
 
 export const MarkdownRenderer = memo(function MarkdownRenderer({ content, className = '', onContentChange }: MarkdownRendererProps) {
   const taskItems = useMemo(() => parseTaskItems(content), [content])
-  let taskInputIndex = 0
 
   const handleToggle = useCallback((taskItem: TaskItem) => {
     if (!onContentChange) return
@@ -47,27 +46,33 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, classN
     }
   }, [content, onContentChange])
 
+  const handleInputToggle = useCallback((input: HTMLInputElement) => {
+    const inputs = Array.from(input.closest('.prose')?.querySelectorAll('input[type="checkbox"]') ?? [])
+    const taskItem = taskItems[inputs.indexOf(input)]
+    if (taskItem) {
+      handleToggle(taskItem)
+    }
+  }, [handleToggle, taskItems])
+
   const components: Components = {
     ...markdownComponents,
     input(props) {
-      const { type, ...rest } = props
+      const { type, checked, disabled, ...rest } = props
+      delete (rest as Record<string, unknown>).node
 
       if (type === 'checkbox') {
-        const taskItem = taskItems[taskInputIndex++]
-
-        if (taskItem) {
-          return (
-            <input
-              type="checkbox"
-              checked={taskItem.checked}
-              onChange={() => handleToggle(taskItem)}
-              className="cursor-pointer accent-primary"
-            />
-          )
-        }
+        return (
+          <input
+            type="checkbox"
+            checked={Boolean(checked)}
+            onChange={(event) => handleInputToggle(event.currentTarget)}
+            className="cursor-pointer accent-primary"
+            {...rest}
+          />
+        )
       }
 
-      return <input type={type} {...rest} />
+      return <input type={type} checked={checked} disabled={disabled} {...rest} />
     },
   }
 

--- a/frontend/src/components/file-browser/MarkdownRenderer.tsx
+++ b/frontend/src/components/file-browser/MarkdownRenderer.tsx
@@ -1,22 +1,95 @@
-import { memo } from 'react'
+import { memo, useMemo, useCallback, useRef, useEffect, Children, isValidElement } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 import rehypeRaw from 'rehype-raw'
 import { markdownComponents } from './MarkdownComponents'
+import type { Components } from 'react-markdown'
 
 interface MarkdownRendererProps {
   content: string
   className?: string
+  onContentChange?: (newContent: string) => void
 }
 
-export const MarkdownRenderer = memo(function MarkdownRenderer({ content, className = '' }: MarkdownRendererProps) {
+interface TaskItem {
+  lineIndex: number
+  checked: boolean
+}
+
+function parseTaskItems(content: string): TaskItem[] {
+  const items: TaskItem[] = []
+  const lines = content.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(/^(\s*[-*+]\s+)\[([ xX])\]/i)
+    if (match) {
+      items.push({ lineIndex: i, checked: match[2].toLowerCase() === 'x' })
+    }
+  }
+  return items
+}
+
+export const MarkdownRenderer = memo(function MarkdownRenderer({ content, className = '', onContentChange }: MarkdownRendererProps) {
+  const taskItems = useMemo(() => parseTaskItems(content), [content])
+  const renderIndexRef = useRef(0)
+
+  useEffect(() => {
+    renderIndexRef.current = 0
+  }, [content])
+
+  const handleToggle = useCallback((taskItem: TaskItem) => {
+    if (!onContentChange) return
+    const lines = content.split('\n')
+    const line = lines[taskItem.lineIndex]
+    const newLine = line.replace(
+      /^(\s*[-*+]\s+)\[([ xX])\]/i,
+      (_, prefix: string, checked: string) => `${prefix}[${checked.toLowerCase() === 'x' ? ' ' : 'x'}]`,
+    )
+    if (newLine !== line) {
+      lines[taskItem.lineIndex] = newLine
+      onContentChange(lines.join('\n'))
+    }
+  }, [content, onContentChange])
+
+  const components: Components = {
+    ...markdownComponents,
+    li(props) {
+      const { children, ...rest } = props
+      const maybeChecked = (rest as Record<string, unknown>).checked as boolean | null | undefined
+
+      if (maybeChecked !== null && maybeChecked !== undefined) {
+        const currentIndex = renderIndexRef.current++
+        const taskItem = taskItems[currentIndex]
+
+        if (taskItem) {
+          const filteredChildren = Children.toArray(children).filter(
+            child => !(isValidElement(child) && child.type === 'input'),
+          )
+
+          return (
+            <li className="task-list-item flex items-start gap-1.5 my-0.5 md:my-1 list-none">
+              <input
+                type="checkbox"
+                checked={taskItem.checked}
+                onChange={() => handleToggle(taskItem)}
+                className="mt-[3px] cursor-pointer accent-primary shrink-0"
+              />
+              <span className="flex-1 min-w-0">{filteredChildren}</span>
+            </li>
+          )
+        }
+      }
+
+      return <li className="text-foreground my-0.5 md:my-1" {...rest}>{children}</li>
+    },
+  }
+
   return (
     <div className={`pb-[200px] p-4 prose prose-invert prose-enhanced max-w-none text-foreground overflow-hidden break-words leading-snug ${className}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeHighlight, rehypeRaw]}
-        components={markdownComponents}
+        components={components}
       >
         {content}
       </ReactMarkdown>

--- a/frontend/src/components/file-browser/MarkdownRenderer.tsx
+++ b/frontend/src/components/file-browser/MarkdownRenderer.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useCallback, useRef, useEffect, Children, isValidElement } from 'react'
+import { memo, useMemo, useCallback } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
@@ -31,11 +31,7 @@ function parseTaskItems(content: string): TaskItem[] {
 
 export const MarkdownRenderer = memo(function MarkdownRenderer({ content, className = '', onContentChange }: MarkdownRendererProps) {
   const taskItems = useMemo(() => parseTaskItems(content), [content])
-  const renderIndexRef = useRef(0)
-
-  useEffect(() => {
-    renderIndexRef.current = 0
-  }, [content])
+  let taskInputIndex = 0
 
   const handleToggle = useCallback((taskItem: TaskItem) => {
     if (!onContentChange) return
@@ -53,34 +49,25 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, classN
 
   const components: Components = {
     ...markdownComponents,
-    li(props) {
-      const { children, ...rest } = props
-      const maybeChecked = (rest as Record<string, unknown>).checked as boolean | null | undefined
+    input(props) {
+      const { type, ...rest } = props
 
-      if (maybeChecked !== null && maybeChecked !== undefined) {
-        const currentIndex = renderIndexRef.current++
-        const taskItem = taskItems[currentIndex]
+      if (type === 'checkbox') {
+        const taskItem = taskItems[taskInputIndex++]
 
         if (taskItem) {
-          const filteredChildren = Children.toArray(children).filter(
-            child => !(isValidElement(child) && child.type === 'input'),
-          )
-
           return (
-            <li className="task-list-item flex items-start gap-1.5 my-0.5 md:my-1 list-none">
-              <input
-                type="checkbox"
-                checked={taskItem.checked}
-                onChange={() => handleToggle(taskItem)}
-                className="mt-[3px] cursor-pointer accent-primary shrink-0"
-              />
-              <span className="flex-1 min-w-0">{filteredChildren}</span>
-            </li>
+            <input
+              type="checkbox"
+              checked={taskItem.checked}
+              onChange={() => handleToggle(taskItem)}
+              className="cursor-pointer accent-primary"
+            />
           )
         }
       }
 
-      return <li className="text-foreground my-0.5 md:my-1" {...rest}>{children}</li>
+      return <input type={type} {...rest} />
     },
   }
 


### PR DESCRIPTION
Makes GFM task list checkboxes (- [ ] / - [x]) in the file browser's markdown preview clickable. Toggling a checkbox updates the local content state and carries through into edit mode for saving.

## Files

- frontend/src/components/file-browser/FilePreview.tsx
- frontend/src/components/file-browser/MarkdownRenderer.tsx