### PR TITLE
fix: avoid auto-applying OpenCode config on dropdown selection

### DIFF
--- a/frontend/src/components/settings/OpenCodeConfigManager.tsx
+++ b/frontend/src/components/settings/OpenCodeConfigManager.tsx
@@ -723,18 +723,16 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
                     </TooltipTrigger>
                     <TooltipContent side="bottom">Delete</TooltipContent>
                   </Tooltip>
+                  <Button size="sm" onClick={() => setIsCreateDialogOpen(true)}>
+                    <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
+                    <span className="text-xs sm:text-sm">New Config</span>
+                  </Button>
                 </div>
               </TooltipProvider>
-              <div className="flex items-center gap-2 sm:ml-auto">
-                <Button size="sm" onClick={() => setIsCreateDialogOpen(true)}>
-                  <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
-                  <span className="text-xs sm:text-sm">New Config</span>
-                </Button>
-              </div>
             </div>
 
             {activeConfig && (
-              <div className="text-sm text-muted-foreground break-words mt-2">
+              <div className="text-sm text-muted-foreground break-words">
                 <p className="truncate">Updated: {new Date(activeConfig.updatedAt).toLocaleString()}</p>
                 <p className="truncate">Created: {new Date(activeConfig.createdAt).toLocaleString()}</p>
               </div>

--- a/frontend/src/components/settings/OpenCodeConfigManager.tsx
+++ b/frontend/src/components/settings/OpenCodeConfigManager.tsx
@@ -635,6 +635,11 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              {activeConfig?.isDefault && (
+                <span className="text-xs font-medium text-green-600 dark:text-green-400 sm:hidden">
+                  Active
+                </span>
+              )}
               <Select
                 value={activeConfigName}
                 onValueChange={(value) => {
@@ -656,18 +661,13 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
               </Select>
 
               <div className="flex items-center gap-2">
-                {activeConfig?.isDefault && (
-                  <span className="text-xs font-medium text-green-600 dark:text-green-400">
-                    Active
-                  </span>
-                )}
                 {activeConfig && !activeConfig.isValid && (
                   <Badge variant="destructive">Invalid Config</Badge>
                 )}
               </div>
 
               <TooltipProvider delayDuration={200}>
-                <div className="flex items-center gap-1 sm:gap-1.5 sm:ml-auto flex-wrap">
+                <div className="flex items-center gap-1 sm:gap-1.5 sm:ml-auto">
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
@@ -694,21 +694,21 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
                     </TooltipTrigger>
                     <TooltipContent side="bottom">Edit</TooltipContent>
                   </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        size="sm"
-                        variant={activeConfig?.isDefault ? 'outline' : 'default'}
-                        disabled={!activeConfig || activeConfig.isDefault || isUpdating}
-                        onClick={() => activeConfig && setDefaultConfig(activeConfig)}
-                      >
-                        {activeConfig?.isDefault ? 'Applied' : 'Apply'}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      {activeConfig?.isDefault ? 'Applied' : 'Apply as default'}
-                    </TooltipContent>
-                  </Tooltip>
+                  {!activeConfig?.isDefault && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          size="sm"
+                          variant="default"
+                          disabled={!activeConfig || isUpdating}
+                          onClick={() => activeConfig && setDefaultConfig(activeConfig)}
+                        >
+                          Apply
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">Apply as default</TooltipContent>
+                    </Tooltip>
+                  )}
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
@@ -723,16 +723,18 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
                     </TooltipTrigger>
                     <TooltipContent side="bottom">Delete</TooltipContent>
                   </Tooltip>
-                  <Button size="sm" onClick={() => setIsCreateDialogOpen(true)}>
-                    <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
-                    <span className="text-xs sm:text-sm">New Config</span>
-                  </Button>
                 </div>
               </TooltipProvider>
+              <div className="flex items-center gap-2 sm:ml-auto">
+                <Button size="sm" onClick={() => setIsCreateDialogOpen(true)}>
+                  <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
+                  <span className="text-xs sm:text-sm">New Config</span>
+                </Button>
+              </div>
             </div>
 
             {activeConfig && (
-              <div className="text-sm text-muted-foreground break-words">
+              <div className="text-sm text-muted-foreground break-words mt-2">
                 <p className="truncate">Updated: {new Date(activeConfig.updatedAt).toLocaleString()}</p>
                 <p className="truncate">Created: {new Date(activeConfig.createdAt).toLocaleString()}</p>
               </div>
@@ -802,7 +804,7 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
             <div className="space-y-6">
               <div className='px-1'>
                 <Label className="text-sm sm:text-base font-medium">Select Configuration to Edit</Label>
-                <Select 
+                <Select
                   onValueChange={(value) => {
                     const config = configs.find(c => c.name === value)
                     setSelectedConfig(config || null)

--- a/frontend/src/components/settings/OpenCodeConfigManager.tsx
+++ b/frontend/src/components/settings/OpenCodeConfigManager.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { DeleteDialog } from '@/components/ui/delete-dialog'
 import { CreateConfigDialog } from './CreateConfigDialog'
 import { OpenCodeConfigEditor } from './OpenCodeConfigEditor'
@@ -647,7 +648,7 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
                   {configs.map((config) => (
                     <SelectItem key={config.id} value={config.name}>
                       {config.name}
-                      {config.isDefault && ' (Current)'}
+                      {config.isDefault && ' (Active)'}
                       {!config.isValid && ' (Invalid)'}
                     </SelectItem>
                   ))}
@@ -656,54 +657,78 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
 
               <div className="flex items-center gap-2">
                 {activeConfig?.isDefault && (
-                  <Badge variant="default" className="text-green-500 bg-green-500/10">
-                    Current
-                  </Badge>
+                  <span className="text-xs font-medium text-green-600 dark:text-green-400">
+                    Active
+                  </span>
                 )}
                 {activeConfig && !activeConfig.isValid && (
                   <Badge variant="destructive">Invalid Config</Badge>
                 )}
               </div>
 
-              <div className="flex items-center gap-2 sm:ml-auto">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={!activeConfig}
-                  onClick={() => activeConfig && downloadConfig(activeConfig)}
-                >
-                  <Download className="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={!activeConfig}
-                  onClick={() => activeConfig && startEdit(activeConfig)}
-                >
-                  <Edit className="h-4 w-4" />
-                </Button>
-                <Button
-                  size="sm"
-                  variant={activeConfig?.isDefault ? 'outline' : 'default'}
-                  disabled={!activeConfig || activeConfig.isDefault || isUpdating}
-                  onClick={() => activeConfig && setDefaultConfig(activeConfig)}
-                >
-                  {activeConfig?.isDefault ? 'Applied' : 'Apply'}
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={!activeConfig}
-                  className="text-red-500 hover:text-red-600"
-                  onClick={() => activeConfig && setDeleteConfirmConfig(activeConfig)}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
-                <Button size="sm" onClick={() => setIsCreateDialogOpen(true)}>
-                  <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
-                  <span className="text-xs sm:text-sm">New Config</span>
-                </Button>
-              </div>
+              <TooltipProvider delayDuration={200}>
+                <div className="flex items-center gap-1 sm:gap-1.5 sm:ml-auto flex-wrap">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={!activeConfig}
+                        onClick={() => activeConfig && downloadConfig(activeConfig)}
+                      >
+                        <Download className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Download</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={!activeConfig}
+                        onClick={() => activeConfig && startEdit(activeConfig)}
+                      >
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Edit</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        size="sm"
+                        variant={activeConfig?.isDefault ? 'outline' : 'default'}
+                        disabled={!activeConfig || activeConfig.isDefault || isUpdating}
+                        onClick={() => activeConfig && setDefaultConfig(activeConfig)}
+                      >
+                        {activeConfig?.isDefault ? 'Applied' : 'Apply'}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {activeConfig?.isDefault ? 'Applied' : 'Apply as default'}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={!activeConfig}
+                        className="text-red-500 hover:text-red-600"
+                        onClick={() => activeConfig && setDeleteConfirmConfig(activeConfig)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Delete</TooltipContent>
+                  </Tooltip>
+                  <Button size="sm" onClick={() => setIsCreateDialogOpen(true)}>
+                    <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1" />
+                    <span className="text-xs sm:text-sm">New Config</span>
+                  </Button>
+                </div>
+              </TooltipProvider>
             </div>
 
             {activeConfig && (

--- a/frontend/src/components/settings/OpenCodeConfigManager.tsx
+++ b/frontend/src/components/settings/OpenCodeConfigManager.tsx
@@ -635,11 +635,6 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              {activeConfig?.isDefault && (
-                <span className="text-xs font-medium text-green-600 dark:text-green-400 sm:hidden">
-                  Active
-                </span>
-              )}
               <Select
                 value={activeConfigName}
                 onValueChange={(value) => {
@@ -647,13 +642,25 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
                 }}
               >
                 <SelectTrigger className="w-full sm:max-w-xs">
-                  <SelectValue placeholder="Select a configuration..." />
+                  <SelectValue placeholder="Select a configuration...">
+                    {activeConfig && (
+                      <>
+                        {activeConfig.name}
+                        {activeConfig.isDefault && (
+                          <span className="text-orange-500 dark:text-orange-400"> (Active)</span>
+                        )}
+                        {!activeConfig.isValid && ' (Invalid)'}
+                      </>
+                    )}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {configs.map((config) => (
                     <SelectItem key={config.id} value={config.name}>
                       {config.name}
-                      {config.isDefault && ' (Active)'}
+                      {config.isDefault && (
+                        <span className="text-orange-500 dark:text-orange-400"> (Active)</span>
+                      )}
                       {!config.isValid && ' (Invalid)'}
                     </SelectItem>
                   ))}

--- a/frontend/src/components/settings/OpenCodeConfigManager.tsx
+++ b/frontend/src/components/settings/OpenCodeConfigManager.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { cn } from '@/lib/utils'
-import { Loader2, Plus, Trash2, Edit, StarOff, Download, RotateCcw, FileText, ArrowUpCircle, History, ChevronDown } from 'lucide-react'
+import { Loader2, Plus, Trash2, Edit, Download, RotateCcw, FileText, ArrowUpCircle, History, ChevronDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
@@ -638,10 +638,6 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
                 value={activeConfigName}
                 onValueChange={(value) => {
                   setActiveConfigName(value)
-                  const next = configs.find((c) => c.name === value)
-                  if (next && !next.isDefault) {
-                    void setDefaultConfig(next)
-                  }
                 }}
               >
                 <SelectTrigger className="w-full sm:max-w-xs">
@@ -687,12 +683,12 @@ export function OpenCodeConfigManager({ hideHealthStatus = false }: OpenCodeConf
                   <Edit className="h-4 w-4" />
                 </Button>
                 <Button
-                  variant="ghost"
                   size="sm"
+                  variant={activeConfig?.isDefault ? 'outline' : 'default'}
                   disabled={!activeConfig || activeConfig.isDefault || isUpdating}
                   onClick={() => activeConfig && setDefaultConfig(activeConfig)}
                 >
-                  <StarOff className="h-4 w-4" />
+                  {activeConfig?.isDefault ? 'Applied' : 'Apply'}
                 </Button>
                 <Button
                   variant="ghost"


### PR DESCRIPTION
Selecting a config in the OpenCode Configurations dropdown no longer calls setDefaultConfig. The dropdown now only updates activeConfigName so users can preview or edit a config without it being applied as the default.

Also replaces the icon-only Star button with a labeled Apply button that shows 'Applied' (outline, disabled) when the selected config is already the default, making the apply action explicit and visible.

## Files

- frontend/src/components/settings/OpenCodeConfigManager.tsx