### PR TITLE
feat: add bundle-based OCM mirror sync

### DIFF
--- a/backend/src/routes/internal/repo-mirror.ts
+++ b/backend/src/routes/internal/repo-mirror.ts
@@ -102,6 +102,7 @@ async function importBundle(fullPath: string, bundlePath: string, branch: string
     const firstSpace = trimmed.indexOf(' ')
     if (firstSpace === -1) continue
     const name = trimmed.slice(0, firstSpace)
+    if (name === 'HEAD') continue
     const sha = trimmed.slice(firstSpace + 1)
     await gitRaw(fullPath, ['update-ref', `refs/heads/${name}`, sha])
   }

--- a/backend/src/routes/internal/repo-mirror.ts
+++ b/backend/src/routes/internal/repo-mirror.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import type { Database } from 'bun:sqlite'
 import { spawn } from 'child_process'
-import { createWriteStream } from 'fs'
+import { copyFileSync, createReadStream, createWriteStream, existsSync } from 'fs'
 import { mkdirSync, mkdtempSync, writeFileSync } from 'fs'
 import { Readable } from 'stream'
 import { pipeline } from 'stream/promises'
@@ -42,7 +42,93 @@ interface CommitBody {
   gzip?: boolean
 }
 
+interface PatchBody {
+  baseHead?: string | null
+  patch?: string
+  force?: boolean
+}
+
 const LEGACY_UPGRADE_MESSAGE = 'this ocm CLI is too old for this server; upgrade to ocm-cli >= 0.1.2 (the mirror upload protocol changed to chunked uploads)'
+
+function gitRaw(repoPath: string, args: string[], env: NodeJS.ProcessEnv = process.env, input?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('git', args, { cwd: repoPath, env })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString() })
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString() })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) resolve(stdout)
+      else reject(new Error(stderr.trim() || `git exited with code ${code}`))
+    })
+    if (input !== undefined) child.stdin.end(input)
+  })
+}
+
+async function createMirrorPatch(fullPath: string): Promise<string> {
+  const untracked = (await gitRaw(fullPath, ['ls-files', '--others', '--exclude-standard', '-z']).catch(() => ''))
+    .split('\0')
+    .filter(Boolean)
+  if (untracked.length === 0) return gitRaw(fullPath, ['diff', '--binary', 'HEAD', '--'])
+
+  const indexPath = (await safeGitOut(fullPath, ['rev-parse', '--git-path', 'index']))?.trim()
+  const tempIndexDir = mkdtempSync(join(getReposPath(), '.ocm-index-'))
+  const tempIndex = join(tempIndexDir, 'index')
+  const env = { ...process.env, GIT_INDEX_FILE: tempIndex }
+
+  try {
+    if (indexPath && existsSync(join(fullPath, indexPath))) {
+      copyFileSync(join(fullPath, indexPath), tempIndex)
+    }
+    await gitRaw(fullPath, ['add', '-N', '--', ...untracked], env)
+    return gitRaw(fullPath, ['diff', '--binary', 'HEAD', '--'], env)
+  } finally {
+    await fsp.rm(tempIndexDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+async function applyMirrorPatch(fullPath: string, patch: string): Promise<void> {
+  if (!patch) return
+  await gitRaw(fullPath, ['apply', '--binary', '--whitespace=nowarn', '-'], process.env, patch)
+}
+
+async function importBundle(fullPath: string, bundlePath: string, branch: string | null): Promise<void> {
+  await gitRaw(fullPath, ['fetch', bundlePath, '+refs/heads/*:refs/remotes/ocm-sync/*', '+refs/tags/*:refs/tags/*'])
+  const refs = await gitRaw(fullPath, ['for-each-ref', '--format=%(refname:strip=3) %(objectname)', 'refs/remotes/ocm-sync'])
+  for (const line of refs.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const firstSpace = trimmed.indexOf(' ')
+    if (firstSpace === -1) continue
+    const name = trimmed.slice(0, firstSpace)
+    const sha = trimmed.slice(firstSpace + 1)
+    await gitRaw(fullPath, ['update-ref', `refs/heads/${name}`, sha])
+  }
+
+  if (branch) {
+    await gitRaw(fullPath, ['checkout', branch])
+    const head = (await gitRaw(fullPath, ['rev-parse', `refs/remotes/ocm-sync/${branch}`])).trim()
+    if (head) await gitRaw(fullPath, ['reset', '--hard', head])
+  }
+
+  await gitRaw(fullPath, ['for-each-ref', '--format=%(refname)', 'refs/remotes/ocm-sync'])
+    .then(async (out) => {
+      for (const ref of out.split('\n').map((line) => line.trim()).filter(Boolean)) {
+        await gitRaw(fullPath, ['update-ref', '-d', ref])
+      }
+    })
+    .catch(() => {})
+}
+
+async function createBundle(fullPath: string): Promise<string> {
+  const stagingRoot = join(getReposPath(), '.ocm-staging')
+  mkdirSync(stagingRoot, { recursive: true })
+  const bundleDir = mkdtempSync(join(stagingRoot, 'bundle-'))
+  const bundlePath = join(bundleDir, 'repo.bundle')
+  await gitRaw(fullPath, ['bundle', 'create', bundlePath, '--all'])
+  return bundlePath
+}
 
 export function createInternalRepoMirrorRoutes(db: Database) {
   const app = new Hono()
@@ -212,6 +298,146 @@ export function createInternalRepoMirrorRoutes(db: Database) {
     }
     await deleteUploadSession(uploadId)
     return c.json({ ok: true })
+  })
+
+  app.get('/:repoId/mirror/bundle', async (c) => {
+    const repoIdRaw = c.req.param('repoId')
+    const repoId = Number(repoIdRaw)
+    if (!Number.isFinite(repoId)) return c.json({ error: 'invalid repoId' }, 400)
+    const repo = getRepoById(db, repoId)
+    if (!repo) return c.json({ error: 'repo not found' }, 404)
+
+    let bundlePath: string | undefined
+    try {
+      bundlePath = await createBundle(repo.fullPath)
+      const stream = createReadStream(bundlePath)
+      stream.on('close', () => {
+        if (bundlePath) fsp.rm(join(bundlePath, '..'), { recursive: true, force: true }).catch(() => {})
+      })
+      return new Response(Readable.toWeb(stream) as ReadableStream, {
+        headers: { 'Content-Type': 'application/octet-stream' },
+      })
+    } catch (error) {
+      logger.error('mirror bundle download failed:', error)
+      if (bundlePath) await fsp.rm(join(bundlePath, '..'), { recursive: true, force: true }).catch(() => {})
+      return c.json({ error: getErrorMessage(error) }, 500)
+    }
+  })
+
+  app.post('/:repoId/mirror/bundle', async (c) => {
+    const repoIdRaw = c.req.param('repoId')
+    const repoId = Number(repoIdRaw)
+    if (!Number.isFinite(repoId)) return c.json({ error: 'invalid repoId' }, 400)
+    const repo = getRepoById(db, repoId)
+    if (!repo) return c.json({ error: 'repo not found' }, 404)
+    if (isRepoInUse(db, repoId) && c.req.query('force') !== '1') {
+      return c.json({ error: 'repo_in_use', message: 'open OpenCode sessions are using this repo; rerun with force=1' }, 409)
+    }
+
+    const rawBody = c.req.raw.body
+    if (!rawBody) return c.json({ error: 'no body provided' }, 400)
+
+    const stagingRoot = join(getReposPath(), '.ocm-staging')
+    mkdirSync(stagingRoot, { recursive: true })
+    const bundleDir = mkdtempSync(join(stagingRoot, 'bundle-upload-'))
+    const bundlePath = join(bundleDir, 'repo.bundle')
+    const branch = c.req.header('x-ocm-branch')?.trim() || null
+
+    try {
+      const body = Readable.fromWeb(rawBody as unknown as Parameters<typeof Readable.fromWeb>[0])
+      await pipeline(body, createWriteStream(bundlePath))
+      await importBundle(repo.fullPath, bundlePath, branch)
+
+      const branchName = await safeGitOut(repo.fullPath, ['rev-parse', '--abbrev-ref', 'HEAD'])
+      const head = await safeGitOut(repo.fullPath, ['rev-parse', 'HEAD'])
+      if (branchName) updateRepoBranch(db, repoId, branchName.trim())
+      updateLastPulled(db, repoId)
+
+      return c.json({
+        repoId,
+        fullPath: repo.fullPath,
+        branch: branchName?.trim() || null,
+        head: head?.trim() || null,
+        created: false,
+      })
+    } catch (error) {
+      logger.error('mirror bundle upload failed:', error)
+      return c.json({ error: getErrorMessage(error) }, 409)
+    } finally {
+      await fsp.rm(bundleDir, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  app.get('/:repoId/mirror/patch', async (c) => {
+    const repoIdRaw = c.req.param('repoId')
+    const repoId = Number(repoIdRaw)
+    if (!Number.isFinite(repoId)) return c.json({ error: 'invalid repoId' }, 400)
+    const repo = getRepoById(db, repoId)
+    if (!repo) return c.json({ error: 'repo not found' }, 404)
+
+    try {
+      const branchName = await safeGitOut(repo.fullPath, ['rev-parse', '--abbrev-ref', 'HEAD'])
+      const head = await safeGitOut(repo.fullPath, ['rev-parse', 'HEAD'])
+      const patch = await createMirrorPatch(repo.fullPath)
+      return c.json({
+        repoId: repo.id,
+        branch: branchName?.trim() || null,
+        head: head?.trim() || null,
+        patch,
+      })
+    } catch (error) {
+      logger.error('mirror patch snapshot failed:', error)
+      return c.json({ error: getErrorMessage(error) }, 500)
+    }
+  })
+
+  app.post('/:repoId/mirror/patch', async (c) => {
+    const repoIdRaw = c.req.param('repoId')
+    const repoId = Number(repoIdRaw)
+    if (!Number.isFinite(repoId)) return c.json({ error: 'invalid repoId' }, 400)
+
+    let body: PatchBody
+    try {
+      body = (await c.req.json()) as PatchBody
+    } catch {
+      return c.json({ error: 'invalid json body' }, 400)
+    }
+
+    const repo = getRepoById(db, repoId)
+    if (!repo) return c.json({ error: 'repo not found' }, 404)
+    if (!body.patch && body.patch !== '') return c.json({ error: 'patch required' }, 400)
+    if (body.force !== true && isRepoInUse(db, repoId)) {
+      return c.json({ error: 'repo_in_use', message: 'open OpenCode sessions are using this repo; rerun with force=1' }, 409)
+    }
+
+    try {
+      const currentHead = await safeGitOut(repo.fullPath, ['rev-parse', 'HEAD'])
+      const currentHeadTrimmed = currentHead?.trim() || null
+      const baseHead = body.baseHead?.trim() || null
+      if (baseHead && currentHeadTrimmed && baseHead !== currentHeadTrimmed) {
+        return c.json({ error: 'head_mismatch', message: 'Manager repo HEAD differs from patch base' }, 409)
+      }
+
+      await applyMirrorPatch(repo.fullPath, body.patch)
+
+      const branchName = await safeGitOut(repo.fullPath, ['rev-parse', '--abbrev-ref', 'HEAD'])
+      const head = await safeGitOut(repo.fullPath, ['rev-parse', 'HEAD'])
+
+      if (branchName) updateRepoBranch(db, repoId, branchName.trim())
+      updateLastPulled(db, repoId)
+
+      return c.json({
+        repoId,
+        fullPath: repo.fullPath,
+        branch: branchName?.trim() || null,
+        head: head?.trim() || null,
+        created: false,
+        applied: true,
+      })
+    } catch (error) {
+      logger.error('mirror patch failed:', error)
+      return c.json({ error: getErrorMessage(error) }, 409)
+    }
   })
 
   app.get('/:repoId/mirror', async (c) => {

--- a/backend/src/routes/settings.test.ts
+++ b/backend/src/routes/settings.test.ts
@@ -371,3 +371,82 @@ describe('settings routes — OpenCode directory file upload', () => {
     ])
   })
 })
+
+describe('settings routes — opencode model discovery', () => {
+  let db: Database
+  let app: Hono
+  let originalFetch: typeof globalThis.fetch
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    db = createTestDb()
+    app = createTestApp(db)
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    db.close()
+  })
+
+  it('returns 400 when baseUrl is missing', async () => {
+    const res = await app.request('/settings/opencode-discover-models')
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when baseUrl is invalid', async () => {
+    const res = await app.request('/settings/opencode-discover-models?baseUrl=not-a-url')
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when baseUrl is not http/https', async () => {
+    const res = await app.request('/settings/opencode-discover-models?baseUrl=ftp://example.com')
+    expect(res.status).toBe(400)
+  })
+
+  it('discovers models from the endpoint', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [{ id: 'gpt-4o' }, { id: 'gpt-3.5-turbo' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const res = await app.request('/settings/opencode-discover-models?baseUrl=http://localhost:1234&refresh=true')
+    expect(res.status).toBe(200)
+    const data = (await res.json()) as { models: string[]; cached: boolean }
+    expect(data.models).toEqual(['gpt-4o', 'gpt-3.5-turbo'])
+    expect(data.cached).toBe(false)
+  })
+
+  it('returns cached models on subsequent requests without re-fetching', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [{ id: 'llama-3' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const firstRes = await app.request('/settings/opencode-discover-models?baseUrl=http://localhost:5678&refresh=true')
+    const firstData = (await firstRes.json()) as { models: string[]; cached: boolean }
+    expect(firstData.models).toEqual(['llama-3'])
+    expect(firstData.cached).toBe(false)
+
+    const secondRes = await app.request('/settings/opencode-discover-models?baseUrl=http://localhost:5678')
+    const secondData = (await secondRes.json()) as { models: string[]; cached: boolean }
+    expect(secondData.models).toEqual(['llama-3'])
+    expect(secondData.cached).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns empty models when endpoint is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('connection refused'))
+
+    const res = await app.request('/settings/opencode-discover-models?baseUrl=http://localhost:9999&refresh=true')
+    expect(res.status).toBe(200)
+    const data = (await res.json()) as { models: string[] }
+    expect(data.models).toEqual([])
+  })
+})

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -24,6 +24,13 @@ import {
   type SkillScope,
 } from '@opencode-manager/shared'
 import { logger } from '../utils/logger'
+import {
+  fetchAvailableModels,
+  generateDiscoveryCacheKey,
+  getCachedDiscovery,
+  cacheDiscovery,
+  ensureDiscoveryCacheDir,
+} from '../utils/discovery-cache'
 import { opencodeServerManager, ConfigReloadError } from '../services/opencode-single-server'
 import { getOrCreateInternalToken, rotateInternalToken } from '../services/internal-token'
 import { sseAggregator } from '../services/sse-aggregator'
@@ -1873,6 +1880,49 @@ export function createSettingsRoutes(db: Database, gitAuthService: GitAuthServic
     } catch (error) {
       logger.error('Failed to rotate manager token:', error)
       return c.json({ error: 'Failed to rotate manager token' }, 500)
+    }
+  })
+
+  app.get('/opencode-discover-models', async (c) => {
+    try {
+      const baseUrl = c.req.query('baseUrl')
+      const apiKey = c.req.query('apiKey') || ''
+      const forceRefresh = c.req.query('refresh') === 'true'
+
+      if (!baseUrl || !baseUrl.trim()) {
+        return c.json({ error: 'baseUrl is required' }, 400)
+      }
+
+      let parsedUrl: URL
+      try {
+        parsedUrl = new URL(baseUrl.trim())
+      } catch {
+        return c.json({ error: 'Invalid baseUrl' }, 400)
+      }
+      if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+        return c.json({ error: 'baseUrl must be an http or https URL' }, 400)
+      }
+
+      const trimmedBaseUrl = baseUrl.trim()
+      const cacheKey = generateDiscoveryCacheKey(trimmedBaseUrl, apiKey, 'opencode-models')
+
+      if (!forceRefresh) {
+        const cachedModels = await getCachedDiscovery<string[]>(cacheKey)
+        if (cachedModels) {
+          return c.json({ models: cachedModels, cached: true })
+        }
+      }
+
+      await ensureDiscoveryCacheDir()
+      logger.info(`Discovering OpenCode models from ${trimmedBaseUrl}`)
+
+      const models = await fetchAvailableModels(trimmedBaseUrl, apiKey, /.*/, [])
+      await cacheDiscovery(cacheKey, models)
+
+      return c.json({ models, cached: false })
+    } catch (error) {
+      logger.error('Failed to discover OpenCode models:', error)
+      return c.json({ error: 'Failed to discover models' }, 500)
     }
   })
 

--- a/backend/test/routes/internal/repo-mirror.test.ts
+++ b/backend/test/routes/internal/repo-mirror.test.ts
@@ -284,6 +284,47 @@ describe('internal-repo-mirror routes', () => {
       expect(featureRef.status).toBe(0)
     })
 
+    it('imports a bundle whose ocm-sync refs include a symbolic HEAD without failing', async () => {
+      const sourceDir = join(getTmpRoot(), 'bundle-source-head')
+      mkdirSync(sourceDir, { recursive: true })
+      spawnSync('git', ['init', '-b', 'main'], { cwd: sourceDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: sourceDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.name', 'Test'], { cwd: sourceDir, stdio: 'ignore' })
+      writeFileSync(join(sourceDir, 'tracked.txt'), 'from bundle\n')
+      spawnSync('git', ['add', 'tracked.txt'], { cwd: sourceDir, stdio: 'ignore' })
+      spawnSync('git', ['commit', '-m', 'source'], { cwd: sourceDir, stdio: 'ignore' })
+      const headSha = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: sourceDir, encoding: 'utf-8' }).stdout.trim()
+      spawnSync('git', ['checkout', headSha], { cwd: sourceDir, stdio: 'ignore' })
+      const bundlePath = join(getTmpRoot(), 'source-head.bundle')
+      spawnSync('git', ['bundle', 'create', bundlePath, '--all'], { cwd: sourceDir, stdio: 'ignore' })
+
+      const targetDir = join(getTmpRoot(), 'bundle-target-head')
+      mkdirSync(targetDir, { recursive: true })
+      spawnSync('git', ['init', '-b', 'main'], { cwd: targetDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: targetDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.name', 'Test'], { cwd: targetDir, stdio: 'ignore' })
+      writeFileSync(join(targetDir, 'old.txt'), 'old\n')
+      spawnSync('git', ['add', 'old.txt'], { cwd: targetDir, stdio: 'ignore' })
+      spawnSync('git', ['commit', '-m', 'target'], { cwd: targetDir, stdio: 'ignore' })
+
+      mockGetRepoById.mockReturnValue({ id: 1, fullPath: targetDir })
+      mockSafeGitOut.mockImplementation(async (_repoPath: string, args: string[]) => {
+        if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return 'main'
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return headSha
+        return null
+      })
+
+      const res = await app.request('/api/internal/repos/1/mirror/bundle', {
+        method: 'POST',
+        body: readFileSync(bundlePath),
+        headers: { 'content-type': 'application/octet-stream' },
+      })
+
+      expect(res.status).toBe(200)
+      const headRef = spawnSync('git', ['rev-parse', '--verify', 'refs/heads/HEAD'], { cwd: targetDir, encoding: 'utf-8' })
+      expect(headRef.status).not.toBe(0)
+    })
+
     it('returns a git bundle for pull fast path', async () => {
       const repoDir = join(getTmpRoot(), 'bundle-download')
       mkdirSync(repoDir, { recursive: true })

--- a/backend/test/routes/internal/repo-mirror.test.ts
+++ b/backend/test/routes/internal/repo-mirror.test.ts
@@ -238,6 +238,133 @@ describe('internal-repo-mirror routes', () => {
     })
   })
 
+  describe('patch sync flow', () => {
+    it('imports a git bundle into an existing manager repo', async () => {
+      const sourceDir = join(getTmpRoot(), 'bundle-source')
+      mkdirSync(sourceDir, { recursive: true })
+      spawnSync('git', ['init', '-b', 'main'], { cwd: sourceDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: sourceDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.name', 'Test'], { cwd: sourceDir, stdio: 'ignore' })
+      writeFileSync(join(sourceDir, 'tracked.txt'), 'from bundle\n')
+      spawnSync('git', ['add', 'tracked.txt'], { cwd: sourceDir, stdio: 'ignore' })
+      spawnSync('git', ['commit', '-m', 'source'], { cwd: sourceDir, stdio: 'ignore' })
+      spawnSync('git', ['checkout', '-b', 'feature'], { cwd: sourceDir, stdio: 'ignore' })
+      writeFileSync(join(sourceDir, 'feature.txt'), 'feature branch\n')
+      spawnSync('git', ['add', 'feature.txt'], { cwd: sourceDir, stdio: 'ignore' })
+      spawnSync('git', ['commit', '-m', 'feature'], { cwd: sourceDir, stdio: 'ignore' })
+      spawnSync('git', ['checkout', 'main'], { cwd: sourceDir, stdio: 'ignore' })
+      const bundlePath = join(getTmpRoot(), 'source.bundle')
+      spawnSync('git', ['bundle', 'create', bundlePath, '--all'], { cwd: sourceDir, stdio: 'ignore' })
+
+      const targetDir = join(getTmpRoot(), 'bundle-target')
+      mkdirSync(targetDir, { recursive: true })
+      spawnSync('git', ['init', '-b', 'main'], { cwd: targetDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: targetDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.name', 'Test'], { cwd: targetDir, stdio: 'ignore' })
+      writeFileSync(join(targetDir, 'old.txt'), 'old\n')
+      spawnSync('git', ['add', 'old.txt'], { cwd: targetDir, stdio: 'ignore' })
+      spawnSync('git', ['commit', '-m', 'target'], { cwd: targetDir, stdio: 'ignore' })
+
+      mockGetRepoById.mockReturnValue({ id: 1, fullPath: targetDir })
+      mockSafeGitOut.mockImplementation(async (_repoPath: string, args: string[]) => {
+        if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return 'main'
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'abc'
+        return null
+      })
+
+      const res = await app.request('/api/internal/repos/1/mirror/bundle', {
+        method: 'POST',
+        body: readFileSync(bundlePath),
+        headers: { 'content-type': 'application/octet-stream', 'x-ocm-branch': 'main' },
+      })
+
+      expect(res.status).toBe(200)
+      expect(readFileSync(join(targetDir, 'tracked.txt'), 'utf-8')).toBe('from bundle\n')
+      const featureRef = spawnSync('git', ['rev-parse', '--verify', 'refs/heads/feature'], { cwd: targetDir, encoding: 'utf-8' })
+      expect(featureRef.status).toBe(0)
+    })
+
+    it('returns a git bundle for pull fast path', async () => {
+      const repoDir = join(getTmpRoot(), 'bundle-download')
+      mkdirSync(repoDir, { recursive: true })
+      spawnSync('git', ['init', '-b', 'main'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.name', 'Test'], { cwd: repoDir, stdio: 'ignore' })
+      writeFileSync(join(repoDir, 'tracked.txt'), 'bundle payload\n')
+      spawnSync('git', ['add', 'tracked.txt'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['commit', '-m', 'bundle'], { cwd: repoDir, stdio: 'ignore' })
+      mockGetRepoById.mockReturnValue({ id: 1, fullPath: repoDir })
+
+      const res = await app.request('/api/internal/repos/1/mirror/bundle')
+      const body = Buffer.from(await res.arrayBuffer())
+
+      expect(res.status).toBe(200)
+      expect(body.length).toBeGreaterThan(0)
+      const verifyPath = join(getTmpRoot(), 'download.bundle')
+      writeFileSync(verifyPath, body)
+      const verify = spawnSync('git', ['bundle', 'verify', verifyPath], { cwd: repoDir, encoding: 'utf-8' })
+      expect(verify.status).toBe(0)
+    })
+
+    it('applies a patch to an existing manager repo', async () => {
+      const repoDir = join(getTmpRoot(), 'patch-repo')
+      mkdirSync(repoDir, { recursive: true })
+      spawnSync('git', ['init'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.name', 'Test'], { cwd: repoDir, stdio: 'ignore' })
+      writeFileSync(join(repoDir, 'tracked.txt'), 'before\n')
+      spawnSync('git', ['add', 'tracked.txt'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['commit', '-m', 'initial'], { cwd: repoDir, stdio: 'ignore' })
+      const head = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: repoDir, encoding: 'utf-8' }).stdout.trim()
+
+      mockGetRepoById.mockReturnValue({ id: 1, fullPath: repoDir })
+      mockSafeGitOut.mockImplementation(async (_repoPath: string, args: string[]) => {
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return head
+        if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return 'main'
+        return null
+      })
+
+      const patch = 'diff --git a/tracked.txt b/tracked.txt\nindex 6e58d95..7c6cae9 100644\n--- a/tracked.txt\n+++ b/tracked.txt\n@@ -1 +1 @@\n-before\n+after\n'
+      const res = await app.request('/api/internal/repos/1/mirror/patch', {
+        method: 'POST',
+        body: JSON.stringify({ baseHead: head, patch }),
+        headers: { 'content-type': 'application/json' },
+      })
+
+      expect(res.status).toBe(200)
+      expect(readFileSync(join(repoDir, 'tracked.txt'), 'utf-8')).toBe('after\n')
+      expect(mockUpdateLastPulled).toHaveBeenCalledWith(expect.anything(), 1)
+    })
+
+    it('returns a patch snapshot for pull fast path', async () => {
+      const repoDir = join(getTmpRoot(), 'snapshot-repo')
+      mkdirSync(repoDir, { recursive: true })
+      spawnSync('git', ['init'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['config', 'user.name', 'Test'], { cwd: repoDir, stdio: 'ignore' })
+      writeFileSync(join(repoDir, 'tracked.txt'), 'before\n')
+      spawnSync('git', ['add', 'tracked.txt'], { cwd: repoDir, stdio: 'ignore' })
+      spawnSync('git', ['commit', '-m', 'initial'], { cwd: repoDir, stdio: 'ignore' })
+      writeFileSync(join(repoDir, 'tracked.txt'), 'after\n')
+
+      mockGetRepoById.mockReturnValue({ id: 1, fullPath: repoDir })
+      mockSafeGitOut.mockImplementation(async (_repoPath: string, args: string[]) => {
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'abc'
+        if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return 'main'
+        if (args[0] === 'rev-parse' && args[1] === '--git-path') return '.git/index'
+        return null
+      })
+
+      const res = await app.request('/api/internal/repos/1/mirror/patch')
+      const json = await res.json() as { patch: string; head: string; branch: string }
+
+      expect(res.status).toBe(200)
+      expect(json.head).toBe('abc')
+      expect(json.branch).toBe('main')
+      expect(json.patch).toContain('diff --git a/tracked.txt b/tracked.txt')
+    })
+  })
+
   describe('chunked upload flow (begin/parts/commit)', () => {
     it('creates a repo and populates from chunked tarball', async () => {
       const targetPath = join(getTmpRoot(), 'test-repo')

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -132,6 +132,19 @@ export const settingsApi = {
     }
   },
 
+  discoverOpenCodeModels: async (
+    baseUrl: string,
+    apiKey?: string,
+    forceRefresh = false,
+  ): Promise<{ models: string[]; cached: boolean }> => {
+    const params: Record<string, string> = { baseUrl }
+    if (apiKey) params.apiKey = apiKey
+    if (forceRefresh) params.refresh = 'true'
+    return fetchWrapper(`${API_BASE_URL}/api/settings/opencode-discover-models`, {
+      params,
+    })
+  },
+
   restartOpenCodeServer: async (): Promise<{ success: boolean; message: string; details?: string }> => {
     return fetchWrapper(`${API_BASE_URL}/api/settings/opencode-restart`, {
       method: 'POST',

--- a/frontend/src/components/settings/OpenCodeModelDialog.tsx
+++ b/frontend/src/components/settings/OpenCodeModelDialog.tsx
@@ -1,7 +1,7 @@
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
@@ -9,6 +9,10 @@ import { Textarea } from '@/components/ui/textarea'
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { Combobox } from '@/components/ui/combobox'
+import { Label } from '@/components/ui/label'
+import { RefreshCw, Loader2 } from 'lucide-react'
+import { settingsApi } from '@/api/settings'
 import type { ModelConfig, ProviderConfig } from '@/api/types/settings'
 
 type ConfigModel = Partial<ModelConfig> & {
@@ -71,6 +75,18 @@ function parseOptionalNumber(value: string): number | undefined {
   if (!value.trim()) return undefined
   const parsed = Number(value)
   return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function sanitizeModelId(modelId: string): string {
+  return modelId.replace(/[^a-zA-Z0-9._-]/g, '-')
+}
+
+function prettifyModelName(modelId: string): string {
+  return modelId
+    .replace(/[-_/]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
 function jsonObjectField(label: string) {
@@ -248,14 +264,83 @@ export function OpenCodeModelDialog({
   const { isValid } = form.formState
   const createNewProvider = form.watch('createNewProvider')
   const newProviderType = form.watch('newProviderType')
+  const watchedProviderId = form.watch('providerId')
+  const watchedNewProviderBaseUrl = form.watch('newProviderBaseUrl')
   const resetKeyRef = useRef<string | null>(null)
   const resetKey = editingModel
     ? `edit-${editingModel.providerId}-${editingModel.modelId}`
     : `create-${selectedProviderId || availableProviders[0] || ''}`
 
+  const [discoveredModels, setDiscoveredModels] = useState<string[]>([])
+  const [isLoadingModels, setIsLoadingModels] = useState(false)
+  const [discoveryError, setDiscoveryError] = useState<string | null>(null)
+  const [discoveryApiKey, setDiscoveryApiKey] = useState('')
+
+  const discoveryBaseUrl = useMemo(() => {
+    if (createNewProvider) {
+      return watchedNewProviderBaseUrl?.trim() || ''
+    }
+    const provider = existingProviders?.[watchedProviderId]
+    const options = provider?.options as { baseURL?: string } | undefined
+    return (options?.baseURL || provider?.api || '').trim()
+  }, [createNewProvider, watchedNewProviderBaseUrl, watchedProviderId, existingProviders])
+
+  const discoverModels = useCallback(async (forceRefresh = false) => {
+    if (!discoveryBaseUrl) {
+      setDiscoveredModels([])
+      return
+    }
+    try {
+      new URL(discoveryBaseUrl)
+    } catch {
+      setDiscoveredModels([])
+      return
+    }
+    setIsLoadingModels(true)
+    setDiscoveryError(null)
+    try {
+      const response = await settingsApi.discoverOpenCodeModels(discoveryBaseUrl, discoveryApiKey || undefined, forceRefresh)
+      setDiscoveredModels(response.models)
+    } catch {
+      setDiscoveredModels([])
+      setDiscoveryError('Failed to discover models. Check the endpoint URL and API key.')
+    } finally {
+      setIsLoadingModels(false)
+    }
+  }, [discoveryBaseUrl, discoveryApiKey])
+
+  useEffect(() => {
+    if (!open) return
+    if (!discoveryBaseUrl) {
+      setDiscoveredModels([])
+      setDiscoveryError(null)
+      return
+    }
+    if (createNewProvider && newProviderType !== 'api') return
+    const timer = setTimeout(() => {
+      void discoverModels()
+    }, 600)
+    return () => clearTimeout(timer)
+  }, [open, discoveryBaseUrl, createNewProvider, newProviderType, discoverModels])
+
+  const handleDiscoveredModelSelect = useCallback((modelId: string) => {
+    const currentModelId = form.getValues('modelId')
+    const sanitized = sanitizeModelId(modelId)
+    if (!currentModelId && sanitized) {
+      form.setValue('modelId', sanitized, { shouldValidate: true, shouldDirty: true })
+    }
+    const currentDisplayName = form.getValues('displayName')
+    if (!currentDisplayName) {
+      form.setValue('displayName', prettifyModelName(modelId), { shouldValidate: true, shouldDirty: true })
+    }
+  }, [form])
+
   useEffect(() => {
     if (!open) {
       resetKeyRef.current = null
+      setDiscoveredModels([])
+      setDiscoveryError(null)
+      setDiscoveryApiKey('')
       return
     }
 
@@ -409,6 +494,22 @@ export function OpenCodeModelDialog({
                     )} />
                   )}
 
+                  {newProviderType === 'api' && (
+                    <div className="space-y-2">
+                      <Label htmlFor="discovery-api-key">API Key (for discovery)</Label>
+                      <Input
+                        id="discovery-api-key"
+                        type="password"
+                        value={discoveryApiKey}
+                        onChange={(e) => setDiscoveryApiKey(e.target.value)}
+                        placeholder="Optional - used to fetch the model list"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Used only to discover available models. Configure provider auth separately via env vars or headers.
+                      </p>
+                    </div>
+                  )}
+
                   {newProviderType === 'npm' && (
                     <FormField control={form.control} name="newProviderNpm" render={({ field }) => (
                       <FormItem>
@@ -451,8 +552,40 @@ export function OpenCodeModelDialog({
 
                 <FormField control={form.control} name="backingModelId" render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Provider Model ID</FormLabel>
-                    <FormControl><Input {...field} placeholder="e.g., MiniMax-M2.7" /></FormControl>
+                    <div className="flex items-center justify-between">
+                      <FormLabel>Provider Model ID</FormLabel>
+                      {discoveryBaseUrl && (
+                        <button
+                          type="button"
+                          onClick={() => discoverModels(true)}
+                          disabled={isLoadingModels}
+                          className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 disabled:opacity-50"
+                        >
+                          {isLoadingModels ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                          {discoveredModels.length > 0 ? 'Refresh' : 'Discover'}
+                        </button>
+                      )}
+                    </div>
+                    <FormControl>
+                      <Combobox
+                        value={field.value}
+                        onChange={(value) => {
+                          field.onChange(value)
+                          if (discoveredModels.includes(value)) {
+                            handleDiscoveredModelSelect(value)
+                          }
+                        }}
+                        options={discoveredModels.map((m) => ({ value: m, label: m }))}
+                        placeholder="e.g., MiniMax-M2.7"
+                        disabled={isLoadingModels}
+                        allowCustomValue={true}
+                      />
+                    </FormControl>
+                    {discoveryError && <p className="text-xs text-destructive">{discoveryError}</p>}
+                    {!discoveryError && isLoadingModels && <p className="text-xs text-muted-foreground">Discovering models...</p>}
+                    {!discoveryError && !isLoadingModels && discoveredModels.length > 0 && (
+                      <p className="text-xs text-muted-foreground">{discoveredModels.length} model{discoveredModels.length === 1 ? '' : 's'} found</p>
+                    )}
                     <FormMessage />
                   </FormItem>
                 )} />

--- a/frontend/src/components/settings/OpenCodeModelsEditor.test.tsx
+++ b/frontend/src/components/settings/OpenCodeModelsEditor.test.tsx
@@ -1,8 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { OpenCodeModelsEditor } from './OpenCodeModelsEditor'
 import type { ConfigProvider, ConfigModel } from './OpenCodeModelsEditor'
+import { settingsApi } from '../../api/settings'
+
+vi.mock('../../api/settings', () => ({
+  settingsApi: {
+    discoverOpenCodeModels: vi.fn(),
+  },
+}))
 
 const mockProviders: Record<string, ConfigProvider> = {
   openai: {
@@ -348,6 +355,106 @@ describe('OpenCodeModelDialog', () => {
           })
         )
       })
+    })
+  })
+})
+
+describe('OpenCodeModelDialog — model discovery', () => {
+  const discoveryProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    onSubmit: vi.fn(),
+    availableProviders: [],
+    selectedProviderId: '',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(settingsApi.discoverOpenCodeModels).mockReset()
+  })
+
+  afterEach(() => {
+    vi.mocked(settingsApi.discoverOpenCodeModels).mockReset()
+  })
+
+  it('shows a Discover button when a new API provider has a base URL', async () => {
+    const { OpenCodeModelDialog } = await import('./OpenCodeModelDialog')
+    render(<OpenCodeModelDialog {...discoveryProps} />)
+
+    const baseUrlInput = screen.getByPlaceholderText('e.g., https://api.openai.com/v1')
+    fireEvent.change(baseUrlInput, { target: { value: 'http://localhost:1234' } })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /discover|refresh/i })).toBeInTheDocument()
+    })
+  })
+
+  it('discovers models and shows the count when Discover is clicked', async () => {
+    vi.mocked(settingsApi.discoverOpenCodeModels).mockResolvedValue({
+      models: ['gpt-4o', 'gpt-3.5-turbo'],
+      cached: false,
+    })
+    const { OpenCodeModelDialog } = await import('./OpenCodeModelDialog')
+    render(<OpenCodeModelDialog {...discoveryProps} />)
+
+    fireEvent.change(screen.getByPlaceholderText('e.g., https://api.openai.com/v1'), {
+      target: { value: 'http://localhost:1234' },
+    })
+
+    const discoverButton = await screen.findByRole('button', { name: /discover|refresh/i })
+    fireEvent.click(discoverButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 models found/i)).toBeInTheDocument()
+    })
+    expect(settingsApi.discoverOpenCodeModels).toHaveBeenCalledWith('http://localhost:1234', undefined, true)
+  })
+
+  it('auto-populates config key and display name when selecting a discovered model', async () => {
+    vi.mocked(settingsApi.discoverOpenCodeModels).mockResolvedValue({
+      models: ['gpt-4o'],
+      cached: false,
+    })
+    const { OpenCodeModelDialog } = await import('./OpenCodeModelDialog')
+    render(<OpenCodeModelDialog {...discoveryProps} />)
+
+    fireEvent.change(screen.getByPlaceholderText('e.g., https://api.openai.com/v1'), {
+      target: { value: 'http://localhost:1234' },
+    })
+
+    const discoverButton = await screen.findByRole('button', { name: /discover|refresh/i })
+    fireEvent.click(discoverButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 model found/i)).toBeInTheDocument()
+    })
+
+    const providerModelInput = screen.getByPlaceholderText('e.g., MiniMax-M2.7')
+    fireEvent.focus(providerModelInput)
+
+    const option = await screen.findByRole('button', { name: 'gpt-4o' })
+    fireEvent.click(option)
+
+    const modelIdInput = document.querySelector('input[name="modelId"]') as HTMLInputElement
+    const displayNameInput = document.querySelector('input[name="displayName"]') as HTMLInputElement
+    expect(modelIdInput).toHaveValue('gpt-4o')
+    expect(displayNameInput).toHaveValue('Gpt 4o')
+  })
+
+  it('shows an error message when discovery fails', async () => {
+    vi.mocked(settingsApi.discoverOpenCodeModels).mockRejectedValue(new Error('network error'))
+    const { OpenCodeModelDialog } = await import('./OpenCodeModelDialog')
+    render(<OpenCodeModelDialog {...discoveryProps} />)
+
+    fireEvent.change(screen.getByPlaceholderText('e.g., https://api.openai.com/v1'), {
+      target: { value: 'http://localhost:1234' },
+    })
+
+    const discoverButton = await screen.findByRole('button', { name: /discover|refresh/i })
+    fireEvent.click(discoverButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to discover models/i)).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -25,3 +25,7 @@ global.ResizeObserver = class ResizeObserver {
   unobserve() {}
   disconnect() {}
 }
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {}
+}

--- a/ocm-cli/bin/ocm.ts
+++ b/ocm-cli/bin/ocm.ts
@@ -3,7 +3,7 @@ import { basename } from 'path'
 import { readState, writeState, clearState, getStatePath, type OcmState } from '../src/state.js'
 import { getToken, setToken, deleteToken, KeychainError } from '../src/keychain.js'
 import { ManagerApi } from '../src/manager-api.js'
-import { mirrorUp, mirrorDown, prepareMirror } from '../src/mirror.js'
+import { mirrorUp, mirrorDown, mirrorUpFast, mirrorDownFast, prepareMirror, MirrorAbort } from '../src/mirror.js'
 import type { RemoteRepoSummary, MirrorProgress } from '../src/mirror.js'
 import { createProgressReporter } from '../src/progress.js'
 import { getBranchName } from '../src/local-repo.js'
@@ -23,8 +23,8 @@ Usage:
   ocm status                Show current manager URL, repo, and whether token is set
   ocm list                  List ready repos from the manager
   ocm use <repoId|name>     Attach to a specific repo and remember it as last
-  ocm push [--force] [--create] [--yes]   Mirror $PWD to the matching Manager repo (or create one)
-  ocm pull [--force]                      Mirror the matching Manager repo over $PWD
+  ocm push [--force] [--create] [--yes] [--full]   Mirror $PWD to the matching Manager repo (fast patch sync by default)
+  ocm pull [--force] [--full]                      Mirror the matching Manager repo over $PWD (fast patch sync by default)
   ocm --version             Show the installed ocm version
   ocm --help                Show this help
 `
@@ -283,20 +283,19 @@ export async function cmdPush(args: string[]): Promise<void> {
   let force = false
   let create = false
   let yes = false
+  let full = false
 
   for (const arg of args) {
     if (arg === '--force') force = true
     else if (arg === '--create') create = true
     else if (arg === '--yes') yes = true
+    else if (arg === '--full') full = true
   }
 
   const state = requireState()
   const token = requireToken(state)
   const api = new ManagerApi(state.managerUrl, token)
   const repos = await fetchRepos(state.managerUrl, token)
-
-  const progress = createProgressReporter('push')
-  const onProgress = (p: MirrorProgress) => progress.tick(p.bytesSent)
 
   const remotes: RemoteRepoSummary[] = repos.map((r) => ({
     repoId: r.repoId,
@@ -329,6 +328,8 @@ export async function cmdPush(args: string[]): Promise<void> {
       die('stdin is not a TTY; pass --yes to confirm creation')
     }
 
+    const progress = createProgressReporter('push')
+    const onProgress = (p: MirrorProgress) => progress.tick(p.bytesSent)
     const result = await mirrorUp(plan, {
       api,
       force,
@@ -338,6 +339,18 @@ export async function cmdPush(args: string[]): Promise<void> {
     progress.done()
     info(`pushed ${plan.repoRoot} -> ${result.created ? 'created' : 'updated'} (repoId=${result.repoId}, branch=${result.branch})`)
   } else if (plan.matched.length === 1) {
+    if (!full) {
+      try {
+        const result = await mirrorUpFast(plan, { api, force })
+        info(`pushed ${plan.repoRoot} -> ${plan.matched[0]!.name} via bundle (repoId=${result.repoId}, branch=${result.branch})`)
+        return
+      } catch (error) {
+        if (error instanceof MirrorAbort) throw error
+        process.stderr.write(`ocm: patch push failed; falling back to full mirror: ${error instanceof Error ? error.message : String(error)}\n`)
+      }
+    }
+    const progress = createProgressReporter('push')
+    const onProgress = (p: MirrorProgress) => progress.tick(p.bytesSent)
     const result = await mirrorUp(plan, { api, force, onProgress })
     progress.done()
     info(`pushed ${plan.repoRoot} -> ${plan.matched[0]!.name} (repoId=${result.repoId}, branch=${result.branch})`)
@@ -349,9 +362,11 @@ export async function cmdPush(args: string[]): Promise<void> {
 
 async function cmdPull(args: string[]): Promise<void> {
   let force = false
+  let full = false
 
   for (const arg of args) {
     if (arg === '--force') force = true
+    else if (arg === '--full') full = true
   }
 
   const state = requireState()
@@ -377,6 +392,16 @@ async function cmdPull(args: string[]): Promise<void> {
     die(`multiple Manager repos match origin ${plan.localOrigin}: ${names}; disambiguate with \`ocm pull <repoId>\``)
   }
 
+  if (!full) {
+    try {
+      await mirrorDownFast(plan.matched[0]!.repoId, plan.repoRoot, api, { force })
+      info(`pulled ${plan.matched[0]!.name} -> ${plan.repoRoot} via bundle`)
+      return
+    } catch (error) {
+      if (error instanceof MirrorAbort && !error.message.includes('falling back')) throw error
+      process.stderr.write(`ocm: patch pull failed; falling back to full mirror: ${error instanceof Error ? error.message : String(error)}\n`)
+    }
+  }
   const progress = createProgressReporter('pull')
   try {
     await mirrorDown(plan.matched[0]!.repoId, plan.repoRoot, api, { force, onProgress: (bytes) => progress.tick(bytes) })

--- a/ocm-cli/package.json
+++ b/ocm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-manager/ocm-cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "OpenCode Manager CLI: attach a local OpenCode TUI to a Manager-hosted repo.",
   "license": "MIT",
   "repository": {

--- a/ocm-cli/src/local-repo.ts
+++ b/ocm-cli/src/local-repo.ts
@@ -1,9 +1,18 @@
 import { spawnSync } from 'child_process'
+import { copyFileSync, existsSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
 
-function git(cwd: string, args: string[]): string | null {
-  const res = spawnSync('git', args, { cwd, encoding: 'utf-8' })
+function git(cwd: string, args: string[], env: NodeJS.ProcessEnv = process.env): string | null {
+  const res = spawnSync('git', args, { cwd, encoding: 'utf-8', env })
   if (res.status !== 0) return null
   return (res.stdout ?? '').trim()
+}
+
+function gitRaw(cwd: string, args: string[], env: NodeJS.ProcessEnv = process.env): string | null {
+  const res = spawnSync('git', args, { cwd, encoding: 'utf-8', env })
+  if (res.status !== 0) return null
+  return res.stdout ?? ''
 }
 
 export function getRepoRoot(cwd: string): string | null {
@@ -37,6 +46,36 @@ function normalizeUrl(url: string): string {
 
 export function getBranchName(dir: string): string | null {
   return git(dir, ['rev-parse', '--abbrev-ref', 'HEAD'])
+}
+
+export function getWorkingTreeDiff(dir: string): string {
+  return gitRaw(dir, ['diff', '--binary', 'HEAD', '--']) ?? ''
+}
+
+export function getHeadSha(dir: string): string | null {
+  return git(dir, ['rev-parse', 'HEAD'])
+}
+
+export function getMirrorPatch(dir: string): string {
+  const untracked = gitRaw(dir, ['ls-files', '--others', '--exclude-standard', '-z'])
+    ?.split('\0')
+    .filter(Boolean) ?? []
+  if (untracked.length === 0) return getWorkingTreeDiff(dir)
+
+  const indexPath = git(dir, ['rev-parse', '--git-path', 'index'])
+  const tempIndex = join(tmpdir(), `ocm-index-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  const env = { ...process.env, GIT_INDEX_FILE: tempIndex }
+
+  try {
+    if (indexPath && existsSync(indexPath)) {
+      copyFileSync(indexPath, tempIndex)
+    }
+    const add = spawnSync('git', ['add', '-N', '--', ...untracked], { cwd: dir, encoding: 'utf-8', env })
+    if (add.status !== 0) return getWorkingTreeDiff(dir)
+    return gitRaw(dir, ['diff', '--binary', 'HEAD', '--'], env) ?? ''
+  } finally {
+    rmSync(tempIndex, { force: true })
+  }
 }
 
 export function urlsEqual(a: string | null | undefined, b: string | null | undefined): boolean {

--- a/ocm-cli/src/local-repo.ts
+++ b/ocm-cli/src/local-repo.ts
@@ -45,7 +45,8 @@ function normalizeUrl(url: string): string {
 }
 
 export function getBranchName(dir: string): string | null {
-  return git(dir, ['rev-parse', '--abbrev-ref', 'HEAD'])
+  const branch = git(dir, ['rev-parse', '--abbrev-ref', 'HEAD'])
+  return branch && branch !== 'HEAD' ? branch : null
 }
 
 export function getWorkingTreeDiff(dir: string): string {

--- a/ocm-cli/src/manager-api.ts
+++ b/ocm-cli/src/manager-api.ts
@@ -18,6 +18,30 @@ export interface MirrorCommitResult {
   created: boolean
 }
 
+export interface MirrorPatchResult {
+  repoId: number
+  fullPath: string
+  branch: string | null
+  head: string | null
+  created: false
+  applied: true
+}
+
+export interface MirrorPatchSnapshot {
+  repoId: number
+  branch: string | null
+  head: string | null
+  patch: string
+}
+
+export interface MirrorBundleResult {
+  repoId: number
+  fullPath: string
+  branch: string | null
+  head: string | null
+  created: false
+}
+
 export class ManagerApiError extends Error {
   constructor(
     message: string,
@@ -114,5 +138,49 @@ export class ManagerApi {
 
     if (!res.ok) throw await formatErrorResponse(res, 'mirror download')
     return res.body!
+  }
+
+  async mirrorPatch(repoId: number, body: { baseHead: string | null; patch: string; force?: boolean }): Promise<MirrorPatchResult> {
+    const res = await fetch(`${this.baseUrl}/api/internal/repos/${repoId}/mirror/patch`, {
+      method: 'POST',
+      headers: { ...this.headers(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ baseHead: body.baseHead, patch: body.patch, force: body.force === true }),
+    })
+
+    if (!res.ok) throw await formatErrorResponse(res, 'mirror patch')
+    return (await res.json()) as MirrorPatchResult
+  }
+
+  async mirrorUploadBundle(repoId: number, bundle: Buffer, opts: { branch: string | null; force?: boolean }): Promise<MirrorBundleResult> {
+    const query = opts.force === true ? '?force=1' : ''
+    const headers: Record<string, string> = { ...this.headers(), 'Content-Type': 'application/octet-stream' }
+    if (opts.branch) headers['X-OCM-Branch'] = opts.branch
+    const ab = bundle.buffer.slice(bundle.byteOffset, bundle.byteOffset + bundle.byteLength)
+    const res = await fetch(`${this.baseUrl}/api/internal/repos/${repoId}/mirror/bundle${query}`, {
+      method: 'POST',
+      headers,
+      body: ab as ArrayBuffer,
+    })
+
+    if (!res.ok) throw await formatErrorResponse(res, 'mirror bundle upload')
+    return (await res.json()) as MirrorBundleResult
+  }
+
+  async mirrorDownloadBundle(repoId: number): Promise<ReadableStream<Uint8Array>> {
+    const res = await fetch(`${this.baseUrl}/api/internal/repos/${repoId}/mirror/bundle`, {
+      headers: this.headers(),
+    })
+
+    if (!res.ok) throw await formatErrorResponse(res, 'mirror bundle download')
+    return res.body!
+  }
+
+  async mirrorPatchSnapshot(repoId: number): Promise<MirrorPatchSnapshot> {
+    const res = await fetch(`${this.baseUrl}/api/internal/repos/${repoId}/mirror/patch`, {
+      headers: this.headers(),
+    })
+
+    if (!res.ok) throw await formatErrorResponse(res, 'mirror patch snapshot')
+    return (await res.json()) as MirrorPatchSnapshot
   }
 }

--- a/ocm-cli/src/mirror.ts
+++ b/ocm-cli/src/mirror.ts
@@ -4,7 +4,7 @@ import * as fsp from 'fs/promises'
 import { Readable } from 'stream'
 import { join, dirname } from 'path'
 import { tmpdir } from 'os'
-import { getRepoRoot, getOriginUrl, getDirtyPaths, urlsEqual } from './local-repo.js'
+import { getRepoRoot, getOriginUrl, getDirtyPaths, getHeadSha, getBranchName, getMirrorPatch, urlsEqual } from './local-repo.js'
 import type { ManagerApi } from './manager-api.js'
 import { ManagerApiError } from './manager-api.js'
 
@@ -301,4 +301,131 @@ export async function mirrorDown(
     await fsp.rm(staging, { recursive: true, force: true }).catch(() => {})
     throw error
   }
+}
+
+export async function mirrorUpPatch(
+  plan: MirrorPlan,
+  opts: Pick<MirrorUpOpts, 'api' | 'force'>,
+): Promise<{ repoId: number; fullPath: string; branch: string | null; head: string | null; created: false; applied: true }> {
+  const repoId = plan.matched[0]!.repoId
+  const patch = getMirrorPatch(plan.repoRoot)
+  return opts.api.mirrorPatch(repoId, { baseHead: getHeadSha(plan.repoRoot), patch, force: opts.force })
+}
+
+function applyPatch(repoRoot: string, patch: string): void {
+  if (!patch) return
+  const child = spawnSync('git', ['apply', '--binary', '--whitespace=nowarn', '-'], {
+    cwd: repoRoot,
+    input: patch,
+    encoding: 'utf-8',
+  })
+  if (child.status !== 0) {
+    const stderr = (child.stderr ?? '').trim()
+    throw new Error(`git apply failed${stderr ? `: ${stderr}` : ''}`)
+  }
+}
+
+function runGit(repoRoot: string, args: string[], input?: string): string {
+  const res = spawnSync('git', args, { cwd: repoRoot, input, encoding: 'utf-8' })
+  if (res.status !== 0) {
+    const stderr = (res.stderr ?? '').trim()
+    throw new Error(`git ${args.join(' ')} failed${stderr ? `: ${stderr}` : ''}`)
+  }
+  return res.stdout ?? ''
+}
+
+async function createLocalBundle(repoRoot: string): Promise<string> {
+  const bundlePath = join(tmpdir(), `ocm-bundle-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`)
+  runGit(repoRoot, ['bundle', 'create', bundlePath, '--all'])
+  return bundlePath
+}
+
+function importLocalBundle(repoRoot: string, bundlePath: string, branch: string | null): void {
+  runGit(repoRoot, ['fetch', bundlePath, '+refs/heads/*:refs/remotes/ocm-sync/*', '+refs/tags/*:refs/tags/*'])
+  const refs = runGit(repoRoot, ['for-each-ref', '--format=%(refname:strip=3) %(objectname)', 'refs/remotes/ocm-sync'])
+  for (const line of refs.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const firstSpace = trimmed.indexOf(' ')
+    if (firstSpace === -1) continue
+    const name = trimmed.slice(0, firstSpace)
+    const sha = trimmed.slice(firstSpace + 1)
+    runGit(repoRoot, ['update-ref', `refs/heads/${name}`, sha])
+  }
+
+  if (branch) {
+    runGit(repoRoot, ['checkout', branch])
+    const head = runGit(repoRoot, ['rev-parse', `refs/remotes/ocm-sync/${branch}`]).trim()
+    if (head) runGit(repoRoot, ['reset', '--hard', head])
+  }
+
+  const syncRefs = runGit(repoRoot, ['for-each-ref', '--format=%(refname)', 'refs/remotes/ocm-sync'])
+  for (const ref of syncRefs.split('\n').map((line) => line.trim()).filter(Boolean)) {
+    runGit(repoRoot, ['update-ref', '-d', ref])
+  }
+}
+
+async function writeBundleStream(repoId: number, api: ManagerApi): Promise<string> {
+  const bundlePath = join(tmpdir(), `ocm-bundle-down-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`)
+  const stream = await api.mirrorDownloadBundle(repoId)
+  const chunks: Buffer[] = []
+  for await (const chunk of Readable.fromWeb(stream as unknown as Parameters<typeof Readable.fromWeb>[0]) as AsyncIterable<Buffer>) {
+    chunks.push(Buffer.from(chunk))
+  }
+  await fsp.writeFile(bundlePath, Buffer.concat(chunks))
+  return bundlePath
+}
+
+export async function mirrorUpFast(
+  plan: MirrorPlan,
+  opts: Pick<MirrorUpOpts, 'api' | 'force'>,
+): Promise<{ repoId: number; branch: string | null; head: string | null; created: false }> {
+  const repoId = plan.matched[0]!.repoId
+  const bundlePath = await createLocalBundle(plan.repoRoot)
+  try {
+    const bundle = await fsp.readFile(bundlePath)
+    await opts.api.mirrorUploadBundle(repoId, bundle, { branch: getBranchName(plan.repoRoot), force: opts.force })
+    const patchResult = await mirrorUpPatch(plan, opts)
+    return { repoId: patchResult.repoId, branch: patchResult.branch, head: patchResult.head, created: false }
+  } finally {
+    await fsp.rm(bundlePath, { force: true }).catch(() => {})
+  }
+}
+
+export async function mirrorDownFast(
+  repoId: number,
+  repoRoot: string,
+  api: ManagerApi,
+  opts: { force: boolean } = { force: false },
+): Promise<void> {
+  if (!opts.force && getDirtyPaths(repoRoot).size > 0) {
+    throw new MirrorAbort('working tree has uncommitted changes; rerun with --force')
+  }
+
+  const snapshot = await api.mirrorPatchSnapshot(repoId)
+  const bundlePath = await writeBundleStream(repoId, api)
+  try {
+    importLocalBundle(repoRoot, bundlePath, snapshot.branch)
+    applyPatch(repoRoot, snapshot.patch)
+  } finally {
+    await fsp.rm(bundlePath, { force: true }).catch(() => {})
+  }
+}
+
+export async function mirrorDownPatch(
+  repoId: number,
+  repoRoot: string,
+  api: ManagerApi,
+  opts: { force: boolean } = { force: false },
+): Promise<void> {
+  if (!opts.force && getDirtyPaths(repoRoot).size > 0) {
+    throw new MirrorAbort('working tree has uncommitted changes; rerun with --force')
+  }
+
+  const snapshot = await api.mirrorPatchSnapshot(repoId)
+  const localHead = getHeadSha(repoRoot)
+  if (snapshot.head && localHead && snapshot.head !== localHead) {
+    throw new MirrorAbort('local HEAD differs from Manager HEAD; falling back to full mirror')
+  }
+  applyPatch(repoRoot, snapshot.patch)
 }

--- a/ocm-cli/src/mirror.ts
+++ b/ocm-cli/src/mirror.ts
@@ -349,6 +349,7 @@ function importLocalBundle(repoRoot: string, bundlePath: string, branch: string 
     const firstSpace = trimmed.indexOf(' ')
     if (firstSpace === -1) continue
     const name = trimmed.slice(0, firstSpace)
+    if (name === 'HEAD') continue
     const sha = trimmed.slice(firstSpace + 1)
     runGit(repoRoot, ['update-ref', `refs/heads/${name}`, sha])
   }

--- a/ocm-cli/test/mirror.test.ts
+++ b/ocm-cli/test/mirror.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'os'
 import { randomBytes } from 'crypto'
 import { spawnSync, execSync } from 'child_process'
 import { prepareMirror, MirrorAbort, mirrorDown, mirrorDownPatch, mirrorUp, mirrorUpPatch } from '../src/mirror'
+import { getBranchName } from '../src/local-repo'
 
 describe('prepareMirror', () => {
   let tmpDir: string
@@ -64,6 +65,33 @@ describe('prepareMirror', () => {
     expect(plan.matched).toHaveLength(1)
     expect(plan.matched[0]!.repoId).toBe(1)
     expect(plan.localOrigin).toContain('me/repo')
+  })
+})
+
+describe('local repo branch detection', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'local-repo-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('treats detached HEAD as no branch', () => {
+    const repoRoot = join(tmpDir, 'detached')
+    mkdirSync(repoRoot)
+    spawnSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: repoRoot, stdio: 'ignore' })
+    writeFileSync(join(repoRoot, 'tracked.txt'), 'content\n')
+    spawnSync('git', ['add', 'tracked.txt'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['commit', '-m', 'initial'], { cwd: repoRoot, stdio: 'ignore' })
+    const head = execSync('git rev-parse HEAD', { cwd: repoRoot, encoding: 'utf-8' }).trim()
+    spawnSync('git', ['checkout', head], { cwd: repoRoot, stdio: 'ignore' })
+
+    expect(getBranchName(repoRoot)).toBeNull()
   })
 })
 

--- a/ocm-cli/test/mirror.test.ts
+++ b/ocm-cli/test/mirror.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { randomBytes } from 'crypto'
 import { spawnSync, execSync } from 'child_process'
-import { prepareMirror, MirrorAbort, mirrorDown, mirrorUp } from '../src/mirror'
+import { prepareMirror, MirrorAbort, mirrorDown, mirrorDownPatch, mirrorUp, mirrorUpPatch } from '../src/mirror'
 
 describe('prepareMirror', () => {
   let tmpDir: string
@@ -537,5 +537,63 @@ describe('mirrorUp chunked upload', () => {
     const combined = Buffer.concat(ctx.partsReceived)
     expect(combined[0]).toBe(0x1f)
     expect(combined[1]).toBe(0x8b)
+  })
+})
+
+describe('mirror patch helpers', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mirror-diff-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('pushes a local working tree patch through the manager API', async () => {
+    const repoRoot = join(tmpDir, 'repo-local-diff')
+    mkdirSync(repoRoot)
+    spawnSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: repoRoot, stdio: 'ignore' })
+    writeFileSync(join(repoRoot, 'tracked.txt'), 'before\n')
+    spawnSync('git', ['add', 'tracked.txt'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['commit', '-m', 'initial'], { cwd: repoRoot, stdio: 'ignore' })
+    writeFileSync(join(repoRoot, 'tracked.txt'), 'after\n')
+
+    const api = {
+      mirrorPatch: vi.fn().mockResolvedValue({ repoId: 1, fullPath: '/tmp/remote', branch: 'main', head: 'abc', created: false, applied: true }),
+    }
+
+    await mirrorUpPatch({
+      repoRoot,
+      localOrigin: 'https://github.com/test/repo.git',
+      matched: [{ repoId: 1, name: 'test-repo', originUrl: 'https://github.com/test/repo.git', branch: 'main' }],
+    }, { api: api as any, force: false })
+
+    expect(api.mirrorPatch).toHaveBeenCalledTimes(1)
+    const body = api.mirrorPatch.mock.calls[0]![1]
+    expect(body.patch).toContain('diff --git a/tracked.txt b/tracked.txt')
+    expect(body.patch).toContain('-before')
+    expect(body.patch).toContain('+after')
+  })
+
+  it('applies a manager patch during pull patch mode', async () => {
+    const repoRoot = join(tmpDir, 'repo-remote-diff')
+    mkdirSync(repoRoot)
+    spawnSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: repoRoot, stdio: 'ignore' })
+    writeFileSync(join(repoRoot, 'tracked.txt'), 'before\n')
+    spawnSync('git', ['add', 'tracked.txt'], { cwd: repoRoot, stdio: 'ignore' })
+    spawnSync('git', ['commit', '-m', 'initial'], { cwd: repoRoot, stdio: 'ignore' })
+    const head = execSync('git rev-parse HEAD', { cwd: repoRoot, encoding: 'utf-8' }).trim()
+    const patch = 'diff --git a/tracked.txt b/tracked.txt\nindex 6e58d95..7c6cae9 100644\n--- a/tracked.txt\n+++ b/tracked.txt\n@@ -1 +1 @@\n-before\n+after\n'
+    const api = { mirrorPatchSnapshot: vi.fn().mockResolvedValue({ repoId: 1, branch: 'main', head, patch }) }
+
+    await mirrorDownPatch(1, repoRoot, api as any, { force: false })
+
+    expect(readFileSync(join(repoRoot, 'tracked.txt'), 'utf-8')).toBe('after\n')
   })
 })


### PR DESCRIPTION
Adds Git bundle-based fast sync for OCM push/pull.

Changes:
- Default OCM push/pull now sync committed refs with git bundles
- Dirty working tree changes sync with binary patches after bundle import
- Full tar mirror remains available through --full and as fallback
- Backend bundle upload/download routes import and export branches/tags
- Tests cover bundle import/download and dirty patch sync

Validation:
- pnpm --filter ocm-cli test -- mirror.test.ts
- pnpm --filter backend test -- repo-mirror.test.ts
- pnpm lint