### PR TITLE
fix: consolidate discovery-cache, batch bundle refs, remove dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For OAuth, Passkeys, Push Notifications (VAPID), and advanced configuration, see
 
 ## `ocm` CLI
 
-OpenCode Manager ships an `ocm` CLI (from `ocm-cli/`) that attaches your local OpenCode TUI to a repo hosted on the Manager. It lists ready repos, attaches via the Manager's `/api/opencode-proxy` (so prompts run on the Manager's filesystem against a single shared OpenCode server), and can tarball-sync the working tree up or down with `ocm push` / `ocm pull`. Running `ocm` inside a local clone auto-detects the matching Manager repo by `origin` URL.
+OpenCode Manager ships an `ocm` CLI (from `ocm-cli/`) that attaches your local OpenCode TUI to a repo hosted on the Manager. It lists ready repos, attaches via the Manager's `/api/opencode-proxy` (so prompts run on the Manager's filesystem against a single shared OpenCode server), and can sync the working tree up or down with `ocm push` / `ocm pull` (fast git bundle + working-tree patch by default; pass `--full` for the legacy tarball mirror). Running `ocm` inside a local clone auto-detects the matching Manager repo by `origin` URL.
 
 See the [`ocm` CLI guide](docs/ocm-cli.md) for setup and commands.
 

--- a/backend/src/routes/internal/repo-mirror.ts
+++ b/backend/src/routes/internal/repo-mirror.ts
@@ -19,6 +19,7 @@ import {
   readUploadMeta,
   deleteUploadSession,
   getPartPath,
+  getStagingRoot,
   extractPartsToStaging,
   atomicSwapIntoPlace,
   carryOverIgnoredFiles,
@@ -96,6 +97,7 @@ async function applyMirrorPatch(fullPath: string, patch: string): Promise<void> 
 async function importBundle(fullPath: string, bundlePath: string, branch: string | null): Promise<void> {
   await gitRaw(fullPath, ['fetch', bundlePath, '+refs/heads/*:refs/remotes/ocm-sync/*', '+refs/tags/*:refs/tags/*'])
   const refs = await gitRaw(fullPath, ['for-each-ref', '--format=%(refname:strip=3) %(objectname)', 'refs/remotes/ocm-sync'])
+  const updates: string[] = []
   for (const line of refs.split('\n')) {
     const trimmed = line.trim()
     if (!trimmed) continue
@@ -104,7 +106,10 @@ async function importBundle(fullPath: string, bundlePath: string, branch: string
     const name = trimmed.slice(0, firstSpace)
     if (name === 'HEAD') continue
     const sha = trimmed.slice(firstSpace + 1)
-    await gitRaw(fullPath, ['update-ref', `refs/heads/${name}`, sha])
+    updates.push(`update refs/heads/${name} ${sha}\n`)
+  }
+  if (updates.length > 0) {
+    await gitRaw(fullPath, ['update-ref', '--stdin'], process.env, updates.join(''))
   }
 
   if (branch) {
@@ -113,17 +118,15 @@ async function importBundle(fullPath: string, bundlePath: string, branch: string
     if (head) await gitRaw(fullPath, ['reset', '--hard', head])
   }
 
-  await gitRaw(fullPath, ['for-each-ref', '--format=%(refname)', 'refs/remotes/ocm-sync'])
-    .then(async (out) => {
-      for (const ref of out.split('\n').map((line) => line.trim()).filter(Boolean)) {
-        await gitRaw(fullPath, ['update-ref', '-d', ref])
-      }
-    })
-    .catch(() => {})
+  const syncRefsOut = await gitRaw(fullPath, ['for-each-ref', '--format=%(refname)', 'refs/remotes/ocm-sync']).catch(() => '')
+  const deletes = syncRefsOut.split('\n').map((l) => l.trim()).filter(Boolean).map((ref) => `delete ${ref}\n`)
+  if (deletes.length > 0) {
+    await gitRaw(fullPath, ['update-ref', '--stdin'], process.env, deletes.join('')).catch(() => {})
+  }
 }
 
 async function createBundle(fullPath: string): Promise<string> {
-  const stagingRoot = join(getReposPath(), '.ocm-staging')
+  const stagingRoot = getStagingRoot()
   mkdirSync(stagingRoot, { recursive: true })
   const bundleDir = mkdtempSync(join(stagingRoot, 'bundle-'))
   const bundlePath = join(bundleDir, 'repo.bundle')
@@ -338,7 +341,7 @@ export function createInternalRepoMirrorRoutes(db: Database) {
     const rawBody = c.req.raw.body
     if (!rawBody) return c.json({ error: 'no body provided' }, 400)
 
-    const stagingRoot = join(getReposPath(), '.ocm-staging')
+    const stagingRoot = getStagingRoot()
     mkdirSync(stagingRoot, { recursive: true })
     const bundleDir = mkdtempSync(join(stagingRoot, 'bundle-upload-'))
     const bundlePath = join(bundleDir, 'repo.bundle')
@@ -460,7 +463,7 @@ export function createInternalRepoMirrorRoutes(db: Database) {
     try {
       const ignored = await gitOut(fullPath, ['ls-files', '--others', '--ignored', '--exclude-standard', '--directory'])
       if (ignored.trim()) {
-        const excludeParent = join(getReposPath(), '.ocm-staging')
+        const excludeParent = getStagingRoot()
         mkdirSync(excludeParent, { recursive: true })
         ignoreFile = mkdtempSync(join(excludeParent, 'exclude-'))
         writeFileSync(join(ignoreFile, '.gitignore'), ignored)

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -25,11 +25,7 @@ import {
 } from '@opencode-manager/shared'
 import { logger } from '../utils/logger'
 import {
-  fetchAvailableModels,
-  generateDiscoveryCacheKey,
-  getCachedDiscovery,
-  cacheDiscovery,
-  ensureDiscoveryCacheDir,
+  discoverModelsCached,
 } from '../utils/discovery-cache'
 import { opencodeServerManager, ConfigReloadError } from '../services/opencode-single-server'
 import { getOrCreateInternalToken, rotateInternalToken } from '../services/internal-token'
@@ -1904,22 +1900,17 @@ export function createSettingsRoutes(db: Database, gitAuthService: GitAuthServic
       }
 
       const trimmedBaseUrl = baseUrl.trim()
-      const cacheKey = generateDiscoveryCacheKey(trimmedBaseUrl, apiKey, 'opencode-models')
 
-      if (!forceRefresh) {
-        const cachedModels = await getCachedDiscovery<string[]>(cacheKey)
-        if (cachedModels) {
-          return c.json({ models: cachedModels, cached: true })
-        }
-      }
+      const { models, cached } = await discoverModelsCached({
+        baseUrl: trimmedBaseUrl,
+        apiKey,
+        type: 'opencode-models',
+        filterPattern: /.*/,
+        defaultModels: [],
+        forceRefresh,
+      })
 
-      await ensureDiscoveryCacheDir()
-      logger.info(`Discovering OpenCode models from ${trimmedBaseUrl}`)
-
-      const models = await fetchAvailableModels(trimmedBaseUrl, apiKey, /.*/, [])
-      await cacheDiscovery(cacheKey, models)
-
-      return c.json({ models, cached: false })
+      return c.json({ models, cached })
     } catch (error) {
       logger.error('Failed to discover OpenCode models:', error)
       return c.json({ error: 'Failed to discover models' }, 500)

--- a/backend/src/routes/stt.ts
+++ b/backend/src/routes/stt.ts
@@ -4,11 +4,7 @@ import { SettingsService } from '../services/settings'
 import { logger } from '../utils/logger'
 import {
   normalizeToBaseUrl,
-  ensureDiscoveryCacheDir,
-  getCachedDiscovery,
-  cacheDiscovery,
-  generateDiscoveryCacheKey,
-  fetchAvailableModels,
+  discoverModelsCached,
 } from '../utils/discovery-cache'
 import { type STTConfig } from '@opencode-manager/shared'
 
@@ -142,37 +138,26 @@ export function createSTTRoutes(db: Database) {
         return c.json({ error: 'STT not configured' }, 400)
       }
 
-      const cacheKey = generateDiscoveryCacheKey(sttConfig.endpoint, sttConfig.apiKey, 'models')
+      const { models, cached } = await discoverModelsCached({
+        baseUrl: sttConfig.endpoint,
+        apiKey: sttConfig.apiKey,
+        type: 'models',
+        filterPattern: /whisper|transcri/,
+        defaultModels: ['whisper-1'],
+        forceRefresh,
+      })
 
-      if (!forceRefresh) {
-        const cachedModels = await getCachedDiscovery<string[]>(cacheKey)
-        if (cachedModels) {
-          logger.info(`STT models cache hit for user ${userId}`)
-          return c.json({ models: cachedModels, cached: true })
-        }
+      if (!cached) {
+        await settingsService.updateSettings({
+          stt: {
+            ...sttConfig,
+            availableModels: models,
+            lastModelsFetch: Date.now(),
+          } as STTConfig,
+        }, userId)
       }
 
-      await ensureDiscoveryCacheDir()
-      logger.info(`Fetching STT models for user ${userId}`)
-
-      const models = await fetchAvailableModels(
-        sttConfig.endpoint,
-        sttConfig.apiKey,
-        /whisper|transcri/,
-        ['whisper-1'],
-      )
-      await cacheDiscovery(cacheKey, models)
-
-      await settingsService.updateSettings({
-        stt: {
-          ...sttConfig,
-          availableModels: models,
-          lastModelsFetch: Date.now()
-        } as STTConfig
-      }, userId)
-
-      logger.info(`Fetched ${models.length} STT models`)
-      return c.json({ models, cached: false })
+      return c.json({ models, cached })
     } catch (error) {
       logger.error('Failed to fetch STT models:', error)
       return c.json({ error: 'Failed to fetch models' }, 500)

--- a/backend/src/routes/tts.ts
+++ b/backend/src/routes/tts.ts
@@ -9,11 +9,11 @@ import { logger } from '../utils/logger'
 import { getWorkspacePath } from '@opencode-manager/shared/config/env'
 import {
   normalizeToBaseUrl,
+  discoverModelsCached,
   ensureDiscoveryCacheDir,
   getCachedDiscovery,
   cacheDiscovery,
   generateDiscoveryCacheKey,
-  fetchAvailableModels,
 } from '../utils/discovery-cache'
 
 const TTS_CACHE_DIR = join(getWorkspacePath(), 'cache', 'tts')
@@ -357,40 +357,26 @@ export function createTTSRoutes(db: Database) {
         return c.json({ error: 'TTS not configured' }, 400)
       }
       
-      const cacheKey = generateDiscoveryCacheKey(ttsConfig.endpoint, ttsConfig.apiKey, 'models')
-      
-      // Check cache first (unless force refresh)
-      if (!forceRefresh) {
-        const cachedModels = await getCachedDiscovery<string[]>(cacheKey)
-        if (cachedModels) {
-          logger.info(`Models cache hit for user ${userId}`)
-          return c.json({ models: cachedModels, cached: true })
-        }
+      const { models, cached } = await discoverModelsCached({
+        baseUrl: ttsConfig.endpoint,
+        apiKey: ttsConfig.apiKey,
+        type: 'models',
+        filterPattern: /tts|audio|speech/,
+        defaultModels: ['tts-1', 'tts-1-hd'],
+        forceRefresh,
+      })
+
+      if (!cached) {
+        await settingsService.updateSettings({
+          tts: {
+            ...ttsConfig,
+            availableModels: models,
+            lastModelsFetch: Date.now(),
+          },
+        }, userId)
       }
-      
-      // Fetch from API
-      await ensureDiscoveryCacheDir()
-      logger.info(`Fetching TTS models for user ${userId}`)
-      
-      const models = await fetchAvailableModels(
-        ttsConfig.endpoint,
-        ttsConfig.apiKey,
-        /tts|audio|speech/,
-        ['tts-1', 'tts-1-hd'],
-      )
-      await cacheDiscovery(cacheKey, models)
-      
-      // Update user preferences with available models
-      await settingsService.updateSettings({
-        tts: {
-          ...ttsConfig,
-          availableModels: models,
-          lastModelsFetch: Date.now()
-        }
-      }, userId)
-      
-      logger.info(`Fetched ${models.length} TTS models`)
-      return c.json({ models, cached: false })
+
+      return c.json({ models, cached })
     } catch (error) {
       logger.error('Failed to fetch TTS models:', error)
       return c.json({ error: 'Failed to fetch models' }, 500)

--- a/backend/src/routes/tts.ts
+++ b/backend/src/routes/tts.ts
@@ -10,10 +10,7 @@ import { getWorkspacePath } from '@opencode-manager/shared/config/env'
 import {
   normalizeToBaseUrl,
   discoverModelsCached,
-  ensureDiscoveryCacheDir,
-  getCachedDiscovery,
-  cacheDiscovery,
-  generateDiscoveryCacheKey,
+  discoverCached,
 } from '../utils/discovery-cache'
 
 const TTS_CACHE_DIR = join(getWorkspacePath(), 'cache', 'tts')
@@ -396,35 +393,25 @@ export function createTTSRoutes(db: Database) {
         return c.json({ error: 'TTS not configured' }, 400)
       }
       
-      const cacheKey = generateDiscoveryCacheKey(ttsConfig.endpoint, ttsConfig.apiKey, 'voices')
-      
-      // Check cache first (unless force refresh)
-      if (!forceRefresh) {
-        const cachedVoices = await getCachedDiscovery<string[]>(cacheKey)
-        if (cachedVoices) {
-          logger.info(`Voices cache hit for user ${userId}`)
-          return c.json({ voices: cachedVoices, cached: true })
-        }
+      const { value: voices, cached } = await discoverCached({
+        baseUrl: ttsConfig.endpoint,
+        apiKey: ttsConfig.apiKey,
+        type: 'voices',
+        forceRefresh,
+        fetcher: () => fetchAvailableVoices(ttsConfig.endpoint, ttsConfig.apiKey),
+      })
+
+      if (!cached) {
+        await settingsService.updateSettings({
+          tts: {
+            ...ttsConfig,
+            availableVoices: voices,
+            lastVoicesFetch: Date.now(),
+          },
+        }, userId)
       }
-      
-      // Fetch from API
-      await ensureDiscoveryCacheDir()
-      logger.info(`Fetching TTS voices for user ${userId}`)
-      
-      const voices = await fetchAvailableVoices(ttsConfig.endpoint, ttsConfig.apiKey)
-      await cacheDiscovery(cacheKey, voices)
-      
-      // Update user preferences with available voices
-      await settingsService.updateSettings({
-        tts: {
-          ...ttsConfig,
-          availableVoices: voices,
-          lastVoicesFetch: Date.now()
-        }
-      }, userId)
-      
-      logger.info(`Fetched ${voices.length} TTS voices`)
-      return c.json({ voices, cached: false })
+
+      return c.json({ voices, cached })
     } catch (error) {
       logger.error('Failed to fetch TTS voices:', error)
       return c.json({ error: 'Failed to fetch voices' }, 500)

--- a/backend/src/utils/discovery-cache.ts
+++ b/backend/src/utils/discovery-cache.ts
@@ -16,11 +16,11 @@ export function normalizeToBaseUrl(endpoint: string): string {
     .replace(/\/$/, '')
 }
 
-export async function ensureDiscoveryCacheDir(): Promise<void> {
+async function ensureDiscoveryCacheDir(): Promise<void> {
   await mkdir(DISCOVERY_CACHE_DIR, { recursive: true })
 }
 
-export async function getCachedDiscovery<T>(cacheKey: string): Promise<T | null> {
+async function getCachedDiscovery<T>(cacheKey: string): Promise<T | null> {
   try {
     const filePath = join(DISCOVERY_CACHE_DIR, `${cacheKey}.json`)
     const fileStat = await stat(filePath)
@@ -37,7 +37,7 @@ export async function getCachedDiscovery<T>(cacheKey: string): Promise<T | null>
   }
 }
 
-export async function cacheDiscovery<T>(cacheKey: string, data: T): Promise<void> {
+async function cacheDiscovery<T>(cacheKey: string, data: T): Promise<void> {
   try {
     await ensureDiscoveryCacheDir()
     const filePath = join(DISCOVERY_CACHE_DIR, `${cacheKey}.json`)
@@ -47,13 +47,13 @@ export async function cacheDiscovery<T>(cacheKey: string, data: T): Promise<void
   }
 }
 
-export function generateDiscoveryCacheKey(baseUrl: string, apiKey: string, type: string): string {
+function generateDiscoveryCacheKey(baseUrl: string, apiKey: string, type: string): string {
   const hash = createHash('sha256')
   hash.update(`${baseUrl}|${apiKey}|${type}`)
   return hash.digest('hex')
 }
 
-export async function fetchAvailableModels(
+async function fetchAvailableModels(
   baseUrl: string,
   apiKey: string,
   filterPattern: RegExp,
@@ -104,6 +104,29 @@ export async function fetchAvailableModels(
   return defaultModels
 }
 
+export async function discoverCached<T>(opts: {
+  baseUrl: string
+  apiKey: string
+  type: string
+  forceRefresh: boolean
+  fetcher: () => Promise<T>
+}): Promise<{ value: T; cached: boolean }> {
+  const cacheKey = generateDiscoveryCacheKey(opts.baseUrl, opts.apiKey, opts.type)
+
+  if (!opts.forceRefresh) {
+    const cached = await getCachedDiscovery<T>(cacheKey)
+    if (cached) return { value: cached, cached: true }
+  }
+
+  await ensureDiscoveryCacheDir()
+  logger.info(`Discovering ${opts.type} from ${opts.baseUrl}`)
+
+  const value = await opts.fetcher()
+  await cacheDiscovery(cacheKey, value)
+
+  return { value, cached: false }
+}
+
 export async function discoverModelsCached(opts: {
   baseUrl: string
   apiKey: string
@@ -112,18 +135,12 @@ export async function discoverModelsCached(opts: {
   defaultModels: string[]
   forceRefresh: boolean
 }): Promise<{ models: string[]; cached: boolean }> {
-  const cacheKey = generateDiscoveryCacheKey(opts.baseUrl, opts.apiKey, opts.type)
-
-  if (!opts.forceRefresh) {
-    const cached = await getCachedDiscovery<string[]>(cacheKey)
-    if (cached) return { models: cached, cached: true }
-  }
-
-  await ensureDiscoveryCacheDir()
-  logger.info(`Discovering ${opts.type} models from ${opts.baseUrl}`)
-
-  const models = await fetchAvailableModels(opts.baseUrl, opts.apiKey, opts.filterPattern, opts.defaultModels)
-  await cacheDiscovery(cacheKey, models)
-
-  return { models, cached: false }
+  const { value, cached } = await discoverCached({
+    baseUrl: opts.baseUrl,
+    apiKey: opts.apiKey,
+    type: opts.type,
+    forceRefresh: opts.forceRefresh,
+    fetcher: () => fetchAvailableModels(opts.baseUrl, opts.apiKey, opts.filterPattern, opts.defaultModels),
+  })
+  return { models: value, cached }
 }

--- a/backend/src/utils/discovery-cache.ts
+++ b/backend/src/utils/discovery-cache.ts
@@ -103,3 +103,27 @@ export async function fetchAvailableModels(
 
   return defaultModels
 }
+
+export async function discoverModelsCached(opts: {
+  baseUrl: string
+  apiKey: string
+  type: string
+  filterPattern: RegExp
+  defaultModels: string[]
+  forceRefresh: boolean
+}): Promise<{ models: string[]; cached: boolean }> {
+  const cacheKey = generateDiscoveryCacheKey(opts.baseUrl, opts.apiKey, opts.type)
+
+  if (!opts.forceRefresh) {
+    const cached = await getCachedDiscovery<string[]>(cacheKey)
+    if (cached) return { models: cached, cached: true }
+  }
+
+  await ensureDiscoveryCacheDir()
+  logger.info(`Discovering ${opts.type} models from ${opts.baseUrl}`)
+
+  const models = await fetchAvailableModels(opts.baseUrl, opts.apiKey, opts.filterPattern, opts.defaultModels)
+  await cacheDiscovery(cacheKey, models)
+
+  return { models, cached: false }
+}

--- a/docs/ocm-cli.md
+++ b/docs/ocm-cli.md
@@ -96,8 +96,8 @@ ocm logout                Forget saved token (Keychain) and state
 ocm status                Show current manager URL, repo, and whether token is set
 ocm list                  List ready repos from the manager
 ocm use <repoId|name>     Attach to a specific repo and remember it as last
-ocm push [--force] [--create] [--yes]   Mirror $PWD to the matching Manager repo
-ocm pull [--force]                      Mirror the matching Manager repo over $PWD
+ocm push [--force] [--create] [--yes] [--full]   Mirror $PWD to the matching Manager repo (fast bundle/patch sync by default)
+ocm pull [--force] [--full]                      Mirror the matching Manager repo over $PWD (fast bundle/patch sync by default)
 ocm --help                Show this help
 ```
 
@@ -125,7 +125,9 @@ The child takes over the terminal (`stdio: inherit`); closing the TUI exits `ocm
 
 ### Mirror commands
 
-`ocm push` tarballs `$PWD` (skipping `node_modules`, `dist`, `.next`, `.venv`, `__pycache__`, `.turbo`, and anything matched by `.gitignore`) and streams it to the Manager. `ocm pull` does the reverse.
+`ocm push` uses a fast git bundle + working-tree patch by default to sync `$PWD` to the matching Manager repo. Pass `--full` to fall back to the legacy tarball mirror (skipping `node_modules`, `dist`, `.next`, `.venv`, `__pycache__`, `.turbo`, and anything matched by `.gitignore`). The tarball fallback is also used automatically when the fast path fails.
+
+`ocm pull` uses a fast git bundle + working-tree patch by default to sync the matching Manager repo over `$PWD`. Pass `--full` to fall back to the legacy tarball mirror (also used automatically when the fast path fails).
 
 - `--force` skips the dirty-working-tree check on `pull` and the safety bail on `push`.
 - `--create` (on `push`) creates a new Manager repo when no `origin` match is found.

--- a/frontend/src/components/settings/OpenCodeModelDialog.tsx
+++ b/frontend/src/components/settings/OpenCodeModelDialog.tsx
@@ -418,6 +418,11 @@ export function OpenCodeModelDialog({
     return availableProviders.map((p: string) => ({ value: p, label: existingProviders?.[p]?.name || p }))
   }, [availableProviders, existingProviders])
 
+  const discoveredModelOptions = useMemo(
+    () => discoveredModels.map((m) => ({ value: m, label: m })),
+    [discoveredModels],
+  )
+
   const isEditing = !!editingModel
 
   if (!open) return null
@@ -575,7 +580,7 @@ export function OpenCodeModelDialog({
                             handleDiscoveredModelSelect(value)
                           }
                         }}
-                        options={discoveredModels.map((m) => ({ value: m, label: m }))}
+                        options={discoveredModelOptions}
                         placeholder="e.g., MiniMax-M2.7"
                         disabled={isLoadingModels}
                         allowCustomValue={true}

--- a/ocm-cli/README.md
+++ b/ocm-cli/README.md
@@ -34,8 +34,8 @@ ocm
 ocm status
 ocm list
 ocm use <repoId|name>
-ocm push [--force] [--create] [--yes]
-ocm pull [--force]
+ocm push [--force] [--create] [--yes] [--full]
+ocm pull [--force] [--full]
 ocm logout
 ```
 
@@ -47,11 +47,15 @@ to local `opencode`.
 `ocm use <repoId|name>` selects a Manager repo, remembers it as the last repo,
 and attaches OpenCode to it.
 
-`ocm push` uploads the current git repo to the matching Manager repo. Use
+`ocm push` syncs the current git repo to the matching Manager repo using a fast
+git bundle + working-tree patch by default. Pass `--full` to fall back to the
+legacy tarball mirror (also used automatically when the fast path fails). Use
 `--create` to create a Manager repo when no origin match exists, and `--yes` to
 confirm creation in non-interactive shells.
 
-`ocm pull` replaces the current working tree with the matching Manager repo. It
+`ocm pull` syncs the matching Manager repo over the current working tree using a
+fast git bundle + working-tree patch by default. Pass `--full` to fall back to
+the legacy tarball mirror (also used automatically when the fast path fails). It
 refuses to overwrite uncommitted local changes unless `--force` is passed.
 
 ## OpenCode plugin

--- a/ocm-cli/src/local-repo.ts
+++ b/ocm-cli/src/local-repo.ts
@@ -15,6 +15,20 @@ function gitRaw(cwd: string, args: string[], env: NodeJS.ProcessEnv = process.en
   return res.stdout ?? ''
 }
 
+export function runGit(
+  cwd: string,
+  args: string[],
+  input?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const res = spawnSync('git', args, { cwd, input, encoding: 'utf-8', env })
+  if (res.status !== 0) {
+    const stderr = (res.stderr ?? '').trim()
+    throw new Error(`git ${args.join(' ')} failed${stderr ? `: ${stderr}` : ''}`)
+  }
+  return res.stdout ?? ''
+}
+
 export function getRepoRoot(cwd: string): string | null {
   return git(cwd, ['rev-parse', '--show-toplevel'])
 }
@@ -49,7 +63,7 @@ export function getBranchName(dir: string): string | null {
   return branch && branch !== 'HEAD' ? branch : null
 }
 
-export function getWorkingTreeDiff(dir: string): string {
+function getWorkingTreeDiff(dir: string): string {
   return gitRaw(dir, ['diff', '--binary', 'HEAD', '--']) ?? ''
 }
 

--- a/ocm-cli/src/local-repo.ts
+++ b/ocm-cli/src/local-repo.ts
@@ -1,16 +1,24 @@
-import { spawnSync } from 'child_process'
+import { spawnSync, type SpawnSyncReturns } from 'child_process'
 import { copyFileSync, existsSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
+function spawnGit(
+  cwd: string,
+  args: string[],
+  opts: { input?: string; env?: NodeJS.ProcessEnv } = {},
+): SpawnSyncReturns<string> {
+  return spawnSync('git', args, { cwd, input: opts.input, encoding: 'utf-8', env: opts.env ?? process.env })
+}
+
 function git(cwd: string, args: string[], env: NodeJS.ProcessEnv = process.env): string | null {
-  const res = spawnSync('git', args, { cwd, encoding: 'utf-8', env })
+  const res = spawnGit(cwd, args, { env })
   if (res.status !== 0) return null
   return (res.stdout ?? '').trim()
 }
 
 function gitRaw(cwd: string, args: string[], env: NodeJS.ProcessEnv = process.env): string | null {
-  const res = spawnSync('git', args, { cwd, encoding: 'utf-8', env })
+  const res = spawnGit(cwd, args, { env })
   if (res.status !== 0) return null
   return res.stdout ?? ''
 }
@@ -21,7 +29,7 @@ export function runGit(
   input?: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  const res = spawnSync('git', args, { cwd, input, encoding: 'utf-8', env })
+  const res = spawnGit(cwd, args, { input, env })
   if (res.status !== 0) {
     const stderr = (res.stderr ?? '').trim()
     throw new Error(`git ${args.join(' ')} failed${stderr ? `: ${stderr}` : ''}`)

--- a/ocm-cli/src/manager-api.ts
+++ b/ocm-cli/src/manager-api.ts
@@ -155,11 +155,11 @@ export class ManagerApi {
     const query = opts.force === true ? '?force=1' : ''
     const headers: Record<string, string> = { ...this.headers(), 'Content-Type': 'application/octet-stream' }
     if (opts.branch) headers['X-OCM-Branch'] = opts.branch
-    const ab = bundle.buffer.slice(bundle.byteOffset, bundle.byteOffset + bundle.byteLength)
+    const body = new Uint8Array(bundle.buffer, bundle.byteOffset, bundle.byteLength)
     const res = await fetch(`${this.baseUrl}/api/internal/repos/${repoId}/mirror/bundle${query}`, {
       method: 'POST',
       headers,
-      body: ab as ArrayBuffer,
+      body: body as BodyInit,
     })
 
     if (!res.ok) throw await formatErrorResponse(res, 'mirror bundle upload')

--- a/ocm-cli/src/mirror.ts
+++ b/ocm-cli/src/mirror.ts
@@ -1,10 +1,11 @@
 import { spawnSync, spawn } from 'child_process'
-import { existsSync } from 'fs'
+import { createWriteStream, existsSync } from 'fs'
 import * as fsp from 'fs/promises'
 import { Readable } from 'stream'
+import { pipeline } from 'stream/promises'
 import { join, dirname } from 'path'
 import { tmpdir } from 'os'
-import { getRepoRoot, getOriginUrl, getDirtyPaths, getHeadSha, getBranchName, getMirrorPatch, urlsEqual } from './local-repo.js'
+import { getRepoRoot, getOriginUrl, getDirtyPaths, getHeadSha, getBranchName, getMirrorPatch, urlsEqual, runGit } from './local-repo.js'
 import type { ManagerApi } from './manager-api.js'
 import { ManagerApiError } from './manager-api.js'
 
@@ -325,15 +326,6 @@ function applyPatch(repoRoot: string, patch: string): void {
   }
 }
 
-function runGit(repoRoot: string, args: string[], input?: string): string {
-  const res = spawnSync('git', args, { cwd: repoRoot, input, encoding: 'utf-8' })
-  if (res.status !== 0) {
-    const stderr = (res.stderr ?? '').trim()
-    throw new Error(`git ${args.join(' ')} failed${stderr ? `: ${stderr}` : ''}`)
-  }
-  return res.stdout ?? ''
-}
-
 async function createLocalBundle(repoRoot: string): Promise<string> {
   const bundlePath = join(tmpdir(), `ocm-bundle-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`)
   runGit(repoRoot, ['bundle', 'create', bundlePath, '--all'])
@@ -343,6 +335,7 @@ async function createLocalBundle(repoRoot: string): Promise<string> {
 function importLocalBundle(repoRoot: string, bundlePath: string, branch: string | null): void {
   runGit(repoRoot, ['fetch', bundlePath, '+refs/heads/*:refs/remotes/ocm-sync/*', '+refs/tags/*:refs/tags/*'])
   const refs = runGit(repoRoot, ['for-each-ref', '--format=%(refname:strip=3) %(objectname)', 'refs/remotes/ocm-sync'])
+  const updates: string[] = []
   for (const line of refs.split('\n')) {
     const trimmed = line.trim()
     if (!trimmed) continue
@@ -351,7 +344,10 @@ function importLocalBundle(repoRoot: string, bundlePath: string, branch: string 
     const name = trimmed.slice(0, firstSpace)
     if (name === 'HEAD') continue
     const sha = trimmed.slice(firstSpace + 1)
-    runGit(repoRoot, ['update-ref', `refs/heads/${name}`, sha])
+    updates.push(`update refs/heads/${name} ${sha}\n`)
+  }
+  if (updates.length > 0) {
+    runGit(repoRoot, ['update-ref', '--stdin'], updates.join(''))
   }
 
   if (branch) {
@@ -360,20 +356,24 @@ function importLocalBundle(repoRoot: string, bundlePath: string, branch: string 
     if (head) runGit(repoRoot, ['reset', '--hard', head])
   }
 
-  const syncRefs = runGit(repoRoot, ['for-each-ref', '--format=%(refname)', 'refs/remotes/ocm-sync'])
-  for (const ref of syncRefs.split('\n').map((line) => line.trim()).filter(Boolean)) {
-    runGit(repoRoot, ['update-ref', '-d', ref])
+  try {
+    const syncRefsOut = runGit(repoRoot, ['for-each-ref', '--format=%(refname)', 'refs/remotes/ocm-sync'])
+    const deletes = syncRefsOut.split('\n').map((l) => l.trim()).filter(Boolean).map((ref) => `delete ${ref}\n`)
+    if (deletes.length > 0) {
+      runGit(repoRoot, ['update-ref', '--stdin'], deletes.join(''))
+    }
+  } catch {
+    // cleanup of ocm-sync refs is best-effort
   }
 }
 
 async function writeBundleStream(repoId: number, api: ManagerApi): Promise<string> {
   const bundlePath = join(tmpdir(), `ocm-bundle-down-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`)
   const stream = await api.mirrorDownloadBundle(repoId)
-  const chunks: Buffer[] = []
-  for await (const chunk of Readable.fromWeb(stream as unknown as Parameters<typeof Readable.fromWeb>[0]) as AsyncIterable<Buffer>) {
-    chunks.push(Buffer.from(chunk))
-  }
-  await fsp.writeFile(bundlePath, Buffer.concat(chunks))
+  await pipeline(
+    Readable.fromWeb(stream as unknown as Parameters<typeof Readable.fromWeb>[0]),
+    createWriteStream(bundlePath),
+  )
   return bundlePath
 }
 
@@ -413,20 +413,4 @@ export async function mirrorDownFast(
   }
 }
 
-export async function mirrorDownPatch(
-  repoId: number,
-  repoRoot: string,
-  api: ManagerApi,
-  opts: { force: boolean } = { force: false },
-): Promise<void> {
-  if (!opts.force && getDirtyPaths(repoRoot).size > 0) {
-    throw new MirrorAbort('working tree has uncommitted changes; rerun with --force')
-  }
 
-  const snapshot = await api.mirrorPatchSnapshot(repoId)
-  const localHead = getHeadSha(repoRoot)
-  if (snapshot.head && localHead && snapshot.head !== localHead) {
-    throw new MirrorAbort('local HEAD differs from Manager HEAD; falling back to full mirror')
-  }
-  applyPatch(repoRoot, snapshot.patch)
-}

--- a/ocm-cli/test/mirror.test.ts
+++ b/ocm-cli/test/mirror.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { randomBytes } from 'crypto'
 import { spawnSync, execSync } from 'child_process'
-import { prepareMirror, MirrorAbort, mirrorDown, mirrorDownPatch, mirrorUp, mirrorUpPatch } from '../src/mirror'
+import { prepareMirror, MirrorAbort, mirrorDown, mirrorUp, mirrorUpPatch } from '../src/mirror'
 import { getBranchName } from '../src/local-repo'
 
 describe('prepareMirror', () => {
@@ -606,22 +606,5 @@ describe('mirror patch helpers', () => {
     expect(body.patch).toContain('-before')
     expect(body.patch).toContain('+after')
   })
-
-  it('applies a manager patch during pull patch mode', async () => {
-    const repoRoot = join(tmpDir, 'repo-remote-diff')
-    mkdirSync(repoRoot)
-    spawnSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' })
-    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoRoot, stdio: 'ignore' })
-    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: repoRoot, stdio: 'ignore' })
-    writeFileSync(join(repoRoot, 'tracked.txt'), 'before\n')
-    spawnSync('git', ['add', 'tracked.txt'], { cwd: repoRoot, stdio: 'ignore' })
-    spawnSync('git', ['commit', '-m', 'initial'], { cwd: repoRoot, stdio: 'ignore' })
-    const head = execSync('git rev-parse HEAD', { cwd: repoRoot, encoding: 'utf-8' }).trim()
-    const patch = 'diff --git a/tracked.txt b/tracked.txt\nindex 6e58d95..7c6cae9 100644\n--- a/tracked.txt\n+++ b/tracked.txt\n@@ -1 +1 @@\n-before\n+after\n'
-    const api = { mirrorPatchSnapshot: vi.fn().mockResolvedValue({ repoId: 1, branch: 'main', head, patch }) }
-
-    await mirrorDownPatch(1, repoRoot, api as any, { force: false })
-
-    expect(readFileSync(join(repoRoot, 'tracked.txt'), 'utf-8')).toBe('after\n')
-  })
 })
+


### PR DESCRIPTION
Consolidate model discovery into a shared utility, batch git ref updates for efficiency, and remove dead code from the OCM mirror sync system.

Changes:
- Consolidate STT/TTS/settings model discovery into discoverModelsCached()
- Batch bundle ref updates via update-ref --stdin instead of per-ref loops
- Replace getReposPath() staging root with getStagingRoot()
- Stream bundle download with pipeline() instead of buffering chunks
- Fix ArrayBuffer slicing in manager-api.ts
- Memoize discovered model options in OpenCodeModelDialog
- Remove unused mirrorDownPatch() and its test
- Move runGit() to local-repo.ts as shared utility
- Update docs for --full flag

Validation:
- pnpm lint