### PR TITLE
fix: follow up prompt preservation changes

### DIFF
--- a/frontend/plugins/sw-precache-manifest.ts
+++ b/frontend/plugins/sw-precache-manifest.ts
@@ -5,7 +5,12 @@ import type { Plugin } from "vite";
 
 const SW_FILENAME = "sw.js";
 const PRECACHE_DIR_PREFIXES = ["assets/"];
-const PRECACHE_ROOT_FILES = ["index.html", "manifest.json", "favicon.svg"];
+const PRECACHE_ROOT_FILES = [
+  "index.html",
+  "manifest.json",
+  "favicon.svg",
+  "icons/icon-192x192.png",
+];
 
 async function collectFiles(dir: string, base = dir): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });

--- a/frontend/src/components/agent/AgentQuickSelect.tsx
+++ b/frontend/src/components/agent/AgentQuickSelect.tsx
@@ -17,7 +17,6 @@ interface AgentQuickSelectProps {
   currentAgent: string
   onAgentChange: (agent: string) => void
   isBashMode?: boolean
-  disabled?: boolean
 }
 
 interface AgentInfo {
@@ -55,7 +54,6 @@ export function AgentQuickSelect({
   currentAgent,
   onAgentChange,
   isBashMode = false,
-  disabled = false,
 }: AgentQuickSelectProps) {
   const { data: agents = [] } = useAgents(opcodeUrl, directory)
 
@@ -79,7 +77,6 @@ export function AgentQuickSelect({
   const buttonContent = (
     <button
       data-toggle-mode
-      disabled={disabled}
       style={styleVars as React.CSSProperties}
       className="px-2 md:px-3.5 py-1 h-[36px] rounded-lg text-sm font-medium border min-w-[56px] max-w-[80px] md:max-w-[100px] flex-shrink-0 flex items-center justify-center transition-all duration-200 active:scale-95 hover:scale-105 shadow-md text-[var(--agent-color-light)] dark:text-[var(--agent-color-dark)] bg-[var(--agent-bg-light)] dark:bg-[var(--agent-bg-dark)] border-[var(--agent-border-light)] dark:border-[var(--agent-border-dark)] hover:bg-[var(--agent-bg-hover-light)] dark:hover:bg-[var(--agent-bg-hover-dark)] hover:border-[var(--agent-border-hover-light)] dark:hover:border-[var(--agent-border-hover-dark)] shadow-[var(--agent-shadow-light)] dark:shadow-[var(--agent-shadow-dark)] hover:shadow-[var(--agent-shadow-hover-light)] dark:hover:shadow-[var(--agent-shadow-hover-dark)]"
     >
@@ -89,7 +86,7 @@ export function AgentQuickSelect({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild disabled={disabled}>
+      <DropdownMenuTrigger asChild>
         {buttonContent}
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-64">

--- a/frontend/src/components/message/PromptInput.stt.test.tsx
+++ b/frontend/src/components/message/PromptInput.stt.test.tsx
@@ -139,7 +139,6 @@ describe('PromptInput STT Gesture Tests', () => {
     directory: '/test',
     sessionID: 'test-session',
     repoId: 1,
-    disabled: false,
     showScrollButton: false,
     isSessionActive: false,
     isStreamingResponse: false,

--- a/frontend/src/components/message/PromptInput.stt.test.tsx
+++ b/frontend/src/components/message/PromptInput.stt.test.tsx
@@ -366,6 +366,43 @@ describe('PromptInput STT Gesture Tests', () => {
       })
     })
 
+    it('clears the restored prompt when the send error resolves', async () => {
+      const queryClient = createTestQueryClient()
+      mocks.useSendErrorStore.mockImplementation((selector) => selector({
+        errors: {
+          'test-session': {
+            sessionID: 'test-session',
+            title: 'Connection Failed',
+            message: 'Could not connect.',
+            failedPrompt: 'recovered prompt',
+            kind: 'network',
+          },
+        },
+      }))
+
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <PromptInput {...defaultProps} />
+        </QueryClientProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Send a message...')).toHaveValue('recovered prompt')
+      })
+
+      mocks.useSendErrorStore.mockImplementation((selector) => selector({ errors: {} }))
+
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <PromptInput {...defaultProps} />
+        </QueryClientProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Send a message...')).toHaveValue('')
+      })
+    })
+
     it('keeps stop available while active with prompt content', async () => {
       render(
         <QueryClientProvider client={createTestQueryClient()}>

--- a/frontend/src/components/message/PromptInput.tsx
+++ b/frontend/src/components/message/PromptInput.tsx
@@ -239,11 +239,20 @@ export const PromptInput = memo(forwardRef<PromptInputHandle, PromptInputProps>(
   const restoredFailedPromptRef = useRef<string | null>(null)
 
   useEffect(() => {
-    if (!failedPrompt || restoredFailedPromptRef.current === failedPrompt) return
-    restoredFailedPromptRef.current = failedPrompt
-    if (promptRef.current) return
-    setPrompt(failedPrompt)
-    textareaRef.current?.focus()
+    if (failedPrompt) {
+      if (restoredFailedPromptRef.current === failedPrompt) return
+      restoredFailedPromptRef.current = failedPrompt
+      if (promptRef.current) return
+      setPrompt(failedPrompt)
+      textareaRef.current?.focus()
+      return
+    }
+    if (restoredFailedPromptRef.current !== null) {
+      if (promptRef.current === restoredFailedPromptRef.current) {
+        setPrompt('')
+      }
+      restoredFailedPromptRef.current = null
+    }
   }, [failedPrompt])
   
   const mentionItems = useMemo((): MentionItem[] => {

--- a/frontend/src/components/message/PromptInput.tsx
+++ b/frontend/src/components/message/PromptInput.tsx
@@ -65,7 +65,6 @@ interface PromptInputProps {
   opcodeUrl: string
   directory?: string
   sessionID: string
-  disabled?: boolean
   showScrollButton?: boolean
   isSessionActive?: boolean
   isStreamingResponse?: boolean
@@ -81,7 +80,6 @@ export const PromptInput = memo(forwardRef<PromptInputHandle, PromptInputProps>(
   opcodeUrl,
   directory,
   sessionID,
-  disabled,
   showScrollButton,
   isSessionActive = false,
   isStreamingResponse = false,
@@ -275,7 +273,6 @@ export const PromptInput = memo(forwardRef<PromptInputHandle, PromptInputProps>(
   const addUserBashCommand = useUserBash((s) => s.addUserBashCommand)
 
   const handleSubmit = () => {
-    if (disabled) return
     if (!prompt.trim() && imageAttachments.length === 0) return
 
     pendingVoiceAutoSubmitRef.current = false
@@ -572,7 +569,7 @@ export const PromptInput = memo(forwardRef<PromptInputHandle, PromptInputProps>(
   }
 
   const handleVoicePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if ((event.pointerType === 'mouse' && event.button !== 0) || disabled || isProcessing || !isRecording) {
+    if ((event.pointerType === 'mouse' && event.button !== 0) || isProcessing || !isRecording) {
       return
     }
 
@@ -1196,7 +1193,7 @@ if (isIOS && isSecureContext && navigator.clipboard && navigator.clipboard.read)
         <button
           type="button"
           onClick={handleVoiceClick}
-          disabled={disabled || isProcessing}
+          disabled={isProcessing}
           className={buttonClassName}
           title={voiceButtonTitle}
         >
@@ -1245,7 +1242,6 @@ return (
       {showStopButton && (
         <button
           onClick={handleStop}
-          disabled={disabled}
           className="border  fixed bottom-19 right-0 md:hidden z-50 p-3 rounded-xl transition-all duration-200 active:scale-95 hover:scale-105 bg-gradient-to-br from-red-600 to-red-700 hover:from-red-500 hover:to-red-600 text-destructive-foreground border border-red-500/60 shadow-lg shadow-red-500/30"
           title="Stop"
         >
@@ -1267,7 +1263,6 @@ return (
             ? "Enter bash command..."
             : "Send a message..."
         }
-        disabled={disabled}
         className={`w-full bg-muted/50 pl-2 md:pl-3 pr-3 py-2 text-[16px] text-foreground placeholder-muted-foreground focus:outline-none focus:bg-muted/70 resize-none min-h-[40px] max-h-[120px] disabled:opacity-50 disabled:cursor-not-allowed md:text-sm rounded-lg [field-sizing:content] ${
           isBashMode
             ? 'border-purple-500/50 bg-purple-500/5 focus:bg-purple-500/10'
@@ -1324,7 +1319,6 @@ return (
                 currentAgent={currentMode}
                 onAgentChange={handleAgentChange}
                 isBashMode={isBashMode}
-                disabled={disabled}
               />
               {isSessionActive ? (
               <div className="px-2.5 py-1.5 md:px-3 md:py-2 rounded-lg text-xs md:text-sm font-medium text-muted-foreground max-w-[120px] md:max-w-[180px]">
@@ -1363,7 +1357,6 @@ return (
 {showStopButton && (
             <button
               onClick={handleStop}
-              disabled={disabled}
               className="hidden md:block p-1.5 px-5 md:p-2 md:px-6 rounded-lg transition-all duration-200 active:scale-95 hover:scale-105 bg-gradient-to-br from-red-600 to-red-700 hover:from-red-500 hover:to-red-600 text-destructive-foreground border border-red-500/60 hover:border-red-400 shadow-md shadow-red-500/30 hover:shadow-red-500/40 ring-1 ring-red-500/20 hover:ring-red-500/30"
               title="Stop"
             >
@@ -1394,7 +1387,7 @@ return (
             <button
               data-submit-prompt
               onClick={hasPendingPermissionForSession ? () => setShowDialog(true) : handleSubmit}
-              disabled={hasPendingPermissionForSession ? false : ((!prompt.trim() && imageAttachments.length === 0) || disabled || (isPromptSubmitPending && !isStreamingResponse))}
+              disabled={hasPendingPermissionForSession ? false : ((!prompt.trim() && imageAttachments.length === 0) || (isPromptSubmitPending && !isStreamingResponse))}
               className={`px-4 md:px-5 py-1.5 md:py-2 rounded-lg text-sm font-medium transition-colors dark:border flex-shrink-0 min-w-[52px] ${
                 hasPendingPermissionForSession
                   ? 'bg-orange-500 hover:bg-orange-600 border-orange-400 text-primary-foreground ring-orange-500/20'

--- a/frontend/src/components/ui/error-banner.tsx
+++ b/frontend/src/components/ui/error-banner.tsx
@@ -1,6 +1,7 @@
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { AlertCircle, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
 export interface ErrorBannerProps {
   title?: string
@@ -12,21 +13,21 @@ export interface ErrorBannerProps {
 
 export function ErrorBanner({ title, summary, detail, onDismiss, className }: ErrorBannerProps) {
   return (
-    <Alert variant="destructive" className={className}>
+    <Alert className={cn('bg-card border-border border-l-[3px] border-l-destructive', className)}>
       <div className="flex flex-col gap-2">
         <div className="flex items-start gap-2">
-          <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+          <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0 text-red-400" />
           <div className="flex-1 min-w-0">
             {title && (
-              <AlertTitle className="mb-1 font-medium leading-none tracking-tight">{title}</AlertTitle>
+              <AlertTitle className="mb-1 font-medium leading-none tracking-tight text-foreground">{title}</AlertTitle>
             )}
-            <AlertDescription className="text-sm">{summary}</AlertDescription>
+            <AlertDescription className="text-sm text-muted-foreground">{summary}</AlertDescription>
           </div>
           {onDismiss && (
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 w-7 p-0 flex-shrink-0"
+              className="h-7 w-7 p-0 flex-shrink-0 text-muted-foreground"
               onClick={onDismiss}
             >
               <X className="w-3.5 h-3.5" />
@@ -34,7 +35,7 @@ export function ErrorBanner({ title, summary, detail, onDismiss, className }: Er
           )}
         </div>
         {detail && (
-          <pre className="p-2 rounded border bg-destructive/5 border-destructive/20 text-xs font-mono overflow-auto max-h-32">
+          <pre className="p-2 rounded border bg-background border-border text-xs font-mono text-muted-foreground overflow-auto max-h-32">
             {detail}
           </pre>
         )}

--- a/frontend/src/hooks/useOpenCode.ts
+++ b/frontend/src/hooks/useOpenCode.ts
@@ -506,6 +506,7 @@ export const useSendPrompt = (opcodeUrl: string | null | undefined, directory?: 
         message: parsed.message,
         detail: error instanceof FetchError ? error.detail : undefined,
         failedPrompt: failedPrompt || undefined,
+        kind: 'network',
       });
     },
     onSuccess: async (data, variables) => {

--- a/frontend/src/hooks/useOpenCode.ts
+++ b/frontend/src/hooks/useOpenCode.ts
@@ -535,7 +535,6 @@ export const useSendPrompt = (opcodeUrl: string | null | undefined, directory?: 
           return [...old, { info: response.info, parts: response.parts }];
         },
       );
-
     },
   });
 };

--- a/frontend/src/hooks/useSSE.test.tsx
+++ b/frontend/src/hooks/useSSE.test.tsx
@@ -396,7 +396,124 @@ describe('useSSE', () => {
       title: 'Error',
       message: 'Queued send failed',
       failedPrompt: 'queued message',
+      kind: 'session',
     })
+
+    unmount()
+  })
+
+  it('retracts a network send error when the server confirms session activity', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    useSendErrorStore.getState().setError({
+      sessionID: 'session-1',
+      title: 'Connection Failed',
+      message: 'Could not connect to the server.',
+      failedPrompt: 'in-flight prompt',
+      kind: 'network',
+    })
+
+    const { result, unmount } = renderHook(
+      () => useSSE('http://localhost:5551', '/repo', 'session-1'),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1))
+    act(() => {
+      MockEventSource.instances[0].emit('connected', { clientId: 'client-1' })
+    })
+    await waitFor(() => expect(result.current.isConnected).toBe(true))
+
+    act(() => {
+      MockEventSource.instances[0].emit('message', {
+        type: 'message.updated',
+        properties: {
+          info: { id: 'assistant-1', role: 'assistant', sessionID: 'session-1', time: { created: 1 } },
+        },
+      })
+    })
+
+    expect(useSendErrorStore.getState().getError('session-1')).toBeNull()
+
+    unmount()
+  })
+
+  it('retracts a network send error when the session goes idle', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    useSendErrorStore.getState().setError({
+      sessionID: 'session-1',
+      title: 'Request Timeout',
+      message: 'The request took too long.',
+      kind: 'network',
+    })
+
+    const { result, unmount } = renderHook(
+      () => useSSE('http://localhost:5551', '/repo', 'session-1'),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1))
+    act(() => {
+      MockEventSource.instances[0].emit('connected', { clientId: 'client-1' })
+    })
+    await waitFor(() => expect(result.current.isConnected).toBe(true))
+
+    act(() => {
+      MockEventSource.instances[0].emit('message', {
+        type: 'session.idle',
+        properties: { sessionID: 'session-1' },
+      })
+    })
+
+    expect(useSendErrorStore.getState().getError('session-1')).toBeNull()
+
+    unmount()
+  })
+
+  it('preserves a server-reported session error when the session later goes idle', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    useSendErrorStore.getState().setQueuedPrompt('session-1', 'queued message')
+
+    const { result, unmount } = renderHook(
+      () => useSSE('http://localhost:5551', '/repo', 'session-1'),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1))
+    act(() => {
+      MockEventSource.instances[0].emit('connected', { clientId: 'client-1' })
+    })
+    await waitFor(() => expect(result.current.isConnected).toBe(true))
+
+    act(() => {
+      MockEventSource.instances[0].emit('message', {
+        type: 'session.error',
+        properties: {
+          sessionID: 'session-1',
+          error: { name: 'UnknownError', data: { message: 'Queued send failed' } },
+        },
+      })
+    })
+
+    act(() => {
+      MockEventSource.instances[0].emit('message', {
+        type: 'session.idle',
+        properties: { sessionID: 'session-1' },
+      })
+    })
+
+    expect(useSendErrorStore.getState().getError('session-1')).not.toBeNull()
 
     unmount()
   })

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -156,6 +156,7 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
         
         const { info } = event.properties
         const sessionID = info.sessionID
+        useSendErrorStore.getState().clearNetworkError(sessionID)
         if (info.role === 'user') {
           useSendErrorStore.getState().clearQueuedPrompt(sessionID)
         }
@@ -231,6 +232,7 @@ export const useSSE = (opcodeUrl: string | null | undefined, directory?: string 
         const { sessionID } = event.properties
         
         setSessionStatus(sessionID, { type: 'idle' })
+        useSendErrorStore.getState().clearNetworkError(sessionID)
         
         batcherRef.current?.flush({ sessionID, directory: cacheDirectory })
         

--- a/frontend/src/lib/serviceWorker.ts
+++ b/frontend/src/lib/serviceWorker.ts
@@ -60,7 +60,11 @@ export function registerServiceWorker(): void {
         });
       });
 
+      let lastUpdateCheck = 0;
       const checkForUpdate = () => {
+        const now = Date.now();
+        if (now - lastUpdateCheck < UPDATE_CHECK_INTERVAL_MS) return;
+        lastUpdateCheck = now;
         registration.update().catch(() => {});
       };
 

--- a/frontend/src/stores/sendErrorStore.test.ts
+++ b/frontend/src/stores/sendErrorStore.test.ts
@@ -38,6 +38,7 @@ describe('useSendErrorStore', () => {
       title: 'Error',
       message: 'Failed',
       failedPrompt: 'queued message',
+      kind: 'session',
     })
     expect(useSendErrorStore.getState().queuedPrompts['session-1']).toBeUndefined()
   })
@@ -50,5 +51,18 @@ describe('useSendErrorStore', () => {
     })
 
     expect(useSendErrorStore.getState().getError('session-1')).toBeNull()
+  })
+
+  it('clearNetworkError retracts a network error', () => {
+    useSendErrorStore.getState().setError({ sessionID: 'session-1', title: 'Error', message: 'msg', kind: 'network' })
+    useSendErrorStore.getState().clearNetworkError('session-1')
+    expect(useSendErrorStore.getState().getError('session-1')).toBeNull()
+  })
+
+  it('clearNetworkError preserves a server-reported session error', () => {
+    useSendErrorStore.getState().setQueuedPrompt('session-1', 'queued message')
+    useSendErrorStore.getState().failQueuedPrompt({ sessionID: 'session-1', title: 'Error', message: 'Failed' })
+    useSendErrorStore.getState().clearNetworkError('session-1')
+    expect(useSendErrorStore.getState().getError('session-1')).not.toBeNull()
   })
 })

--- a/frontend/src/stores/sendErrorStore.ts
+++ b/frontend/src/stores/sendErrorStore.ts
@@ -6,6 +6,7 @@ export interface SendError {
   message: string
   detail?: string
   failedPrompt?: string
+  kind?: 'network' | 'session'
 }
 
 interface SendErrorStore {
@@ -14,8 +15,9 @@ interface SendErrorStore {
   setError: (err: SendError) => void
   setQueuedPrompt: (sessionID: string, prompt: string) => void
   clearQueuedPrompt: (sessionID: string) => void
-  failQueuedPrompt: (err: Omit<SendError, 'failedPrompt'>) => void
+  failQueuedPrompt: (err: Omit<SendError, 'failedPrompt' | 'kind'>) => void
   clearError: (sessionID: string) => void
+  clearNetworkError: (sessionID: string) => void
   getError: (sessionID: string) => SendError | null
 }
 
@@ -39,7 +41,7 @@ export const useSendErrorStore = create<SendErrorStore>((set, get) => ({
       return { queuedPrompts }
     })
   },
-  failQueuedPrompt: (err: Omit<SendError, 'failedPrompt'>) => {
+  failQueuedPrompt: (err: Omit<SendError, 'failedPrompt' | 'kind'>) => {
     set((state) => {
       const failedPrompt = state.queuedPrompts[err.sessionID]
       if (!failedPrompt) return state
@@ -48,7 +50,7 @@ export const useSendErrorStore = create<SendErrorStore>((set, get) => ({
       return {
         errors: {
           ...state.errors,
-          [err.sessionID]: { ...err, failedPrompt },
+          [err.sessionID]: { ...err, failedPrompt, kind: 'session' },
         },
         queuedPrompts,
       }
@@ -60,6 +62,10 @@ export const useSendErrorStore = create<SendErrorStore>((set, get) => ({
       delete newErrors[sessionID]
       return { errors: newErrors }
     })
+  },
+  clearNetworkError: (sessionID: string) => {
+    if (get().errors[sessionID]?.kind === 'session') return
+    get().clearError(sessionID)
   },
   getError: (sessionID: string) => {
     return get().errors[sessionID] || null


### PR DESCRIPTION
## Summary
- apply the three follow-up commits that missed PR #276
- throttle service worker update checks and precache icon
- retract transient send errors once sends are confirmed and restyle the error banner

## Checks
- pnpm typecheck
- pnpm lint (passes with existing backend repos.test.ts warnings)