### PR TITLE
fix: add mobile bottom padding to prompts tab and show edit/delete buttons on touch

### DIFF
--- a/frontend/src/components/schedules/PromptTab.tsx
+++ b/frontend/src/components/schedules/PromptTab.tsx
@@ -64,7 +64,7 @@ export function PromptTemplateCard({ template, selected = false, onApply, onEdit
       ) : (
         <div className={cardClassName}>{content}</div>
       )}
-      <div className={`absolute top-2 flex gap-1 transition-opacity ${selected || onApply ? 'right-10' : 'right-2'} ${selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
+      <div className={`absolute top-2 flex gap-1 transition-opacity ${selected || onApply ? 'right-10' : 'right-2'} ${selected ? 'opacity-100' : 'max-md:opacity-100 md:opacity-0 md:group-hover:opacity-100'}`}>
         <Button
           type="button"
           variant="ghost"

--- a/frontend/src/pages/GlobalSchedules.tsx
+++ b/frontend/src/pages/GlobalSchedules.tsx
@@ -862,7 +862,7 @@ export function GlobalSchedules() {
           </div>
         </TabsContent>
         <TabsContent value="prompts" className="mt-0 flex-1 min-h-0 flex flex-col overflow-hidden">
-          <div className="flex-1 min-h-0 overflow-y-auto p-4">
+          <div className="flex-1 min-h-0 overflow-y-auto p-4 pb-[calc(env(safe-area-inset-bottom)+56px)] sm:pb-4">
             <PromptsTab
               promptDialog={promptDialog}
               templateId={templateId}


### PR DESCRIPTION
Two mobile fixes for the schedules prompts UI:

- Add bottom padding to the Prompts tab scroll container in GlobalSchedules, preventing the fixed mobile tab bar from covering template cards.
- Show template edit/delete buttons on mobile (<768px) where hover does not work, while preserving hover-only reveal on desktop.

## Checks
- pnpm lint