### PR TITLE
feat: add schedule worktree isolation for running jobs in isolated worktrees

### DIFF
--- a/backend/src/db/migrations/015-schedule-worktree-isolation.ts
+++ b/backend/src/db/migrations/015-schedule-worktree-isolation.ts
@@ -17,9 +17,6 @@ const migration: Migration = {
     if (!jobColumnNames.has('branch')) {
       db.run('ALTER TABLE schedule_jobs ADD COLUMN branch TEXT')
     }
-    if (!jobColumnNames.has('isolation_mode')) {
-      db.run("ALTER TABLE schedule_jobs ADD COLUMN isolation_mode TEXT NOT NULL DEFAULT 'worktree'")
-    }
 
     const runColumns = db.prepare('PRAGMA table_info(schedule_runs)').all() as ColumnInfo[]
     const runColumnNames = new Set(runColumns.map((c) => c.name))
@@ -36,12 +33,11 @@ const migration: Migration = {
   },
 
   down(db) {
-    // Rebuild schedule_jobs without branch, isolation_mode
+    // Rebuild schedule_jobs without branch
     const jobColumns = db.prepare('PRAGMA table_info(schedule_jobs)').all() as ColumnInfo[]
     const hasBranch = jobColumns.some((c) => c.name === 'branch')
-    const hasIsolationMode = jobColumns.some((c) => c.name === 'isolation_mode')
 
-    if (hasBranch || hasIsolationMode) {
+    if (hasBranch) {
       db.run(`
         CREATE TABLE schedule_jobs_old (
           id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/backend/src/db/migrations/015-schedule-worktree-isolation.ts
+++ b/backend/src/db/migrations/015-schedule-worktree-isolation.ts
@@ -1,0 +1,130 @@
+import type { Migration } from '../migration-runner'
+
+interface ColumnInfo {
+  name: string
+  notnull: number
+  dflt_value: string | null
+}
+
+const migration: Migration = {
+  version: 15,
+  name: 'schedule-worktree-isolation',
+
+  up(db) {
+    const jobColumns = db.prepare('PRAGMA table_info(schedule_jobs)').all() as ColumnInfo[]
+    const jobColumnNames = new Set(jobColumns.map((c) => c.name))
+
+    if (!jobColumnNames.has('branch')) {
+      db.run('ALTER TABLE schedule_jobs ADD COLUMN branch TEXT')
+    }
+    if (!jobColumnNames.has('isolation_mode')) {
+      db.run("ALTER TABLE schedule_jobs ADD COLUMN isolation_mode TEXT NOT NULL DEFAULT 'worktree'")
+    }
+
+    const runColumns = db.prepare('PRAGMA table_info(schedule_runs)').all() as ColumnInfo[]
+    const runColumnNames = new Set(runColumns.map((c) => c.name))
+
+    if (!runColumnNames.has('run_branch')) {
+      db.run('ALTER TABLE schedule_runs ADD COLUMN run_branch TEXT')
+    }
+    if (!runColumnNames.has('commit_hash')) {
+      db.run('ALTER TABLE schedule_runs ADD COLUMN commit_hash TEXT')
+    }
+    if (!runColumnNames.has('worktree_path')) {
+      db.run('ALTER TABLE schedule_runs ADD COLUMN worktree_path TEXT')
+    }
+  },
+
+  down(db) {
+    // Rebuild schedule_jobs without branch, isolation_mode
+    const jobColumns = db.prepare('PRAGMA table_info(schedule_jobs)').all() as ColumnInfo[]
+    const hasBranch = jobColumns.some((c) => c.name === 'branch')
+    const hasIsolationMode = jobColumns.some((c) => c.name === 'isolation_mode')
+
+    if (hasBranch || hasIsolationMode) {
+      db.run(`
+        CREATE TABLE schedule_jobs_old (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+          name TEXT NOT NULL,
+          description TEXT,
+          enabled BOOLEAN NOT NULL DEFAULT TRUE,
+          interval_minutes INTEGER,
+          schedule_mode TEXT NOT NULL DEFAULT 'interval',
+          cron_expression TEXT,
+          timezone TEXT,
+          agent_slug TEXT,
+          prompt TEXT NOT NULL,
+          model TEXT,
+          skill_metadata TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          last_run_at INTEGER,
+          next_run_at INTEGER
+        )
+      `)
+
+      db.run(`
+        INSERT INTO schedule_jobs_old (
+          id, repo_id, name, description, enabled, interval_minutes, schedule_mode,
+          cron_expression, timezone, agent_slug, prompt, model, skill_metadata,
+          created_at, updated_at, last_run_at, next_run_at
+        )
+        SELECT
+          id, repo_id, name, description, enabled, interval_minutes, schedule_mode,
+          cron_expression, timezone, agent_slug, prompt, model, skill_metadata,
+          created_at, updated_at, last_run_at, next_run_at
+        FROM schedule_jobs
+      `)
+
+      db.run('DROP TABLE schedule_jobs')
+      db.run('ALTER TABLE schedule_jobs_old RENAME TO schedule_jobs')
+      db.run('CREATE INDEX IF NOT EXISTS idx_schedule_jobs_repo ON schedule_jobs(repo_id)')
+      db.run('CREATE INDEX IF NOT EXISTS idx_schedule_jobs_next_run ON schedule_jobs(enabled, next_run_at)')
+    }
+
+    // Rebuild schedule_runs without run_branch, commit_hash, worktree_path
+    const runColumns = db.prepare('PRAGMA table_info(schedule_runs)').all() as ColumnInfo[]
+    const hasRunBranch = runColumns.some((c) => c.name === 'run_branch')
+    const hasCommitHash = runColumns.some((c) => c.name === 'commit_hash')
+    const hasWorktreePath = runColumns.some((c) => c.name === 'worktree_path')
+
+    if (hasRunBranch || hasCommitHash || hasWorktreePath) {
+      db.run(`
+        CREATE TABLE schedule_runs_old (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          job_id INTEGER NOT NULL REFERENCES schedule_jobs(id) ON DELETE CASCADE,
+          repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+          trigger_source TEXT NOT NULL,
+          status TEXT NOT NULL,
+          started_at INTEGER NOT NULL,
+          finished_at INTEGER,
+          created_at INTEGER NOT NULL,
+          session_id TEXT,
+          session_title TEXT,
+          log_text TEXT,
+          response_text TEXT,
+          error_text TEXT
+        )
+      `)
+
+      db.run(`
+        INSERT INTO schedule_runs_old (
+          id, job_id, repo_id, trigger_source, status, started_at, finished_at,
+          created_at, session_id, session_title, log_text, response_text, error_text
+        )
+        SELECT
+          id, job_id, repo_id, trigger_source, status, started_at, finished_at,
+          created_at, session_id, session_title, log_text, response_text, error_text
+        FROM schedule_runs
+      `)
+
+      db.run('DROP TABLE schedule_runs')
+      db.run('ALTER TABLE schedule_runs_old RENAME TO schedule_runs')
+      db.run('CREATE INDEX IF NOT EXISTS idx_schedule_runs_job ON schedule_runs(job_id, started_at DESC)')
+      db.run('CREATE INDEX IF NOT EXISTS idx_schedule_runs_repo ON schedule_runs(repo_id, started_at DESC)')
+    }
+  },
+}
+
+export default migration

--- a/backend/src/db/migrations/index.ts
+++ b/backend/src/db/migrations/index.ts
@@ -13,6 +13,7 @@ import migration011 from './011-repo-last-accessed'
 import migration012 from './012-opencode-model-state'
 import migration013 from './013-app-secrets'
 import migration014 from './014-repos-add-name'
+import migration015 from './015-schedule-worktree-isolation'
 
 export const allMigrations: Migration[] = [
   migration001,
@@ -29,4 +30,5 @@ export const allMigrations: Migration[] = [
   migration012,
   migration013,
   migration014,
+  migration015,
 ]

--- a/backend/src/db/schedules.ts
+++ b/backend/src/db/schedules.ts
@@ -3,6 +3,7 @@ import {
   ScheduleJobSchema,
   ScheduleRunSchema,
   ScheduleSkillMetadataSchema,
+  type ScheduleIsolationMode,
   type ScheduleJob,
   type ScheduleMode,
   type ScheduleRun,
@@ -26,6 +27,8 @@ interface ScheduleJobRow {
   prompt: string
   model: string | null
   skill_metadata: string | null
+  branch: string | null
+  isolation_mode: string | null
   created_at: number
   updated_at: number
   last_run_at: number | null
@@ -46,6 +49,9 @@ interface ScheduleRunRow {
   log_text: string | null
   response_text: string | null
   error_text: string | null
+  run_branch: string | null
+  commit_hash: string | null
+  worktree_path: string | null
 }
 
 function parseSkillMetadata(raw: string | null) {
@@ -77,6 +83,8 @@ function rowToScheduleJob(row: ScheduleJobRow): ScheduleJob {
     prompt: row.prompt,
     model: row.model,
     skillMetadata: parseSkillMetadata(row.skill_metadata),
+    branch: row.branch,
+    isolationMode: (row.isolation_mode as ScheduleIsolationMode) ?? 'worktree',
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     lastRunAt: row.last_run_at,
@@ -99,6 +107,9 @@ function rowToScheduleRun(row: ScheduleRunRow): ScheduleRun {
     logText: row.log_text,
     responseText: row.response_text,
     errorText: row.error_text,
+    runBranch: row.run_branch,
+    commitHash: row.commit_hash,
+    worktreePath: row.worktree_path,
   })
 }
 
@@ -139,9 +150,10 @@ export function createScheduleJob(db: Database, repoId: number, input: ScheduleJ
   const stmt = db.prepare(`
     INSERT INTO schedule_jobs (
       repo_id, name, description, enabled, schedule_mode, interval_minutes, cron_expression, timezone, agent_slug, prompt, model, skill_metadata,
+      branch, isolation_mode,
       created_at, updated_at, last_run_at, next_run_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
 
   const result = stmt.run(
@@ -157,6 +169,8 @@ export function createScheduleJob(db: Database, repoId: number, input: ScheduleJ
     input.prompt,
     input.model ?? null,
     serializeSkillMetadata(input.skillMetadata),
+    input.branch,
+    input.isolationMode,
     now,
     now,
     null,
@@ -180,7 +194,8 @@ export function updateScheduleJob(db: Database, repoId: number, jobId: number, i
 
   const stmt = db.prepare(`
     UPDATE schedule_jobs
-    SET name = ?, description = ?, enabled = ?, schedule_mode = ?, interval_minutes = ?, cron_expression = ?, timezone = ?, agent_slug = ?, prompt = ?, model = ?, skill_metadata = ?, updated_at = ?, next_run_at = ?
+    SET name = ?, description = ?, enabled = ?, schedule_mode = ?, interval_minutes = ?, cron_expression = ?, timezone = ?,
+        agent_slug = ?, prompt = ?, model = ?, skill_metadata = ?, branch = ?, isolation_mode = ?, updated_at = ?, next_run_at = ?
     WHERE repo_id = ? AND id = ?
   `)
 
@@ -196,6 +211,8 @@ export function updateScheduleJob(db: Database, repoId: number, jobId: number, i
     input.prompt,
     input.model,
     serializeSkillMetadata(input.skillMetadata),
+    input.branch,
+    input.isolationMode,
     now,
     input.nextRunAt,
     repoId,
@@ -341,6 +358,36 @@ export function updateScheduleRunMetadata(
   return getScheduleRunById(db, repoId, jobId, runId)
 }
 
+export function updateScheduleRunWorktree(
+  db: Database,
+  repoId: number,
+  jobId: number,
+  runId: number,
+  input: { worktreePath?: string | null; runBranch?: string | null; commitHash?: string | null },
+): ScheduleRun | null {
+  const existing = getScheduleRunById(db, repoId, jobId, runId)
+  if (!existing) {
+    return null
+  }
+
+  const stmt = db.prepare(`
+    UPDATE schedule_runs
+    SET worktree_path = ?, run_branch = ?, commit_hash = ?
+    WHERE repo_id = ? AND job_id = ? AND id = ?
+  `)
+
+  stmt.run(
+    input.worktreePath === undefined ? existing.worktreePath : input.worktreePath,
+    input.runBranch === undefined ? existing.runBranch : input.runBranch,
+    input.commitHash === undefined ? existing.commitHash : input.commitHash,
+    repoId,
+    jobId,
+    runId,
+  )
+
+  return getScheduleRunById(db, repoId, jobId, runId)
+}
+
 export function getScheduleRunById(db: Database, repoId: number, jobId: number, runId: number): ScheduleRun | null {
   const stmt = db.prepare('SELECT * FROM schedule_runs WHERE repo_id = ? AND job_id = ? AND id = ?')
   const row = stmt.get(repoId, jobId, runId) as ScheduleRunRow | undefined
@@ -384,7 +431,10 @@ export function listScheduleRunsByJob(db: Database, repoId: number, jobId: numbe
       session_title,
       NULL AS log_text,
       NULL AS response_text,
-      error_text
+      error_text,
+      run_branch,
+      commit_hash,
+      worktree_path
     FROM schedule_runs
     WHERE repo_id = ? AND job_id = ?
     ORDER BY started_at DESC
@@ -508,6 +558,7 @@ export function listAllScheduleRuns(db: Database, options: ListAllRunsOptions = 
       sr.started_at, sr.finished_at, sr.created_at,
       sr.session_id, sr.session_title,
       NULL AS log_text, NULL AS response_text, sr.error_text,
+      sr.run_branch, sr.commit_hash, sr.worktree_path,
       sj.name AS job_name, r.local_path AS repo_path, r.name AS repo_name,
       r.repo_url AS repo_url, r.source_path AS repo_source_path
     FROM schedule_runs sr

--- a/backend/src/db/schedules.ts
+++ b/backend/src/db/schedules.ts
@@ -3,7 +3,6 @@ import {
   ScheduleJobSchema,
   ScheduleRunSchema,
   ScheduleSkillMetadataSchema,
-  type ScheduleIsolationMode,
   type ScheduleJob,
   type ScheduleMode,
   type ScheduleRun,
@@ -28,7 +27,6 @@ interface ScheduleJobRow {
   model: string | null
   skill_metadata: string | null
   branch: string | null
-  isolation_mode: string | null
   created_at: number
   updated_at: number
   last_run_at: number | null
@@ -84,7 +82,6 @@ function rowToScheduleJob(row: ScheduleJobRow): ScheduleJob {
     model: row.model,
     skillMetadata: parseSkillMetadata(row.skill_metadata),
     branch: row.branch,
-    isolationMode: (row.isolation_mode as ScheduleIsolationMode) ?? 'worktree',
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     lastRunAt: row.last_run_at,
@@ -150,10 +147,10 @@ export function createScheduleJob(db: Database, repoId: number, input: ScheduleJ
   const stmt = db.prepare(`
     INSERT INTO schedule_jobs (
       repo_id, name, description, enabled, schedule_mode, interval_minutes, cron_expression, timezone, agent_slug, prompt, model, skill_metadata,
-      branch, isolation_mode,
+      branch,
       created_at, updated_at, last_run_at, next_run_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
 
   const result = stmt.run(
@@ -170,7 +167,6 @@ export function createScheduleJob(db: Database, repoId: number, input: ScheduleJ
     input.model ?? null,
     serializeSkillMetadata(input.skillMetadata),
     input.branch,
-    input.isolationMode,
     now,
     now,
     null,
@@ -195,7 +191,7 @@ export function updateScheduleJob(db: Database, repoId: number, jobId: number, i
   const stmt = db.prepare(`
     UPDATE schedule_jobs
     SET name = ?, description = ?, enabled = ?, schedule_mode = ?, interval_minutes = ?, cron_expression = ?, timezone = ?,
-        agent_slug = ?, prompt = ?, model = ?, skill_metadata = ?, branch = ?, isolation_mode = ?, updated_at = ?, next_run_at = ?
+        agent_slug = ?, prompt = ?, model = ?, skill_metadata = ?, branch = ?, updated_at = ?, next_run_at = ?
     WHERE repo_id = ? AND id = ?
   `)
 
@@ -212,7 +208,6 @@ export function updateScheduleJob(db: Database, repoId: number, jobId: number, i
     input.model,
     serializeSkillMetadata(input.skillMetadata),
     input.branch,
-    input.isolationMode,
     now,
     input.nextRunAt,
     repoId,
@@ -227,6 +222,41 @@ export function deleteScheduleJob(db: Database, repoId: number, jobId: number): 
   const stmt = db.prepare('DELETE FROM schedule_jobs WHERE repo_id = ? AND id = ?')
   const result = stmt.run(repoId, jobId)
   return result.changes > 0
+}
+
+export interface ScheduleRunArtifact {
+  id: number
+  status: ScheduleRunStatus
+  runBranch: string | null
+  worktreePath: string | null
+}
+
+export function listScheduleRunArtifactsByJob(db: Database, repoId: number, jobId: number): ScheduleRunArtifact[] {
+  const rows = db
+    .prepare('SELECT id, status, run_branch, worktree_path FROM schedule_runs WHERE repo_id = ? AND job_id = ? ORDER BY id DESC')
+    .all(repoId, jobId) as { id: number; status: string; run_branch: string | null; worktree_path: string | null }[]
+  return rows.map((row) => ({
+    id: row.id,
+    status: row.status as ScheduleRunStatus,
+    runBranch: row.run_branch,
+    worktreePath: row.worktree_path,
+  }))
+}
+
+export function deleteScheduleRunById(db: Database, repoId: number, jobId: number, runId: number): boolean {
+  const result = db
+    .prepare('DELETE FROM schedule_runs WHERE repo_id = ? AND job_id = ? AND id = ?')
+    .run(repoId, jobId, runId)
+  return result.changes > 0
+}
+
+export function deleteScheduleRunsByIds(db: Database, repoId: number, jobId: number, runIds: number[]): number {
+  if (runIds.length === 0) return 0
+  const placeholders = runIds.map(() => '?').join(', ')
+  const result = db
+    .prepare(`DELETE FROM schedule_runs WHERE repo_id = ? AND job_id = ? AND id IN (${placeholders})`)
+    .run(repoId, jobId, ...runIds)
+  return result.changes
 }
 
 export function cleanupOrphanedSchedules(db: Database): { orphanedJobs: number; orphanedRuns: number } {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -44,6 +44,8 @@ import { opencodeServerManager } from './services/opencode-single-server'
 import { createOpenCodeClient } from './services/opencode/client'
 import { NotificationService } from './services/notification'
 import { ScheduleRunner, ScheduleService } from './services/schedules'
+import { CredentialProvider } from './services/credential-provider'
+import { ScheduleWorktreeManager } from './services/schedule-worktree'
 import { migrateGlobalSkills } from './services/skills'
 import { installAssistantWorkspace } from './services/assistant-mode'
 import { getOpenCodeImportStatus, syncOpenCodeImport } from './services/opencode-import'
@@ -287,7 +289,10 @@ try {
   logger.error('Failed to initialize workspace:', error)
 }
 
-const scheduleService = new ScheduleService(db, openCodeClient)
+const settingsServiceForSchedules = new SettingsService(db)
+const credentialProvider = new CredentialProvider(db)
+const scheduleWorktreeManager = new ScheduleWorktreeManager(gitAuthService, settingsServiceForSchedules, credentialProvider, db)
+const scheduleService = new ScheduleService(db, openCodeClient, scheduleWorktreeManager)
 const scheduleRunnerInstance = new ScheduleRunner(scheduleService)
 
 const notificationService = new NotificationService(db)

--- a/backend/src/routes/schedules.ts
+++ b/backend/src/routes/schedules.ts
@@ -159,6 +159,29 @@ export function createScheduleRoutes(scheduleService: ScheduleService) {
     }
   })
 
+  app.delete('/:jobId/runs', async (c) => {
+    try {
+      const repoId = parseId(c.req.param('id'), 'repo id', ScheduleServiceError)
+      const jobId = parseId(c.req.param('jobId'), 'schedule id', ScheduleServiceError)
+      const result = await scheduleService.clearRunHistory(repoId, jobId)
+      return c.json(result)
+    } catch (error) {
+      return handleServiceError(c, error, 'Failed to clear schedule run history', ScheduleServiceError)
+    }
+  })
+
+  app.delete('/:jobId/runs/:runId', async (c) => {
+    try {
+      const repoId = parseId(c.req.param('id'), 'repo id', ScheduleServiceError)
+      const jobId = parseId(c.req.param('jobId'), 'schedule id', ScheduleServiceError)
+      const runId = parseId(c.req.param('runId'), 'run id', ScheduleServiceError)
+      await scheduleService.deleteRun(repoId, jobId, runId)
+      return c.json({ success: true })
+    } catch (error) {
+      return handleServiceError(c, error, 'Failed to delete schedule run', ScheduleServiceError)
+    }
+  })
+
   return app
 }
 

--- a/backend/src/services/repo.ts
+++ b/backend/src/services/repo.ts
@@ -6,7 +6,7 @@ import { createRepo, getRepoByLocalPath, getRepoBySourcePath, getRepoById, updat
 import type { Database } from 'bun:sqlite'
 import type { Repo, CreateRepoInput } from '../types/repo'
 import { logger } from '../utils/logger'
-import { getReposPath } from '@opencode-manager/shared/config/env'
+import { getReposPath, getScheduleWorktreesPath } from '@opencode-manager/shared/config/env'
 import { normalizeRepoDirectoryName, sanitizeRepoDirectoryName, sanitizeBranchForDirectory, normalizeRepoUrlForCompare } from '@opencode-manager/shared/utils'
 import type { GitAuthService } from './git-auth'
 import { isGitHubHttpsUrl, isSSHUrl, normalizeSSHUrl } from '../utils/git-auth'
@@ -1170,6 +1170,7 @@ export async function getSiblingRepos(
     const knownDirectories = new Set(repoSiblings.map((repo) => canonical(repo.fullPath)))
     const targetDirectory = canonical(target.fullPath)
     const reposRoot = canonical(getReposPath())
+    const scheduleWorktreeRoot = canonical(getScheduleWorktreesPath())
 
     const candidates = workspaces.filter((workspace) => {
       if (workspace.projectID !== targetProjectId) return false
@@ -1178,6 +1179,7 @@ export async function getSiblingRepos(
       const workspaceDirectory = canonical(workspace.directory)
       if (workspaceDirectory === targetDirectory) return false
       if (workspaceDirectory === reposRoot) return false
+      if (workspaceDirectory.startsWith(`${scheduleWorktreeRoot}${path.sep}`)) return false
       if (knownDirectories.has(workspaceDirectory)) return false
 
       return true

--- a/backend/src/services/repo.ts
+++ b/backend/src/services/repo.ts
@@ -947,13 +947,7 @@ export async function deleteRepoFiles(database: Database, repoId: number): Promi
     const { name: repoName } = normalizeRepoUrl(repo.repoUrl)
     const baseRepoPath = path.resolve(getReposPath(), repoName)
 
-    try {
-      await executeCommand(['git', '-C', baseRepoPath, 'worktree', 'remove', '--force', fullPath])
-    } catch {
-      // Worktree removal failed, continue with directory removal
-    } finally {
-      await executeCommand(['git', '-C', baseRepoPath, 'worktree', 'prune']).catch(() => {})
-    }
+    await removeWorktree(baseRepoPath, fullPath)
   }
 
   await executeCommand(['rm', '-rf', repo.localPath], getReposPath())
@@ -1008,12 +1002,27 @@ function normalizeRepoUrl(url: string, preserveSSH: boolean = false): { url: str
   }
 }
 
-async function createWorktreeSafely(baseRepoPath: string, worktreePath: string, branch: string, env: Record<string, string>, baseBranch?: string): Promise<void> {
+export async function resolveDefaultBranch(repoPath: string, env: Record<string, string>): Promise<string> {
+  return executeCommand(['git', '-C', repoPath, 'rev-parse', '--abbrev-ref', 'origin/HEAD'], { env, silent: true })
+    .then((ref) => ref.trim().replace('origin/', ''))
+    .catch(() => 'main')
+}
+
+export async function removeWorktree(baseRepoPath: string, worktreePath: string, env?: Record<string, string>): Promise<void> {
+  try {
+    await executeCommand(['git', '-C', baseRepoPath, 'worktree', 'remove', '--force', worktreePath], env ? { env } : undefined)
+  } catch {
+    // fall through to prune + rm
+  } finally {
+    await executeCommand(['git', '-C', baseRepoPath, 'worktree', 'prune'], env ? { env } : undefined).catch(() => {})
+  }
+  await executeCommand(['rm', '-rf', worktreePath]).catch(() => {})
+}
+
+export async function createWorktreeSafely(baseRepoPath: string, worktreePath: string, branch: string, env: Record<string, string>, baseBranch?: string): Promise<void> {
   const currentBranch = await safeGetCurrentBranch(baseRepoPath, env)
   if (currentBranch === branch) {
-    const defaultBranch = await executeCommand(['git', '-C', baseRepoPath, 'rev-parse', '--abbrev-ref', 'origin/HEAD'], { env })
-      .then(ref => ref.trim().replace('origin/', ''))
-      .catch(() => 'main')
+    const defaultBranch = await resolveDefaultBranch(baseRepoPath, env)
 
     await executeCommand(['git', '-C', baseRepoPath, 'checkout', defaultBranch], { env })
       .catch(() => executeCommand(['git', '-C', baseRepoPath, 'checkout', 'main'], { env }))

--- a/backend/src/services/schedule-config.ts
+++ b/backend/src/services/schedule-config.ts
@@ -1,6 +1,7 @@
 import { Cron } from 'croner'
 import type {
   CreateScheduleJobRequest,
+  ScheduleIsolationMode,
   ScheduleJob,
   ScheduleMode,
   ScheduleSkillMetadata,
@@ -21,6 +22,8 @@ export interface ScheduleJobPersistenceInput {
   prompt: string
   model: string | null
   skillMetadata: ScheduleSkillMetadata | null | undefined
+  branch: string | null
+  isolationMode: ScheduleIsolationMode
   nextRunAt: number | null
 }
 
@@ -95,6 +98,8 @@ export function buildCreateSchedulePersistenceInput(input: CreateScheduleJobRequ
     prompt: input.prompt.trim(),
     model: input.model?.trim() || null,
     skillMetadata: input.skillMetadata,
+    branch: input.branch?.trim() || null,
+    isolationMode: input.isolationMode ?? 'worktree' as const,
   }
 
   const scheduleConfig = input.scheduleMode === 'cron'
@@ -151,6 +156,8 @@ export function buildUpdatedSchedulePersistenceInput(
     prompt: input.prompt?.trim() || existing.prompt,
     model: input.model === undefined ? existing.model : (input.model?.trim() || null),
     skillMetadata: input.skillMetadata !== undefined ? input.skillMetadata : existing.skillMetadata,
+    branch: input.branch === undefined ? existing.branch : (input.branch?.trim() || null),
+    isolationMode: input.isolationMode ?? existing.isolationMode,
     nextRunAt,
   }
 }

--- a/backend/src/services/schedule-config.ts
+++ b/backend/src/services/schedule-config.ts
@@ -1,7 +1,6 @@
 import { Cron } from 'croner'
 import type {
   CreateScheduleJobRequest,
-  ScheduleIsolationMode,
   ScheduleJob,
   ScheduleMode,
   ScheduleSkillMetadata,
@@ -23,7 +22,6 @@ export interface ScheduleJobPersistenceInput {
   model: string | null
   skillMetadata: ScheduleSkillMetadata | null | undefined
   branch: string | null
-  isolationMode: ScheduleIsolationMode
   nextRunAt: number | null
 }
 
@@ -99,7 +97,6 @@ export function buildCreateSchedulePersistenceInput(input: CreateScheduleJobRequ
     model: input.model?.trim() || null,
     skillMetadata: input.skillMetadata,
     branch: input.branch?.trim() || null,
-    isolationMode: input.isolationMode ?? 'worktree' as const,
   }
 
   const scheduleConfig = input.scheduleMode === 'cron'
@@ -157,7 +154,6 @@ export function buildUpdatedSchedulePersistenceInput(
     model: input.model === undefined ? existing.model : (input.model?.trim() || null),
     skillMetadata: input.skillMetadata !== undefined ? input.skillMetadata : existing.skillMetadata,
     branch: input.branch === undefined ? existing.branch : (input.branch?.trim() || null),
-    isolationMode: input.isolationMode ?? existing.isolationMode,
     nextRunAt,
   }
 }

--- a/backend/src/services/schedule-worktree.ts
+++ b/backend/src/services/schedule-worktree.ts
@@ -62,14 +62,17 @@ export class ScheduleWorktreeManager {
       await executeCommand(['git', '-C', repo.fullPath, 'fetch', '--prune', 'origin'], { env }).catch(() => {})
 
       const base = job.branch?.trim() || (await resolveDefaultBranch(repo.fullPath, env))
+      const baseRef = await this.resolveBaseRef(repo.fullPath, base, env)
+      if (!baseRef) {
+        throw new Error(`Base branch "${base}" was not found in this repository. Choose an existing branch in the schedule settings.`)
+      }
+
       const runBranch = `schedule/${job.id}/run-${runId}`
       const worktreePath = path.join(getScheduleWorktreesPath(), `job-${job.id}-run-${runId}`)
 
       mkdirSync(path.dirname(worktreePath), { recursive: true })
 
-      await createWorktreeSafely(repo.fullPath, worktreePath, runBranch, env, `origin/${base}`).catch(() =>
-        createWorktreeSafely(repo.fullPath, worktreePath, runBranch, env, base),
-      )
+      await createWorktreeSafely(repo.fullPath, worktreePath, runBranch, env, baseRef)
 
       if (!existsSync(worktreePath)) {
         throw new Error(`Worktree directory was not created at: ${worktreePath}`)
@@ -160,6 +163,24 @@ export class ScheduleWorktreeManager {
     if (branches.length > 0) {
       await executeCommand(['git', '-C', repo.fullPath, 'branch', '-D', ...branches], { env }).catch(() => {})
     }
+  }
+
+  /**
+   * Resolves a user-supplied base branch name to a verified git ref, preferring
+   * the remote-tracking branch for freshness. Returns null when neither the
+   * remote nor local ref exists, allowing the caller to fail with a clear error
+   * instead of a cryptic git "not a valid object name" failure.
+   */
+  private async resolveBaseRef(repoPath: string, base: string, env: Record<string, string>): Promise<string | null> {
+    for (const candidate of [`refs/remotes/origin/${base}`, `refs/heads/${base}`]) {
+      try {
+        await executeCommand(['git', '-C', repoPath, 'rev-parse', '--verify', candidate], { env, silent: true })
+        return candidate.startsWith('refs/remotes/') ? `origin/${base}` : base
+      } catch {
+        continue
+      }
+    }
+    return null
   }
 
   private async buildGitEnv(repo: Repo, sshSetup: boolean, silent: boolean): Promise<Record<string, string>> {

--- a/backend/src/services/schedule-worktree.ts
+++ b/backend/src/services/schedule-worktree.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from 'node:fs'
 import path from 'path'
 import type { Database } from 'bun:sqlite'
-import { getReposPath } from '@opencode-manager/shared/config/env'
+import { getScheduleWorktreesPath } from '@opencode-manager/shared/config/env'
 import { ASSISTANT_REPO_ID } from '@opencode-manager/shared/utils'
 import type { Repo } from '../types/repo'
 import type { GitAuthService } from './git-auth'
@@ -39,10 +39,9 @@ export class ScheduleWorktreeManager {
 
   async prepare(
     repo: Repo,
-    job: { id: number; isolationMode: string; branch: string | null },
+    job: { id: number; branch: string | null },
     runId: number,
   ): Promise<ScheduleWorktreeContext | null> {
-    if (job.isolationMode === 'inline') return null
     if (repo.id === ASSISTANT_REPO_ID) return null
 
     try {
@@ -58,16 +57,13 @@ export class ScheduleWorktreeManager {
     }
 
     try {
-      const baseEnv = this.gitAuthService.getGitEnvironment(true)
-      const sshEnv = sshSetup ? this.gitAuthService.getSSHEnvironment() : {}
-      const identityEnv = await this.buildIdentityEnv()
-      const env = { ...baseEnv, ...buildRepoEnvForRepo(repo), ...sshEnv, ...identityEnv }
+      const env = await this.buildGitEnv(repo, sshSetup, true)
 
-      await executeCommand(['git', '-C', repo.fullPath, 'fetch', '--all', '--prune'], { env }).catch(() => {})
+      await executeCommand(['git', '-C', repo.fullPath, 'fetch', '--prune', 'origin'], { env }).catch(() => {})
 
       const base = job.branch?.trim() || (await resolveDefaultBranch(repo.fullPath, env))
       const runBranch = `schedule/${job.id}/run-${runId}`
-      const worktreePath = path.join(getReposPath(), '.ocm-schedule-worktrees', `job-${job.id}-run-${runId}`)
+      const worktreePath = path.join(getScheduleWorktreesPath(), `job-${job.id}-run-${runId}`)
 
       mkdirSync(path.dirname(worktreePath), { recursive: true })
 
@@ -98,6 +94,7 @@ export class ScheduleWorktreeManager {
 
     let sshSetup = false
     let env: Record<string, string> | undefined
+    let noChanges = false
 
     try {
       if (repo.repoUrl && isSSHUrl(repo.repoUrl)) {
@@ -105,14 +102,12 @@ export class ScheduleWorktreeManager {
         sshSetup = true
       }
 
-      const baseEnv = this.gitAuthService.getGitEnvironment()
-      const sshEnv = sshSetup ? this.gitAuthService.getSSHEnvironment() : {}
-      const identityEnv = await this.buildIdentityEnv()
-      env = { ...baseEnv, ...buildRepoEnvForRepo(repo), ...sshEnv, ...identityEnv }
+      env = await this.buildGitEnv(repo, sshSetup, false)
 
       const status = await executeCommand(['git', '-C', run.worktreePath, 'status', '--porcelain'], { env }).catch(() => '')
 
       if (!status.trim()) {
+        noChanges = true
         return { commitHash: null }
       }
 
@@ -132,6 +127,9 @@ export class ScheduleWorktreeManager {
     } finally {
       try {
         await removeWorktree(repo.fullPath, run.worktreePath, env)
+        if (noChanges && run.runBranch) {
+          await executeCommand(['git', '-C', repo.fullPath, 'branch', '-D', run.runBranch], env ? { env } : undefined).catch(() => {})
+        }
       } catch (error) {
         logger.error(`Failed to remove worktree ${run.worktreePath}:`, error)
       }
@@ -139,6 +137,36 @@ export class ScheduleWorktreeManager {
         await this.gitAuthService.cleanupSSHKey()
       }
     }
+  }
+
+  /**
+   * Removes leftover worktrees and deletes the run branches for a set of
+   * finished runs. Used when clearing run history. Branch and worktree removal
+   * are local git operations, so no SSH setup is needed; failures are swallowed
+   * per artifact so one bad entry does not block the rest.
+   */
+  async pruneRunArtifacts(repo: Repo, artifacts: { runBranch: string | null; worktreePath: string | null }[]): Promise<void> {
+    if (artifacts.length === 0) return
+
+    const env = await this.buildGitEnv(repo, false, true)
+
+    for (const artifact of artifacts) {
+      if (artifact.worktreePath) {
+        await removeWorktree(repo.fullPath, artifact.worktreePath, env)
+      }
+    }
+
+    const branches = artifacts.map((a) => a.runBranch).filter((b): b is string => b !== null && b.length > 0)
+    if (branches.length > 0) {
+      await executeCommand(['git', '-C', repo.fullPath, 'branch', '-D', ...branches], { env }).catch(() => {})
+    }
+  }
+
+  private async buildGitEnv(repo: Repo, sshSetup: boolean, silent: boolean): Promise<Record<string, string>> {
+    const baseEnv = this.gitAuthService.getGitEnvironment(silent)
+    const sshEnv = sshSetup ? this.gitAuthService.getSSHEnvironment() : {}
+    const identityEnv = await this.buildIdentityEnv()
+    return { ...baseEnv, ...buildRepoEnvForRepo(repo), ...sshEnv, ...identityEnv }
   }
 
   private async buildIdentityEnv(): Promise<Record<string, string>> {

--- a/backend/src/services/schedule-worktree.ts
+++ b/backend/src/services/schedule-worktree.ts
@@ -1,0 +1,150 @@
+import { existsSync, mkdirSync } from 'node:fs'
+import path from 'path'
+import type { Database } from 'bun:sqlite'
+import { getReposPath } from '@opencode-manager/shared/config/env'
+import { ASSISTANT_REPO_ID } from '@opencode-manager/shared/utils'
+import type { Repo } from '../types/repo'
+import type { GitAuthService } from './git-auth'
+import type { SettingsService } from './settings'
+import type { CredentialProvider } from './credential-provider'
+import { resolveGitIdentity, createGitIdentityEnv, isSSHUrl } from '../utils/git-auth'
+import { executeCommand } from '../utils/process'
+import { resolveDefaultBranch, createWorktreeSafely, removeWorktree } from './repo'
+import { logger } from '../utils/logger'
+
+export interface ScheduleWorktreeContext {
+  directory: string
+  worktreePath: string
+  runBranch: string
+}
+
+/**
+ * Build repo-context environment variables used by the GIT_ASKPASS handler
+ * to resolve repo-specific credentials. Mirrors GitService.getEnvironmentForRepo.
+ */
+export function buildRepoEnvForRepo(repo: { id?: number; fullPath: string }): Record<string, string> {
+  return {
+    ...(repo.id ? { OCM_GIT_REPO_ID: String(repo.id) } : {}),
+    OCM_GIT_REPO_CWD: repo.fullPath,
+  }
+}
+
+export class ScheduleWorktreeManager {
+  constructor(
+    private readonly gitAuthService: GitAuthService,
+    private readonly settingsService: SettingsService,
+    private readonly credentialProvider: CredentialProvider,
+    private readonly db: Database,
+  ) {}
+
+  async prepare(
+    repo: Repo,
+    job: { id: number; isolationMode: string; branch: string | null },
+    runId: number,
+  ): Promise<ScheduleWorktreeContext | null> {
+    if (job.isolationMode === 'inline') return null
+    if (repo.id === ASSISTANT_REPO_ID) return null
+
+    try {
+      await executeCommand(['git', '-C', repo.fullPath, 'rev-parse', '--is-inside-work-tree'], { silent: true })
+    } catch {
+      return null
+    }
+
+    let sshSetup = false
+    if (repo.repoUrl && isSSHUrl(repo.repoUrl)) {
+      await this.gitAuthService.setupSSHForRepoUrl(repo.repoUrl, this.db)
+      sshSetup = true
+    }
+
+    try {
+      const baseEnv = this.gitAuthService.getGitEnvironment(true)
+      const sshEnv = sshSetup ? this.gitAuthService.getSSHEnvironment() : {}
+      const identityEnv = await this.buildIdentityEnv()
+      const env = { ...baseEnv, ...buildRepoEnvForRepo(repo), ...sshEnv, ...identityEnv }
+
+      await executeCommand(['git', '-C', repo.fullPath, 'fetch', '--all', '--prune'], { env }).catch(() => {})
+
+      const base = job.branch?.trim() || (await resolveDefaultBranch(repo.fullPath, env))
+      const runBranch = `schedule/${job.id}/run-${runId}`
+      const worktreePath = path.join(getReposPath(), '.ocm-schedule-worktrees', `job-${job.id}-run-${runId}`)
+
+      mkdirSync(path.dirname(worktreePath), { recursive: true })
+
+      await createWorktreeSafely(repo.fullPath, worktreePath, runBranch, env, `origin/${base}`).catch(() =>
+        createWorktreeSafely(repo.fullPath, worktreePath, runBranch, env, base),
+      )
+
+      if (!existsSync(worktreePath)) {
+        throw new Error(`Worktree directory was not created at: ${worktreePath}`)
+      }
+
+      return { directory: worktreePath, worktreePath, runBranch }
+    } finally {
+      if (sshSetup) {
+        await this.gitAuthService.cleanupSSHKey()
+      }
+    }
+  }
+
+  async finalize(
+    repo: Repo,
+    job: { id: number; name: string; prompt: string },
+    run: { id: number; worktreePath: string | null; runBranch: string | null; triggerSource: string },
+  ): Promise<{ commitHash: string | null }> {
+    if (!run.worktreePath) {
+      return { commitHash: null }
+    }
+
+    let sshSetup = false
+    let env: Record<string, string> | undefined
+
+    try {
+      if (repo.repoUrl && isSSHUrl(repo.repoUrl)) {
+        await this.gitAuthService.setupSSHForRepoUrl(repo.repoUrl, this.db)
+        sshSetup = true
+      }
+
+      const baseEnv = this.gitAuthService.getGitEnvironment()
+      const sshEnv = sshSetup ? this.gitAuthService.getSSHEnvironment() : {}
+      const identityEnv = await this.buildIdentityEnv()
+      env = { ...baseEnv, ...buildRepoEnvForRepo(repo), ...sshEnv, ...identityEnv }
+
+      const status = await executeCommand(['git', '-C', run.worktreePath, 'status', '--porcelain'], { env }).catch(() => '')
+
+      if (!status.trim()) {
+        return { commitHash: null }
+      }
+
+      await executeCommand(['git', '-C', run.worktreePath, 'add', '-A'], { env })
+
+      const title = `Scheduled run: ${job.name} (run #${run.id})`
+      const promptSummary = job.prompt.length > 200 ? `${job.prompt.slice(0, 200)}...` : job.prompt
+      const body = `Trigger: ${run.triggerSource}\nPrompt: ${promptSummary}`
+      await executeCommand(['git', '-C', run.worktreePath, 'commit', '-m', title, '-m', body], { env })
+
+      const commitHash = (await executeCommand(['git', '-C', run.worktreePath, 'rev-parse', 'HEAD'], { env })).trim()
+
+      return { commitHash }
+    } catch (error) {
+      logger.error(`Failed to finalize schedule run ${run.id} in worktree ${run.worktreePath}:`, error)
+      throw error
+    } finally {
+      try {
+        await removeWorktree(repo.fullPath, run.worktreePath, env)
+      } catch (error) {
+        logger.error(`Failed to remove worktree ${run.worktreePath}:`, error)
+      }
+      if (sshSetup) {
+        await this.gitAuthService.cleanupSSHKey()
+      }
+    }
+  }
+
+  private async buildIdentityEnv(): Promise<Record<string, string>> {
+    const settings = this.settingsService.getSettings()
+    const gitCredentials = this.credentialProvider.getGitCredentials()
+    const identity = await resolveGitIdentity(settings.preferences.gitIdentity, gitCredentials)
+    return identity ? createGitIdentityEnv(identity) : {}
+  }
+}

--- a/backend/src/services/schedules.ts
+++ b/backend/src/services/schedules.ts
@@ -28,6 +28,7 @@ import {
   updateScheduleJobRunState,
   updateScheduleRun,
   updateScheduleRunMetadata,
+  updateScheduleRunWorktree,
 } from '../db/schedules'
 import type { ListAllRunsOptions, ScheduleRunWithContext } from '../db/schedules'
 import {
@@ -37,6 +38,8 @@ import {
 } from './schedule-config'
 import { resolveOpenCodeModel } from './opencode-models'
 import type { OpenCodeClient } from './opencode/client'
+import type { ScheduleWorktreeManager } from './schedule-worktree'
+import type { Repo } from '../types/repo'
 import { sseAggregator, type SSEEvent } from './sse-aggregator'
 import { getErrorMessage } from '../utils/error-utils'
 import { logger } from '../utils/logger'
@@ -355,11 +358,13 @@ function createSessionMonitor(directory: string, sessionId: string): SessionMoni
 
 export class ScheduleService {
   private static activeRuns = new Set<number>()
+  private static activeTeardowns = new Set<string>()
   private onJobChange: ((job: ScheduleJob | null, jobId: number) => void) | null = null
 
   constructor(
     private readonly db: Database,
     private readonly openCodeClient: OpenCodeClient,
+    private readonly worktreeManager: ScheduleWorktreeManager,
   ) {}
 
   setJobChangeHandler(handler: ((job: ScheduleJob | null, jobId: number) => void) | null): void {
@@ -439,6 +444,17 @@ export class ScheduleService {
 
   deleteJob(repoId: number, jobId: number): void {
     this.assertRepo(repoId)
+    this.assertJob(repoId, jobId)
+
+    if (ScheduleService.activeRuns.has(jobId)) {
+      throw new ScheduleServiceError('Cannot delete a schedule while it is running. Cancel the run first.', 409)
+    }
+
+    const runningRun = getRunningScheduleRunByJob(this.db, repoId, jobId)
+    if (runningRun) {
+      throw new ScheduleServiceError('Cannot delete a schedule while it is running. Cancel the run first.', 409)
+    }
+
     const deleted = deleteScheduleJob(this.db, repoId, jobId)
     if (!deleted) {
       throw new ScheduleServiceError('Schedule not found', 404)
@@ -449,6 +465,15 @@ export class ScheduleService {
   prepareRepoDelete(repoId: number): void {
     const jobIds = listScheduleJobIdsByRepo(this.db, repoId)
     for (const jobId of jobIds) {
+      if (ScheduleService.activeRuns.has(jobId)) {
+        throw new ScheduleServiceError('Cannot delete a repo while a schedule run is in progress. Cancel the run first.', 409)
+      }
+
+      const runningRun = getRunningScheduleRunByJob(this.db, repoId, jobId)
+      if (runningRun) {
+        throw new ScheduleServiceError('Cannot delete a repo while a schedule run is in progress. Cancel the run first.', 409)
+      }
+
       this.onJobChange?.(null, jobId)
     }
   }
@@ -506,14 +531,24 @@ export class ScheduleService {
     })
 
     try {
-      const model = await resolveOpenCodeModel(this.openCodeClient, repo.fullPath, {
+      // Prepare worktree for isolated runs
+      const wt = await this.worktreeManager.prepare(repo, job, run.id)
+      const runDirectory = wt?.directory ?? repo.fullPath
+      if (wt) {
+        updateScheduleRunWorktree(this.db, repoId, jobId, run.id, {
+          worktreePath: wt.worktreePath,
+          runBranch: wt.runBranch,
+        })
+      }
+
+      const model = await resolveOpenCodeModel(this.openCodeClient, runDirectory, {
         preferredModel: job.model,
       })
       const sessionTitle = buildSessionTitle(job)
       const sessionResponse = await this.openCodeClient.forward({
         method: 'POST',
         path: '/session',
-        directory: repo.fullPath,
+        directory: runDirectory,
         body: JSON.stringify({
           title: sessionTitle,
           agent: job.agentSlug ?? undefined,
@@ -541,7 +576,7 @@ export class ScheduleService {
         throw new ScheduleServiceError('Failed to attach session to run', 500)
       }
 
-      const sessionMonitor = createSessionMonitor(repo.fullPath, session.id)
+      const sessionMonitor = createSessionMonitor(runDirectory, session.id)
 
       void this.submitPromptAndMonitor({
         repoId,
@@ -552,6 +587,7 @@ export class ScheduleService {
         triggerSource,
         model,
         sessionMonitor,
+        directory: runDirectory,
       })
 
       return runWithSession
@@ -581,6 +617,9 @@ export class ScheduleService {
         logger.error(`Failed to update job state for job ${jobId}:`, updateError)
       }
 
+      // Teardown worktree if one was created before the error
+      await this.teardownWorktree(repoId, jobId, run.id, job, repo)
+
       if (!failedRun) {
         ScheduleService.activeRuns.delete(jobId)
         throw new ScheduleServiceError('Failed to load failed run', 500)
@@ -605,16 +644,18 @@ export class ScheduleService {
       throw new ScheduleServiceError('Only running schedule runs can be cancelled', 409)
     }
 
+    const runDirectory = run.worktreePath ?? repo.fullPath
+
     if (run.sessionId) {
-      const messages = await this.listSessionMessages(repo.fullPath, run.sessionId)
+      const messages = await this.listSessionMessages(runDirectory, run.sessionId)
       const assistantState = getAssistantMessageState(messages)
 
       if (assistantState?.completed || assistantState?.errorText) {
-        this.finalizeRecoveredRun(job, run, {
+        await this.finalizeRecoveredRun(job, run, {
           status: assistantState.errorText ? 'failed' : 'completed',
           responseText: assistantState.responseText,
           errorText: assistantState.errorText,
-        })
+        }, repo)
 
         return this.getRun(repoId, jobId, runId)
       }
@@ -622,7 +663,7 @@ export class ScheduleService {
       const abortResponse = await this.openCodeClient.forward({
         method: 'POST',
         path: `/session/${run.sessionId}/abort`,
-        directory: repo.fullPath,
+        directory: runDirectory,
       })
 
       if (!abortResponse.ok) {
@@ -656,6 +697,7 @@ export class ScheduleService {
       nextRunAt: job.nextRunAt,
     })
 
+    await this.teardownWorktree(repoId, jobId, runId, job, repo)
     ScheduleService.activeRuns.delete(jobId)
 
     if (!cancelledRun) {
@@ -674,6 +716,7 @@ export class ScheduleService {
     triggerSource: ScheduleRunTriggerSource
     model: { providerID: string; modelID: string }
     sessionMonitor: SessionMonitor
+    directory: string
   }): Promise<void> {
     const repo = this.assertRepo(input.repoId)
 
@@ -681,9 +724,9 @@ export class ScheduleService {
       const promptResponse = await this.openCodeClient.forward({
         method: 'POST',
         path: `/session/${input.sessionId}/message`,
-        directory: repo.fullPath,
+        directory: input.directory,
         body: JSON.stringify({
-          parts: [{ type: 'text', text: await buildPromptWithSkills(input.job.prompt, input.job.skillMetadata, repo.fullPath, this.openCodeClient) }],
+          parts: [{ type: 'text', text: await buildPromptWithSkills(input.job.prompt, input.job.skillMetadata, input.directory, this.openCodeClient) }],
           model: input.model,
         }),
         headers: { 'Content-Type': 'application/json' },
@@ -737,6 +780,7 @@ export class ScheduleService {
         sessionId: input.sessionId,
         sessionTitle: input.sessionTitle,
         triggerSource: input.triggerSource,
+        directory: input.directory,
       })
       return
     } catch (error) {
@@ -771,6 +815,7 @@ export class ScheduleService {
       })
     } finally {
       input.sessionMonitor.dispose()
+      await this.teardownWorktree(input.repoId, input.job.id, input.runId, input.job, repo)
       ScheduleService.activeRuns.delete(input.job.id)
     }
   }
@@ -783,16 +828,17 @@ export class ScheduleService {
     sessionId: string
     sessionTitle: string
     triggerSource: ScheduleRunTriggerSource
+    directory: string
     initialSessionStatus?: SessionStatus
   }): Promise<void> {
     try {
       const sessionStatus = input.initialSessionStatus
       if (sessionStatus && sessionStatus.type === 'idle') {
         const repo = this.assertRepo(input.repoId)
-        const messages = await this.listSessionMessages(repo.fullPath, input.sessionId)
+        const messages = await this.listSessionMessages(input.directory, input.sessionId)
         const assistantState = getAssistantMessageState(messages)
         if (assistantState?.completed || assistantState?.errorText) {
-          this.finalizeRecoveredRun(input.job, {
+          await this.finalizeRecoveredRun(input.job, {
             id: input.runId,
             repoId: input.repoId,
             jobId: input.job.id,
@@ -803,16 +849,16 @@ export class ScheduleService {
             status: assistantState.errorText ? 'failed' : 'completed',
             responseText: assistantState.responseText,
             errorText: assistantState.errorText,
-          })
+          }, repo)
           return
         }
       }
 
       const repo = this.assertRepo(input.repoId)
-      const currentMessages = await this.listSessionMessages(repo.fullPath, input.sessionId)
+      const currentMessages = await this.listSessionMessages(input.directory, input.sessionId)
       const currentAssistantState = getAssistantMessageState(currentMessages)
       if (currentAssistantState?.completed || currentAssistantState?.errorText) {
-        this.finalizeRecoveredRun(input.job, {
+        await this.finalizeRecoveredRun(input.job, {
           id: input.runId,
           repoId: input.repoId,
           jobId: input.job.id,
@@ -823,11 +869,11 @@ export class ScheduleService {
           status: currentAssistantState.errorText ? 'failed' : 'completed',
           responseText: currentAssistantState.responseText,
           errorText: currentAssistantState.errorText,
-        })
+        }, repo)
         return
       }
 
-      const response = await this.waitForAssistantMessage(input.job, input.sessionId, input.sessionMonitor)
+      const response = await this.waitForAssistantMessage(input.job, input.sessionId, input.sessionMonitor, input.directory)
       const currentRun = getScheduleRunById(this.db, input.repoId, input.job.id, input.runId)
       if (!currentRun || currentRun.status !== 'running') {
         return
@@ -907,6 +953,7 @@ export class ScheduleService {
       })
     } finally {
       input.sessionMonitor.dispose()
+      await this.teardownWorktree(input.repoId, input.job.id, input.runId, input.job, this.assertRepo(input.repoId))
       ScheduleService.activeRuns.delete(input.job.id)
     }
   }
@@ -914,32 +961,33 @@ export class ScheduleService {
   private async recoverRunningRun(job: ScheduleJob, run: ScheduleRun): Promise<void> {
     try {
       const repo = this.assertRepo(job.repoId)
+      const runDirectory = run.worktreePath ?? repo.fullPath
 
       if (!run.sessionId) {
-        this.finalizeRecoveredRun(job, run, {
+        await this.finalizeRecoveredRun(job, run, {
           status: 'failed',
           errorText: 'This run was interrupted before completion and had no linked session to recover.',
-        })
+        }, repo)
         return
       }
 
-      const messages = await this.listSessionMessages(repo.fullPath, run.sessionId)
+      const messages = await this.listSessionMessages(runDirectory, run.sessionId)
       const assistantState = getAssistantMessageState(messages)
 
       if (assistantState?.completed || assistantState?.errorText) {
-        this.finalizeRecoveredRun(job, run, {
+        await this.finalizeRecoveredRun(job, run, {
           status: assistantState.errorText ? 'failed' : 'completed',
           responseText: assistantState.responseText,
           errorText: assistantState.errorText,
-        })
+        }, repo)
         return
       }
 
-      const sessionStatuses = await this.getSessionStatuses(repo.fullPath)
+      const sessionStatuses = await this.getSessionStatuses(runDirectory)
       const sessionStatus = run.sessionId ? sessionStatuses[run.sessionId] : undefined
 
       if (sessionStatus && sessionStatus.type !== 'idle') {
-        const sessionMonitor = createSessionMonitor(repo.fullPath, run.sessionId)
+        const sessionMonitor = createSessionMonitor(runDirectory, run.sessionId)
         void this.monitorRunCompletion({
           sessionMonitor,
           repoId: run.repoId,
@@ -949,26 +997,27 @@ export class ScheduleService {
           sessionTitle: run.sessionTitle ?? buildSessionTitle(job),
           triggerSource: run.triggerSource,
           initialSessionStatus: sessionStatus,
+          directory: runDirectory,
         })
         return
       }
 
-      this.finalizeRecoveredRun(job, run, {
+      await this.finalizeRecoveredRun(job, run, {
         status: 'failed',
         responseText: assistantState?.responseText ?? null,
         errorText: 'This run was interrupted before completion, likely because OpenCode Manager restarted while it was in progress. Open the linked session to inspect the partial output and rerun if needed.',
-      })
+      }, repo)
     } catch (error) {
       const errorText = getErrorMessage(error)
       logger.error(`Failed to recover schedule ${job.id}:`, error)
-      this.finalizeRecoveredRun(job, run, {
+      await this.finalizeRecoveredRun(job, run, {
         status: 'failed',
         errorText,
-      })
+      }, this.assertRepo(job.repoId))
     }
   }
 
-  private finalizeRecoveredRun(
+  private async finalizeRecoveredRun(
     job: ScheduleJob,
     run: ScheduleRun,
     input: {
@@ -976,7 +1025,8 @@ export class ScheduleService {
       responseText?: string | null
       errorText?: string | null
     },
-  ): void {
+    repo: Repo,
+  ): Promise<void> {
     const finishedAt = Date.now()
 
     updateScheduleRun(this.db, run.repoId, run.jobId, run.id, {
@@ -1002,19 +1052,44 @@ export class ScheduleService {
       nextRunAt: run.triggerSource === 'manual' ? job.nextRunAt : computeNextRunAtForJob(job, finishedAt),
     })
 
+    await this.teardownWorktree(run.repoId, run.jobId, run.id, job, repo)
     ScheduleService.activeRuns.delete(job.id)
+  }
+
+  private async teardownWorktree(repoId: number, jobId: number, runId: number, job: ScheduleJob, repo: Repo): Promise<void> {
+    const key = `${repoId}:${jobId}:${runId}`
+    if (ScheduleService.activeTeardowns.has(key)) return
+    ScheduleService.activeTeardowns.add(key)
+    try {
+      const fresh = getScheduleRunById(this.db, repoId, jobId, runId)
+      if (!fresh?.worktreePath) return
+      try {
+        const { commitHash } = await this.worktreeManager.finalize(repo, job, {
+          id: runId,
+          worktreePath: fresh.worktreePath,
+          runBranch: fresh.runBranch,
+          triggerSource: fresh.triggerSource,
+        })
+        updateScheduleRunWorktree(this.db, repoId, jobId, runId, { worktreePath: null, commitHash })
+      } catch (error) {
+        logger.error(`Failed to finalize worktree for run ${runId}:`, error)
+        updateScheduleRunWorktree(this.db, repoId, jobId, runId, { worktreePath: null })
+      }
+    } finally {
+      ScheduleService.activeTeardowns.delete(key)
+    }
   }
 
   private async waitForAssistantMessage(
     job: ScheduleJob,
     sessionId: string,
     sessionMonitor: SessionMonitor,
+    directory: string,
   ): Promise<{ responseText: string | null; errorText: string | null }> {
     const startedAt = Date.now()
-    const repo = this.assertRepo(job.repoId)
 
     while (Date.now() - startedAt < RUN_POLL_TIMEOUT_MS) {
-      const messages = await this.listSessionMessages(repo.fullPath, sessionId)
+      const messages = await this.listSessionMessages(directory, sessionId)
       const assistantState = getAssistantMessageState(messages)
 
       if (assistantState && (assistantState.completed || assistantState.errorText)) {

--- a/backend/src/services/schedules.ts
+++ b/backend/src/services/schedules.ts
@@ -14,10 +14,13 @@ import {
   createScheduleJob,
   createScheduleRun,
   deleteScheduleJob,
+  deleteScheduleRunById,
+  deleteScheduleRunsByIds,
   getScheduleJobById,
   getRunningScheduleRunByJob,
   getScheduleRunById,
   listAllScheduleJobsWithRepos,
+  listScheduleRunArtifactsByJob,
   listAllScheduleRuns,
   listEnabledScheduleJobs,
   listScheduleJobIdsByRepo,
@@ -503,6 +506,45 @@ export class ScheduleService {
       throw new ScheduleServiceError('Run not found', 404)
     }
     return run
+  }
+
+  /**
+   * Clears a job's run history: deletes every finished run's row plus its git
+   * run branch and any leftover worktree. A run currently in progress is left
+   * untouched (its row and live worktree are skipped).
+   */
+  async clearRunHistory(repoId: number, jobId: number): Promise<{ cleared: number }> {
+    const repo = this.assertRepo(repoId)
+    this.assertJob(repoId, jobId)
+
+    const removable = listScheduleRunArtifactsByJob(this.db, repoId, jobId).filter((run) => run.status !== 'running')
+    if (removable.length === 0) {
+      return { cleared: 0 }
+    }
+
+    await this.worktreeManager.pruneRunArtifacts(repo, removable)
+    const cleared = deleteScheduleRunsByIds(this.db, repoId, jobId, removable.map((run) => run.id))
+    return { cleared }
+  }
+
+  /**
+   * Deletes a single finished run plus its git run branch and any leftover
+   * worktree. A run in progress must be cancelled first.
+   */
+  async deleteRun(repoId: number, jobId: number, runId: number): Promise<void> {
+    const repo = this.assertRepo(repoId)
+    this.assertJob(repoId, jobId)
+    const run = this.getRun(repoId, jobId, runId)
+
+    if (run.status === 'running') {
+      throw new ScheduleServiceError('Cannot delete a run while it is in progress. Cancel it first.', 409)
+    }
+
+    await this.worktreeManager.pruneRunArtifacts(repo, [{ runBranch: run.runBranch, worktreePath: run.worktreePath }])
+    const deleted = deleteScheduleRunById(this.db, repoId, jobId, runId)
+    if (!deleted) {
+      throw new ScheduleServiceError('Run not found', 404)
+    }
   }
 
   async runJob(repoId: number, jobId: number, triggerSource: ScheduleRunTriggerSource): Promise<ScheduleRun> {

--- a/backend/test/db/schedule-migrations.test.ts
+++ b/backend/test/db/schedule-migrations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import migration007 from '../../src/db/migrations/007-schedules'
 import migration008 from '../../src/db/migrations/008-schedule-cron-support'
+import migration014 from '../../src/db/migrations/014-schedule-worktree-isolation'
 
 describe('schedule migrations', () => {
   it('creates schedule jobs with nullable interval minutes in v7', () => {
@@ -83,5 +84,72 @@ describe('schedule migrations', () => {
     expect(db.run).toHaveBeenCalledWith(expect.stringContaining("'interval'"))
     expect(db.run).toHaveBeenCalledWith('DROP TABLE schedule_jobs')
     expect(db.run).toHaveBeenCalledWith('ALTER TABLE schedule_jobs_new RENAME TO schedule_jobs')
+  })
+})
+
+describe('migration 014 - schedule worktree isolation', () => {
+  it('adds branch and isolation_mode columns to schedule_jobs', () => {
+    const db = {
+      prepare: vi.fn().mockImplementation((query: string) => {
+        if (query.includes('PRAGMA table_info(schedule_jobs)')) {
+          return {
+            all: vi.fn().mockReturnValue([
+              { name: 'id', notnull: 1, dflt_value: null },
+              { name: 'repo_id', notnull: 1, dflt_value: null },
+            ]),
+          }
+        }
+        if (query.includes('PRAGMA table_info(schedule_runs)')) {
+          return {
+            all: vi.fn().mockReturnValue([
+              { name: 'id', notnull: 1, dflt_value: null },
+              { name: 'job_id', notnull: 1, dflt_value: null },
+            ]),
+          }
+        }
+        return { all: vi.fn().mockReturnValue([]), get: vi.fn().mockReturnValue(undefined) }
+      }),
+      run: vi.fn(),
+    }
+
+    migration014.up(db as never)
+
+    expect(db.run).toHaveBeenCalledWith('ALTER TABLE schedule_jobs ADD COLUMN branch TEXT')
+    expect(db.run).toHaveBeenCalledWith("ALTER TABLE schedule_jobs ADD COLUMN isolation_mode TEXT NOT NULL DEFAULT 'worktree'")
+    expect(db.run).toHaveBeenCalledWith('ALTER TABLE schedule_runs ADD COLUMN run_branch TEXT')
+    expect(db.run).toHaveBeenCalledWith('ALTER TABLE schedule_runs ADD COLUMN commit_hash TEXT')
+    expect(db.run).toHaveBeenCalledWith('ALTER TABLE schedule_runs ADD COLUMN worktree_path TEXT')
+  })
+
+  it('skips columns that already exist', () => {
+    const db = {
+      prepare: vi.fn().mockImplementation((query: string) => {
+        if (query.includes('PRAGMA table_info(schedule_jobs)')) {
+          return {
+            all: vi.fn().mockReturnValue([
+              { name: 'id', notnull: 1, dflt_value: null },
+              { name: 'branch', notnull: 0, dflt_value: null },
+              { name: 'isolation_mode', notnull: 1, dflt_value: "'worktree'" },
+            ]),
+          }
+        }
+        if (query.includes('PRAGMA table_info(schedule_runs)')) {
+          return {
+            all: vi.fn().mockReturnValue([
+              { name: 'id', notnull: 1, dflt_value: null },
+              { name: 'run_branch', notnull: 0, dflt_value: null },
+              { name: 'commit_hash', notnull: 0, dflt_value: null },
+              { name: 'worktree_path', notnull: 0, dflt_value: null },
+            ]),
+          }
+        }
+        return { all: vi.fn().mockReturnValue([]), get: vi.fn().mockReturnValue(undefined) }
+      }),
+      run: vi.fn(),
+    }
+
+    migration014.up(db as never)
+
+    expect(db.run).not.toHaveBeenCalledWith(expect.stringContaining('ALTER TABLE'))
   })
 })

--- a/backend/test/db/schedule-migrations.test.ts
+++ b/backend/test/db/schedule-migrations.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import migration007 from '../../src/db/migrations/007-schedules'
 import migration008 from '../../src/db/migrations/008-schedule-cron-support'
-import migration014 from '../../src/db/migrations/014-schedule-worktree-isolation'
+import migration015 from '../../src/db/migrations/015-schedule-worktree-isolation'
 
 describe('schedule migrations', () => {
   it('creates schedule jobs with nullable interval minutes in v7', () => {
@@ -87,8 +87,8 @@ describe('schedule migrations', () => {
   })
 })
 
-describe('migration 014 - schedule worktree isolation', () => {
-  it('adds branch and isolation_mode columns to schedule_jobs', () => {
+describe('migration 015 - schedule worktree isolation', () => {
+  it('adds branch column to schedule_jobs and worktree columns to schedule_runs', () => {
     const db = {
       prepare: vi.fn().mockImplementation((query: string) => {
         if (query.includes('PRAGMA table_info(schedule_jobs)')) {
@@ -112,10 +112,9 @@ describe('migration 014 - schedule worktree isolation', () => {
       run: vi.fn(),
     }
 
-    migration014.up(db as never)
+    migration015.up(db as never)
 
     expect(db.run).toHaveBeenCalledWith('ALTER TABLE schedule_jobs ADD COLUMN branch TEXT')
-    expect(db.run).toHaveBeenCalledWith("ALTER TABLE schedule_jobs ADD COLUMN isolation_mode TEXT NOT NULL DEFAULT 'worktree'")
     expect(db.run).toHaveBeenCalledWith('ALTER TABLE schedule_runs ADD COLUMN run_branch TEXT')
     expect(db.run).toHaveBeenCalledWith('ALTER TABLE schedule_runs ADD COLUMN commit_hash TEXT')
     expect(db.run).toHaveBeenCalledWith('ALTER TABLE schedule_runs ADD COLUMN worktree_path TEXT')
@@ -129,7 +128,6 @@ describe('migration 014 - schedule worktree isolation', () => {
             all: vi.fn().mockReturnValue([
               { name: 'id', notnull: 1, dflt_value: null },
               { name: 'branch', notnull: 0, dflt_value: null },
-              { name: 'isolation_mode', notnull: 1, dflt_value: "'worktree'" },
             ]),
           }
         }
@@ -148,7 +146,7 @@ describe('migration 014 - schedule worktree isolation', () => {
       run: vi.fn(),
     }
 
-    migration014.up(db as never)
+    migration015.up(db as never)
 
     expect(db.run).not.toHaveBeenCalledWith(expect.stringContaining('ALTER TABLE'))
   })

--- a/backend/test/db/schedules.test.ts
+++ b/backend/test/db/schedules.test.ts
@@ -20,6 +20,8 @@ function makeJobRow(overrides: Record<string, unknown> = {}) {
     prompt: 'Generate a weekly summary.',
     model: 'openai/gpt-5-mini',
     skill_metadata: JSON.stringify({ skillSlugs: ['planning'], notes: 'Optional notes' }),
+    branch: null,
+    isolation_mode: 'worktree',
     created_at: Date.UTC(2026, 2, 8, 12, 0, 0),
     updated_at: Date.UTC(2026, 2, 9, 12, 0, 0),
     last_run_at: Date.UTC(2026, 2, 9, 11, 0, 0),
@@ -43,6 +45,9 @@ function makeRunRow(overrides: Record<string, unknown> = {}) {
     log_text: 'Run started. Waiting for assistant response...',
     response_text: null,
     error_text: null,
+    run_branch: null,
+    commit_hash: null,
+    worktree_path: null,
     ...overrides,
   }
 }
@@ -107,6 +112,8 @@ describe('schedule database queries', () => {
       prompt: 'Generate a weekly summary.',
       model: 'openai/gpt-5-mini',
       skillMetadata: { skillSlugs: ['planning'], notes: 'Optional notes' },
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
     })
 
@@ -123,6 +130,8 @@ describe('schedule database queries', () => {
       'Generate a weekly summary.',
       'openai/gpt-5-mini',
       JSON.stringify({ skillSlugs: ['planning'], notes: 'Optional notes' }),
+      null,
+      'worktree',
       expect.any(Number),
       expect.any(Number),
       null,
@@ -159,6 +168,8 @@ describe('schedule database queries', () => {
       prompt: 'Run a new summary.',
       model: null,
       skillMetadata: null,
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: null,
     })
 
@@ -174,6 +185,8 @@ describe('schedule database queries', () => {
       'Run a new summary.',
       null,
       null,
+      null,
+      'worktree',
       expect.any(Number),
       null,
       42,
@@ -252,6 +265,52 @@ describe('schedule database queries', () => {
       5,
     )
     expect(run?.sessionTitle).toBe('Updated title')
+  })
+
+  it('returns null when updating worktree for a missing run', () => {
+    const selectStmt = {
+      get: vi.fn().mockReturnValue(undefined),
+    }
+    mockDb.prepare.mockReturnValue(selectStmt)
+
+    const run = schedulesDb.updateScheduleRunWorktree(mockDb, 42, 7, 5, {
+      worktreePath: '/worktrees/feature-branch',
+    })
+
+    expect(run).toBeNull()
+  })
+
+  it('updates worktree fields while preserving omitted ones', () => {
+    const existingRun = makeRunRow({ run_branch: 'feature-x' })
+    const existingStmt = {
+      get: vi.fn().mockReturnValue(existingRun),
+    }
+    const updateStmt = {
+      run: vi.fn(),
+    }
+    const reloadStmt = {
+      get: vi.fn().mockReturnValue(makeRunRow({ worktree_path: '/worktrees/feature-branch', run_branch: 'feature-x' })),
+    }
+
+    mockDb.prepare
+      .mockReturnValueOnce(existingStmt)
+      .mockReturnValueOnce(updateStmt)
+      .mockReturnValueOnce(reloadStmt)
+
+    const run = schedulesDb.updateScheduleRunWorktree(mockDb, 42, 7, 5, {
+      worktreePath: '/worktrees/feature-branch',
+    })
+
+    expect(updateStmt.run).toHaveBeenCalledWith(
+      '/worktrees/feature-branch',
+      'feature-x',
+      null,
+      42,
+      7,
+      5,
+    )
+    expect(run?.worktreePath).toBe('/worktrees/feature-branch')
+    expect(run?.runBranch).toBe('feature-x')
   })
 
   it('creates and reloads a schedule run', () => {
@@ -350,7 +409,7 @@ describe('schedule database queries', () => {
 
     expect(mockDb.prepare).toHaveBeenCalledWith('SELECT * FROM schedule_jobs WHERE repo_id = ? AND id = ?')
     expect(stmt.get).toHaveBeenCalledWith(42, 7)
-    expect(job).toMatchObject({ id: 7, repoId: 42, name: 'Weekly engineering summary' })
+    expect(job).toMatchObject({ id: 7, repoId: 42, name: 'Weekly engineering summary', branch: null, isolationMode: 'worktree' })
   })
 
   it('returns null when schedule job is not found', () => {
@@ -448,7 +507,7 @@ describe('schedule database queries', () => {
 
     expect(mockDb.prepare).toHaveBeenCalledWith('SELECT * FROM schedule_runs WHERE repo_id = ? AND job_id = ? AND id = ?')
     expect(stmt.get).toHaveBeenCalledWith(42, 7, 5)
-    expect(run).toMatchObject({ id: 5, jobId: 7, repoId: 42, status: 'running' })
+    expect(run).toMatchObject({ id: 5, jobId: 7, repoId: 42, status: 'running', runBranch: null, commitHash: null, worktreePath: null })
   })
 
   it('returns null when schedule run is not found', () => {

--- a/backend/test/db/schedules.test.ts
+++ b/backend/test/db/schedules.test.ts
@@ -21,7 +21,6 @@ function makeJobRow(overrides: Record<string, unknown> = {}) {
     model: 'openai/gpt-5-mini',
     skill_metadata: JSON.stringify({ skillSlugs: ['planning'], notes: 'Optional notes' }),
     branch: null,
-    isolation_mode: 'worktree',
     created_at: Date.UTC(2026, 2, 8, 12, 0, 0),
     updated_at: Date.UTC(2026, 2, 9, 12, 0, 0),
     last_run_at: Date.UTC(2026, 2, 9, 11, 0, 0),
@@ -113,7 +112,6 @@ describe('schedule database queries', () => {
       model: 'openai/gpt-5-mini',
       skillMetadata: { skillSlugs: ['planning'], notes: 'Optional notes' },
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
     })
 
@@ -131,7 +129,6 @@ describe('schedule database queries', () => {
       'openai/gpt-5-mini',
       JSON.stringify({ skillSlugs: ['planning'], notes: 'Optional notes' }),
       null,
-      'worktree',
       expect.any(Number),
       expect.any(Number),
       null,
@@ -169,7 +166,6 @@ describe('schedule database queries', () => {
       model: null,
       skillMetadata: null,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: null,
     })
 
@@ -186,7 +182,6 @@ describe('schedule database queries', () => {
       null,
       null,
       null,
-      'worktree',
       expect.any(Number),
       null,
       42,
@@ -409,7 +404,7 @@ describe('schedule database queries', () => {
 
     expect(mockDb.prepare).toHaveBeenCalledWith('SELECT * FROM schedule_jobs WHERE repo_id = ? AND id = ?')
     expect(stmt.get).toHaveBeenCalledWith(42, 7)
-    expect(job).toMatchObject({ id: 7, repoId: 42, name: 'Weekly engineering summary', branch: null, isolationMode: 'worktree' })
+    expect(job).toMatchObject({ id: 7, repoId: 42, name: 'Weekly engineering summary', branch: null })
   })
 
   it('returns null when schedule job is not found', () => {
@@ -602,5 +597,54 @@ describe('schedule database queries', () => {
 
     expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('NULL AS log_text'))
     expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('NULL AS response_text'))
+  })
+
+  it('listScheduleRunArtifactsByJob maps run branch/worktree rows', () => {
+    const stmt = {
+      all: vi.fn().mockReturnValue([
+        { id: 3, status: 'completed', run_branch: 'schedule/7/run-3', worktree_path: null },
+        { id: 2, status: 'running', run_branch: 'schedule/7/run-2', worktree_path: '/wt/2' },
+      ]),
+    }
+    mockDb.prepare.mockReturnValue(stmt)
+
+    const artifacts = schedulesDb.listScheduleRunArtifactsByJob(mockDb, 42, 7)
+
+    expect(stmt.all).toHaveBeenCalledWith(42, 7)
+    expect(artifacts).toEqual([
+      { id: 3, status: 'completed', runBranch: 'schedule/7/run-3', worktreePath: null },
+      { id: 2, status: 'running', runBranch: 'schedule/7/run-2', worktreePath: '/wt/2' },
+    ])
+  })
+
+  it('deleteScheduleRunById deletes a single run row', () => {
+    const stmt = { run: vi.fn().mockReturnValue({ changes: 1 }) }
+    mockDb.prepare.mockReturnValue(stmt)
+
+    const deleted = schedulesDb.deleteScheduleRunById(mockDb, 42, 7, 5)
+
+    expect(mockDb.prepare).toHaveBeenCalledWith('DELETE FROM schedule_runs WHERE repo_id = ? AND job_id = ? AND id = ?')
+    expect(stmt.run).toHaveBeenCalledWith(42, 7, 5)
+    expect(deleted).toBe(true)
+  })
+
+  it('deleteScheduleRunsByIds deletes only the given ids', () => {
+    const stmt = { run: vi.fn().mockReturnValue({ changes: 2 }) }
+    mockDb.prepare.mockReturnValue(stmt)
+
+    const cleared = schedulesDb.deleteScheduleRunsByIds(mockDb, 42, 7, [3, 1])
+
+    expect(mockDb.prepare).toHaveBeenCalledWith('DELETE FROM schedule_runs WHERE repo_id = ? AND job_id = ? AND id IN (?, ?)')
+    expect(stmt.run).toHaveBeenCalledWith(42, 7, 3, 1)
+    expect(cleared).toBe(2)
+  })
+
+  it('deleteScheduleRunsByIds is a no-op for an empty id list', () => {
+    mockDb.prepare.mockClear()
+
+    const cleared = schedulesDb.deleteScheduleRunsByIds(mockDb, 42, 7, [])
+
+    expect(cleared).toBe(0)
+    expect(mockDb.prepare).not.toHaveBeenCalled()
   })
 })

--- a/backend/test/routes/internal-assistant.test.ts
+++ b/backend/test/routes/internal-assistant.test.ts
@@ -10,6 +10,7 @@ import { getOrCreateInternalToken } from '../../src/services/internal-token'
 import { migrate } from '../../src/db/migration-runner'
 import { getAssistantModeDirectory } from '../../src/services/assistant-mode'
 import type { OpenCodeClient } from '../../src/services/opencode/client'
+import type { ScheduleWorktreeManager } from '../../src/services/schedule-worktree'
 
 describe('internal/assistant routes', () => {
   let db: Database
@@ -36,7 +37,8 @@ describe('internal/assistant routes', () => {
       authenticateMcp: vi.fn(),
     } as unknown as OpenCodeClient
 
-    scheduleService = new ScheduleService(db, openCodeClient)
+    const stubWorktreeManager = { prepare: () => Promise.resolve(null), finalize: () => Promise.resolve({ commitHash: null }) } as unknown as ScheduleWorktreeManager
+    scheduleService = new ScheduleService(db, openCodeClient, stubWorktreeManager)
     notificationService = new NotificationService(db)
     settingsService = new SettingsService(db)
     app = new Hono()

--- a/backend/test/routes/internal-notifications.test.ts
+++ b/backend/test/routes/internal-notifications.test.ts
@@ -9,6 +9,7 @@ import { createOpenCodeClient } from '../../src/services/opencode/client'
 import { allMigrations } from '../../src/db/migrations'
 import { getOrCreateInternalToken } from '../../src/services/internal-token'
 import { migrate } from '../../src/db/migration-runner'
+import type { ScheduleWorktreeManager } from '../../src/services/schedule-worktree'
 
 describe('internal/notifications routes', () => {
   let db: Database
@@ -22,7 +23,8 @@ describe('internal/notifications routes', () => {
     db = new Database(':memory:')
     migrate(db, allMigrations)
     const openCodeClient = createOpenCodeClient()
-    scheduleService = new ScheduleService(db, openCodeClient)
+    const stubWorktreeManager = { prepare: () => Promise.resolve(null), finalize: () => Promise.resolve({ commitHash: null }) } as unknown as ScheduleWorktreeManager
+    scheduleService = new ScheduleService(db, openCodeClient, stubWorktreeManager)
     notificationService = new NotificationService(db)
     settingsService = new SettingsService(db)
     app = new Hono()

--- a/backend/test/routes/internal-repos.test.ts
+++ b/backend/test/routes/internal-repos.test.ts
@@ -11,6 +11,7 @@ import { getOrCreateInternalToken } from '../../src/services/internal-token'
 import { migrate } from '../../src/db/migration-runner'
 import { createRepo } from '../../src/db/queries'
 import type { CreateRepoInput } from '../../src/types/repo'
+import type { ScheduleWorktreeManager } from '../../src/services/schedule-worktree'
 
 describe('internal-repos routes', () => {
   let db: Database
@@ -24,7 +25,8 @@ describe('internal-repos routes', () => {
     db = new Database(':memory:')
     migrate(db, allMigrations)
     const openCodeClient = createOpenCodeClient()
-    scheduleService = new ScheduleService(db, openCodeClient)
+    const stubWorktreeManager = { prepare: () => Promise.resolve(null), finalize: () => Promise.resolve({ commitHash: null }) } as unknown as ScheduleWorktreeManager
+    scheduleService = new ScheduleService(db, openCodeClient, stubWorktreeManager)
     notificationService = new NotificationService(db)
     settingsService = new SettingsService(db)
     app = new Hono()

--- a/backend/test/routes/internal-schedules.test.ts
+++ b/backend/test/routes/internal-schedules.test.ts
@@ -9,6 +9,7 @@ import { createOpenCodeClient } from '../../src/services/opencode/client'
 import { allMigrations } from '../../src/db/migrations'
 import { getOrCreateInternalToken } from '../../src/services/internal-token'
 import { migrate } from '../../src/db/migration-runner'
+import type { ScheduleWorktreeManager } from '../../src/services/schedule-worktree'
 
 describe('internal-schedules routes', () => {
   let db: Database
@@ -22,7 +23,8 @@ describe('internal-schedules routes', () => {
     db = new Database(':memory:')
     migrate(db, allMigrations)
     const openCodeClient = createOpenCodeClient()
-    scheduleService = new ScheduleService(db, openCodeClient)
+    const stubWorktreeManager = { prepare: () => Promise.resolve(null), finalize: () => Promise.resolve({ commitHash: null }) } as unknown as ScheduleWorktreeManager
+    scheduleService = new ScheduleService(db, openCodeClient, stubWorktreeManager)
     notificationService = new NotificationService(db)
     settingsService = new SettingsService(db)
     app = new Hono()

--- a/backend/test/routes/internal-settings.test.ts
+++ b/backend/test/routes/internal-settings.test.ts
@@ -10,6 +10,7 @@ import { allMigrations } from '../../src/db/migrations'
 import { getOrCreateInternalToken } from '../../src/services/internal-token'
 import { migrate } from '../../src/db/migration-runner'
 import type { UserPreferences } from '@opencode-manager/shared/types'
+import type { ScheduleWorktreeManager } from '../../src/services/schedule-worktree'
 
 describe('internal/settings routes', () => {
   let db: Database
@@ -23,7 +24,8 @@ describe('internal/settings routes', () => {
     db = new Database(':memory:')
     migrate(db, allMigrations)
     const openCodeClient = createOpenCodeClient()
-    scheduleService = new ScheduleService(db, openCodeClient)
+    const stubWorktreeManager = { prepare: () => Promise.resolve(null), finalize: () => Promise.resolve({ commitHash: null }) } as unknown as ScheduleWorktreeManager
+    scheduleService = new ScheduleService(db, openCodeClient, stubWorktreeManager)
     notificationService = new NotificationService(db)
     settingsService = new SettingsService(db)
     app = new Hono()

--- a/backend/test/services/assistant-mode.test.ts
+++ b/backend/test/services/assistant-mode.test.ts
@@ -11,6 +11,7 @@ import { SettingsService } from '../../src/services/settings'
 import { createOpenCodeClient } from '../../src/services/opencode/client'
 import { getRepoById } from '../../src/db/queries'
 import { ENV } from '@opencode-manager/shared/config/env'
+import type { ScheduleWorktreeManager } from '../../src/services/schedule-worktree'
 
 describe('buildSchedulesSkill', () => {
   it('uses ENV.SERVER.PORT in the internal base URL', () => {
@@ -580,7 +581,8 @@ describe('assistant-mode end-to-end', () => {
 
     const token = (await readFile(path.join(ws.assistantDir, '.opencode/internal-token'), 'utf8')).trim()
 
-    const scheduleService = new ScheduleService(db, createOpenCodeClient())
+    const stubWorktreeManager = { prepare: () => Promise.resolve(null), finalize: () => Promise.resolve({ commitHash: null }) } as unknown as ScheduleWorktreeManager
+    const scheduleService = new ScheduleService(db, createOpenCodeClient(), stubWorktreeManager)
     const notificationService = new NotificationService(db)
     const settingsService = new SettingsService(db)
     const app = new Hono()

--- a/backend/test/services/repo-worktree.test.ts
+++ b/backend/test/services/repo-worktree.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execSync } from 'child_process'
+import { mkdtempSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { rm } from 'fs/promises'
+
+import { resolveDefaultBranch, createWorktreeSafely, removeWorktree } from '../../src/services/repo'
+
+describe('repo worktree helpers', () => {
+  let baseRepoPath: string
+  let originRepoPath: string
+  let worktreePath: string
+  let tmpDir: string
+  const env = process.env as Record<string, string>
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'repo-worktree-test-'))
+    originRepoPath = path.join(tmpDir, 'origin.git')
+    baseRepoPath = path.join(tmpDir, 'base')
+    worktreePath = path.join(tmpDir, 'feature-x')
+
+    // Init bare origin
+    execSync(`git init --bare "${originRepoPath}"`, { env })
+
+    // Clone origin to get a working base repo (default branch is "master" in bare repos)
+    execSync(`git clone "${originRepoPath}" "${baseRepoPath}"`, { env })
+
+    // Set git config for commits
+    execSync(`git -C "${baseRepoPath}" config user.email test@test.com`, { env })
+    execSync(`git -C "${baseRepoPath}" config user.name Test`, { env })
+
+    // Rename default branch to "main" and push
+    execSync(`git -C "${baseRepoPath}" branch -m master main`, { env })
+    execSync(`git -C "${baseRepoPath}" commit --allow-empty -m "Initial commit"`, { env })
+    execSync(`git -C "${baseRepoPath}" push origin main`, { env })
+
+    // Set bare repo HEAD to main so origin/HEAD is resolvable
+    execSync(`git -C "${originRepoPath}" symbolic-ref HEAD refs/heads/main`, { env })
+    execSync(`git -C "${baseRepoPath}" remote set-head origin --auto`, { env })
+  })
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('resolveDefaultBranch', () => {
+    it('resolves default branch from origin/HEAD', async () => {
+      const branch = await resolveDefaultBranch(baseRepoPath, env)
+      expect(branch).toBe('main')
+    })
+
+    it('falls back to main when origin/HEAD cannot be resolved', async () => {
+      const branch = await resolveDefaultBranch('/nonexistent/path', env)
+      expect(branch).toBe('main')
+    })
+  })
+
+  describe('createWorktreeSafely', () => {
+    it('creates a worktree for a new branch and checks it out', async () => {
+      await createWorktreeSafely(baseRepoPath, worktreePath, 'feature/x', env)
+
+      expect(existsSync(worktreePath)).toBe(true)
+
+      const branch = execSync(`git -C "${worktreePath}" rev-parse --abbrev-ref HEAD`, { encoding: 'utf-8' }).trim()
+      expect(branch).toBe('feature/x')
+    })
+  })
+
+  describe('removeWorktree', () => {
+    it('removes a worktree directory and prunes the worktree entry', async () => {
+      expect(existsSync(worktreePath)).toBe(true)
+
+      await removeWorktree(baseRepoPath, worktreePath)
+
+      expect(existsSync(worktreePath)).toBe(false)
+
+      // Verify pruning — the removed worktree should not appear in the list
+      const worktreeList = execSync(`git -C "${baseRepoPath}" worktree list`, { encoding: 'utf-8' })
+      expect(worktreeList).not.toContain(worktreePath)
+    })
+  })
+})

--- a/backend/test/services/schedule-config.test.ts
+++ b/backend/test/services/schedule-config.test.ts
@@ -34,7 +34,6 @@ describe('schedule-config', () => {
       model: 'openai/gpt-5',
       skillMetadata: undefined,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: currentDate + 60 * 60_000,
     })
   })
@@ -73,7 +72,6 @@ describe('schedule-config', () => {
       model: null,
       skillMetadata: null,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
       lastRunAt: Date.UTC(2026, 2, 9, 12, 0, 0),
       createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
@@ -104,7 +102,6 @@ describe('schedule-config', () => {
       model: 'openai/gpt-5-mini',
       skillMetadata: null,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
       lastRunAt: Date.UTC(2026, 2, 9, 12, 0, 0),
       createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
@@ -122,7 +119,7 @@ describe('schedule-config', () => {
     expect(result.model).toBeNull()
   })
 
-  it('preserves existing branch and isolationMode when omitted from update', () => {
+  it('preserves existing branch when omitted from update', () => {
     const existing: ScheduleJob = {
       id: 11,
       repoId: 42,
@@ -138,7 +135,6 @@ describe('schedule-config', () => {
       model: null,
       skillMetadata: null,
       branch: 'feature/foo',
-      isolationMode: 'inline',
       nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
       lastRunAt: null,
       createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
@@ -150,10 +146,9 @@ describe('schedule-config', () => {
     })
 
     expect(result.branch).toBe('feature/foo')
-    expect(result.isolationMode).toBe('inline')
   })
 
-  it('overrides branch and isolationMode when provided in update', () => {
+  it('overrides branch when provided in update', () => {
     const existing: ScheduleJob = {
       id: 12,
       repoId: 42,
@@ -169,7 +164,6 @@ describe('schedule-config', () => {
       model: null,
       skillMetadata: null,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
       lastRunAt: null,
       createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
@@ -178,11 +172,9 @@ describe('schedule-config', () => {
 
     const result = buildUpdatedSchedulePersistenceInput(existing, {
       branch: '  main  ',
-      isolationMode: 'inline',
     })
 
     expect(result.branch).toBe('main')
-    expect(result.isolationMode).toBe('inline')
   })
 
   it('clears branch to null when explicitly set to null in update', () => {
@@ -201,7 +193,6 @@ describe('schedule-config', () => {
       model: null,
       skillMetadata: null,
       branch: 'feature/foo',
-      isolationMode: 'worktree',
       nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
       lastRunAt: null,
       createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
@@ -213,7 +204,6 @@ describe('schedule-config', () => {
     })
 
     expect(result.branch).toBeNull()
-    expect(result.isolationMode).toBe('worktree')
   })
 
   it('recomputes the next run when a disabled schedule is re-enabled', () => {
@@ -232,7 +222,6 @@ describe('schedule-config', () => {
       model: null,
       skillMetadata: null,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: null,
       lastRunAt: null,
       createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
@@ -275,7 +264,6 @@ describe('schedule-config', () => {
       model: null,
       skillMetadata: null,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: null,
       lastRunAt: null,
       createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),

--- a/backend/test/services/schedule-config.test.ts
+++ b/backend/test/services/schedule-config.test.ts
@@ -33,6 +33,8 @@ describe('schedule-config', () => {
       prompt: 'Review the repository and summarize risks.',
       model: 'openai/gpt-5',
       skillMetadata: undefined,
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: currentDate + 60 * 60_000,
     })
   })
@@ -70,6 +72,8 @@ describe('schedule-config', () => {
       prompt: 'Old prompt',
       model: null,
       skillMetadata: null,
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
       lastRunAt: Date.UTC(2026, 2, 9, 12, 0, 0),
       createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
@@ -99,6 +103,8 @@ describe('schedule-config', () => {
       prompt: 'Old prompt',
       model: 'openai/gpt-5-mini',
       skillMetadata: null,
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
       lastRunAt: Date.UTC(2026, 2, 9, 12, 0, 0),
       createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
@@ -116,6 +122,100 @@ describe('schedule-config', () => {
     expect(result.model).toBeNull()
   })
 
+  it('preserves existing branch and isolationMode when omitted from update', () => {
+    const existing: ScheduleJob = {
+      id: 11,
+      repoId: 42,
+      name: 'Branch job',
+      description: null,
+      enabled: true,
+      scheduleMode: 'interval',
+      intervalMinutes: 60,
+      cronExpression: null,
+      timezone: null,
+      agentSlug: null,
+      prompt: 'Prompt',
+      model: null,
+      skillMetadata: null,
+      branch: 'feature/foo',
+      isolationMode: 'inline',
+      nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
+      lastRunAt: null,
+      createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
+      updatedAt: Date.UTC(2026, 2, 9, 12, 0, 0),
+    }
+
+    const result = buildUpdatedSchedulePersistenceInput(existing, {
+      prompt: 'Updated prompt',
+    })
+
+    expect(result.branch).toBe('feature/foo')
+    expect(result.isolationMode).toBe('inline')
+  })
+
+  it('overrides branch and isolationMode when provided in update', () => {
+    const existing: ScheduleJob = {
+      id: 12,
+      repoId: 42,
+      name: 'Branch job',
+      description: null,
+      enabled: true,
+      scheduleMode: 'interval',
+      intervalMinutes: 60,
+      cronExpression: null,
+      timezone: null,
+      agentSlug: null,
+      prompt: 'Prompt',
+      model: null,
+      skillMetadata: null,
+      branch: null,
+      isolationMode: 'worktree',
+      nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
+      lastRunAt: null,
+      createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
+      updatedAt: Date.UTC(2026, 2, 9, 12, 0, 0),
+    }
+
+    const result = buildUpdatedSchedulePersistenceInput(existing, {
+      branch: '  main  ',
+      isolationMode: 'inline',
+    })
+
+    expect(result.branch).toBe('main')
+    expect(result.isolationMode).toBe('inline')
+  })
+
+  it('clears branch to null when explicitly set to null in update', () => {
+    const existing: ScheduleJob = {
+      id: 13,
+      repoId: 42,
+      name: 'Branch job',
+      description: null,
+      enabled: true,
+      scheduleMode: 'interval',
+      intervalMinutes: 60,
+      cronExpression: null,
+      timezone: null,
+      agentSlug: null,
+      prompt: 'Prompt',
+      model: null,
+      skillMetadata: null,
+      branch: 'feature/foo',
+      isolationMode: 'worktree',
+      nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
+      lastRunAt: null,
+      createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
+      updatedAt: Date.UTC(2026, 2, 9, 12, 0, 0),
+    }
+
+    const result = buildUpdatedSchedulePersistenceInput(existing, {
+      branch: null,
+    })
+
+    expect(result.branch).toBeNull()
+    expect(result.isolationMode).toBe('worktree')
+  })
+
   it('recomputes the next run when a disabled schedule is re-enabled', () => {
     const existing: ScheduleJob = {
       id: 8,
@@ -131,6 +231,8 @@ describe('schedule-config', () => {
       prompt: 'Run a report',
       model: null,
       skillMetadata: null,
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: null,
       lastRunAt: null,
       createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
@@ -172,6 +274,8 @@ describe('schedule-config', () => {
       prompt: 'Prompt',
       model: null,
       skillMetadata: null,
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: null,
       lastRunAt: null,
       createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),

--- a/backend/test/services/schedule-worktree.test.ts
+++ b/backend/test/services/schedule-worktree.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { execSync } from 'child_process'
+import { mkdtempSync, existsSync, mkdirSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { rm } from 'fs/promises'
+
+// Mock getReposPath to point into the temp directory so worktree paths are
+// predictable and isolated per test run.  Preserve all other exports (ENV etc.)
+// so that modules imported indirectly (repo.ts, sse-aggregator.ts) still work.
+let tmpRoot: string
+vi.mock('@opencode-manager/shared/config/env', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    getReposPath: () => tmpRoot,
+    getWorkspacePath: vi.fn(() => '/tmp/fake-workspace'),
+  }
+})
+
+describe('buildRepoEnvForRepo', () => {
+  it('includes OCM_GIT_REPO_ID and OCM_GIT_REPO_CWD when id is provided', async () => {
+    const { buildRepoEnvForRepo } = await import('../../src/services/schedule-worktree')
+    const env = buildRepoEnvForRepo({ id: 42, fullPath: '/some/repo' })
+    expect(env.OCM_GIT_REPO_ID).toBe('42')
+    expect(env.OCM_GIT_REPO_CWD).toBe('/some/repo')
+  })
+
+  it('omits OCM_GIT_REPO_ID when id is null', async () => {
+    const { buildRepoEnvForRepo } = await import('../../src/services/schedule-worktree')
+    const env = buildRepoEnvForRepo({ id: undefined, fullPath: '/some/repo' })
+    expect(env.OCM_GIT_REPO_ID).toBeUndefined()
+    expect(env.OCM_GIT_REPO_CWD).toBe('/some/repo')
+  })
+
+  it('omits OCM_GIT_REPO_ID when id is 0', async () => {
+    const { buildRepoEnvForRepo } = await import('../../src/services/schedule-worktree')
+    // id 0 is the assistant repo — skip repo context
+    const env = buildRepoEnvForRepo({ id: 0, fullPath: '/some/repo' })
+    expect(env.OCM_GIT_REPO_ID).toBeUndefined()
+    expect(env.OCM_GIT_REPO_CWD).toBe('/some/repo')
+  })
+})
+
+describe('ScheduleWorktreeManager', () => {
+  let tmpDir: string
+  let originRepoPath: string
+  let baseRepoPath: string
+  let nonGitDir: string
+
+  const env = process.env as Record<string, string>
+  const mockGitAuthService = {
+    getGitEnvironment: vi.fn(() => ({
+      GIT_TERMINAL_PROMPT: '0',
+      LANG: 'en_US.UTF-8',
+      LC_ALL: 'en_US.UTF-8',
+    })),
+    getSSHEnvironment: vi.fn(() => ({})),
+    setupSSHForRepoUrl: vi.fn().mockResolvedValue(false),
+    cleanupSSHKey: vi.fn().mockResolvedValue(undefined),
+  }
+  const mockSettingsService = {
+    getSettings: vi.fn(() => ({
+      preferences: { gitIdentity: undefined },
+      updatedAt: Date.now(),
+    })),
+  }
+  const mockCredentialProvider = {
+    getGitCredentials: vi.fn(() => []),
+  }
+  const mockDb = {} as any
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'schedule-worktree-test-'))
+    tmpRoot = tmpDir
+    originRepoPath = path.join(tmpDir, 'origin.git')
+    baseRepoPath = path.join(tmpDir, 'base')
+    nonGitDir = path.join(tmpDir, 'non-git-dir')
+    mkdirSync(nonGitDir, { recursive: true })
+
+    // Init bare origin and clone a working base repo
+    execSync(`git init --bare "${originRepoPath}"`, { env })
+    execSync(`git clone "${originRepoPath}" "${baseRepoPath}"`, { env })
+    execSync(`git -C "${baseRepoPath}" config user.email test@test.com`, { env })
+    execSync(`git -C "${baseRepoPath}" config user.name Test`, { env })
+    execSync(`git -C "${baseRepoPath}" branch -m master main`, { env })
+    execSync(`git -C "${baseRepoPath}" commit --allow-empty -m "Initial commit"`, { env })
+    execSync(`git -C "${baseRepoPath}" push origin main`, { env })
+    execSync(`git -C "${originRepoPath}" symbolic-ref HEAD refs/heads/main`, { env })
+    execSync(`git -C "${baseRepoPath}" remote set-head origin --auto`, { env })
+
+    // Create a dev branch for branch-override tests
+    execSync(`git -C "${baseRepoPath}" checkout -b dev`, { env })
+    execSync(`git -C "${baseRepoPath}" commit --allow-empty -m "Dev branch init"`, { env })
+    execSync(`git -C "${baseRepoPath}" push origin dev`, { env })
+    execSync(`git -C "${baseRepoPath}" checkout main`, { env })
+  })
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  // ---- Helpers ----
+
+  /** Lazily import the manager so that module-level vi.mock takes effect. */
+  async function createManager() {
+    const { ScheduleWorktreeManager } = await import('../../src/services/schedule-worktree')
+    return new ScheduleWorktreeManager(
+      mockGitAuthService as any,
+      mockSettingsService as any,
+      mockCredentialProvider as any,
+      mockDb,
+    )
+  }
+
+  /** A minimal repo object that points at the test's base repo. */
+  function testRepo(overrides?: Partial<{ fullPath: string; id: number; repoUrl: string | undefined }>) {
+    return {
+      id: 999,
+      fullPath: baseRepoPath,
+      repoUrl: undefined,
+      ...overrides,
+    } as any
+  }
+
+  // ---- Tests ----
+
+  it('prepare creates a worktree with the correct branch name and returns context', async () => {
+    const manager = await createManager()
+    const repo = testRepo()
+    const job = { id: 10, isolationMode: 'worktree' as const, branch: null }
+    const runId = 1
+
+    const ctx = await manager.prepare(repo, job, runId)
+
+    expect(ctx).not.toBeNull()
+    expect(ctx!.directory).toBeDefined()
+    expect(ctx!.worktreePath).toBe(ctx!.directory)
+    expect(ctx!.runBranch).toBe(`schedule/10/run-1`)
+    expect(existsSync(ctx!.worktreePath)).toBe(true)
+
+    // The checked-out branch in the worktree must match the run branch
+    const branch = execSync(`git -C "${ctx!.worktreePath}" rev-parse --abbrev-ref HEAD`, {
+      encoding: 'utf-8',
+    }).trim()
+    expect(branch).toBe(`schedule/10/run-1`)
+
+    // Cleanup
+    const { removeWorktree } = await import('../../src/services/repo')
+    await removeWorktree(baseRepoPath, ctx!.worktreePath)
+  })
+
+  it('prepare returns null for isolationMode inline', async () => {
+    const manager = await createManager()
+    const repo = testRepo()
+    const job = { id: 11, isolationMode: 'inline' as const, branch: null }
+
+    const ctx = await manager.prepare(repo, job, 1)
+    expect(ctx).toBeNull()
+  })
+
+  it('prepare returns null for a non-git directory', async () => {
+    const manager = await createManager()
+    const repo = testRepo({ fullPath: nonGitDir })
+    const job = { id: 12, isolationMode: 'worktree' as const, branch: null }
+
+    const ctx = await manager.prepare(repo, job, 1)
+    expect(ctx).toBeNull()
+  })
+
+  it('prepare returns null for the assistant repo', async () => {
+    const manager = await createManager()
+    const repo = testRepo({ id: 0 })
+    const job = { id: 13, isolationMode: 'worktree' as const, branch: null }
+
+    const ctx = await manager.prepare(repo, job, 1)
+    expect(ctx).toBeNull()
+  })
+
+  it('finalize returns null commit when no changes exist and removes the worktree', async () => {
+    const manager = await createManager()
+    const repo = testRepo()
+    const job = { id: 10, isolationMode: 'worktree' as const, branch: null, name: 'No-change job' }
+    const runId = 100
+
+    // Prepare a worktree first
+    const ctx = await manager.prepare(repo, job, runId)
+    expect(ctx).not.toBeNull()
+
+    const worktreePath = ctx!.worktreePath
+
+    // Finalize without making any changes
+    const result = await manager.finalize(
+      repo,
+      { id: 10, name: 'No-change job', prompt: '' },
+      { id: runId, worktreePath, runBranch: ctx!.runBranch, triggerSource: 'manual' },
+    )
+
+    expect(result.commitHash).toBeNull()
+    // Worktree must be removed after finalize
+    expect(existsSync(worktreePath)).toBe(false)
+  })
+
+  it('finalize commits changes and returns the commit hash, then removes the worktree', async () => {
+    const manager = await createManager()
+    const repo = testRepo()
+    const job = { id: 10, isolationMode: 'worktree' as const, branch: null, name: 'Change job' }
+    const runId = 200
+
+    // Prepare a worktree
+    const ctx = await manager.prepare(repo, job, runId)
+    expect(ctx).not.toBeNull()
+
+    const worktreePath = ctx!.worktreePath
+
+    // Write a file in the worktree
+    writeFileSync(path.join(worktreePath, 'scheduled-output.md'), '# Scheduled Run Output\n\nGenerated content.')
+
+    // Finalize - should commit and clean up
+    const result = await manager.finalize(
+      repo,
+      { id: 10, name: 'Change job', prompt: 'Generate a changelog' },
+      { id: runId, worktreePath, runBranch: ctx!.runBranch, triggerSource: 'schedule' },
+    )
+
+    // Must return a 40-char hex commit hash
+    expect(result.commitHash).toMatch(/^[0-9a-f]{40}$/)
+    // Worktree directory must be gone
+    expect(existsSync(worktreePath)).toBe(false)
+
+    // The commit must exist on the runBranch in the base repo
+    const log = execSync(`git -C "${baseRepoPath}" log "${ctx!.runBranch}"`, {
+      encoding: 'utf-8',
+    }).trim()
+    expect(log).toContain('Scheduled run: Change job (run #200)')
+    // The commit body must include trigger and prompt summary
+    expect(log).toContain('Trigger: schedule')
+    expect(log).toContain('Prompt: Generate a changelog')
+  })
+
+  it('finalize is idempotent when worktreePath is null', async () => {
+    const manager = await createManager()
+    const repo = testRepo()
+
+    const result = await manager.finalize(
+      repo,
+      { id: 10, name: 'Job', prompt: '' },
+      { id: 1, worktreePath: null, runBranch: null, triggerSource: 'manual' },
+    )
+
+    expect(result).toEqual({ commitHash: null })
+  })
+
+  it('prepare respects the branch override', async () => {
+    const manager = await createManager()
+    const repo = testRepo()
+    const job = { id: 20, isolationMode: 'worktree' as const, branch: 'dev' }
+    const runId = 1
+
+    const ctx = await manager.prepare(repo, job, runId)
+
+    expect(ctx).not.toBeNull()
+    expect(ctx!.runBranch).toBe(`schedule/20/run-1`)
+    expect(existsSync(ctx!.worktreePath)).toBe(true)
+
+    // The worktree should be based on the dev branch
+    const devHead = execSync(`git -C "${baseRepoPath}" rev-parse origin/dev`, {
+      encoding: 'utf-8',
+    }).trim()
+    const wtHead = execSync(`git -C "${ctx!.worktreePath}" rev-parse HEAD`, {
+      encoding: 'utf-8',
+    }).trim()
+    expect(wtHead).toBe(devHead)
+
+    // Cleanup
+    const { removeWorktree } = await import('../../src/services/repo')
+    await removeWorktree(baseRepoPath, ctx!.worktreePath)
+  })
+})

--- a/backend/test/services/schedule-worktree.test.ts
+++ b/backend/test/services/schedule-worktree.test.ts
@@ -245,6 +245,21 @@ describe('ScheduleWorktreeManager', () => {
     expect(result).toEqual({ commitHash: null })
   })
 
+  it('prepare throws a clear error when the base branch does not exist', async () => {
+    const manager = await createManager()
+    const repo = testRepo()
+    // A clearly nonexistent ref (avoids case-insensitive filesystem false matches
+    // that would let a typo like "Main" resolve to "main" locally).
+    const job = { id: 21, branch: 'does-not-exist-branch' }
+
+    await expect(manager.prepare(repo, job, 1)).rejects.toThrow(
+      /Base branch "does-not-exist-branch" was not found/,
+    )
+
+    // No worktree directory should be left behind for the failed run
+    expect(existsSync(path.join(scheduleWorktreesRoot, 'job-21-run-1'))).toBe(false)
+  })
+
   it('prepare respects the branch override', async () => {
     const manager = await createManager()
     const repo = testRepo()

--- a/backend/test/services/schedule-worktree.test.ts
+++ b/backend/test/services/schedule-worktree.test.ts
@@ -9,11 +9,13 @@ import { rm } from 'fs/promises'
 // predictable and isolated per test run.  Preserve all other exports (ENV etc.)
 // so that modules imported indirectly (repo.ts, sse-aggregator.ts) still work.
 let tmpRoot: string
+let scheduleWorktreesRoot: string
 vi.mock('@opencode-manager/shared/config/env', async (importOriginal) => {
   const actual = await importOriginal()
   return {
     ...(actual as object),
     getReposPath: () => tmpRoot,
+    getScheduleWorktreesPath: () => scheduleWorktreesRoot,
     getWorkspacePath: vi.fn(() => '/tmp/fake-workspace'),
   }
 })
@@ -73,6 +75,7 @@ describe('ScheduleWorktreeManager', () => {
   beforeAll(() => {
     tmpDir = mkdtempSync(path.join(tmpdir(), 'schedule-worktree-test-'))
     tmpRoot = tmpDir
+    scheduleWorktreesRoot = path.join(tmpDir, 'schedule-worktrees')
     originRepoPath = path.join(tmpDir, 'origin.git')
     baseRepoPath = path.join(tmpDir, 'base')
     nonGitDir = path.join(tmpDir, 'non-git-dir')
@@ -128,7 +131,7 @@ describe('ScheduleWorktreeManager', () => {
   it('prepare creates a worktree with the correct branch name and returns context', async () => {
     const manager = await createManager()
     const repo = testRepo()
-    const job = { id: 10, isolationMode: 'worktree' as const, branch: null }
+    const job = { id: 10, branch: null }
     const runId = 1
 
     const ctx = await manager.prepare(repo, job, runId)
@@ -150,19 +153,10 @@ describe('ScheduleWorktreeManager', () => {
     await removeWorktree(baseRepoPath, ctx!.worktreePath)
   })
 
-  it('prepare returns null for isolationMode inline', async () => {
-    const manager = await createManager()
-    const repo = testRepo()
-    const job = { id: 11, isolationMode: 'inline' as const, branch: null }
-
-    const ctx = await manager.prepare(repo, job, 1)
-    expect(ctx).toBeNull()
-  })
-
   it('prepare returns null for a non-git directory', async () => {
     const manager = await createManager()
     const repo = testRepo({ fullPath: nonGitDir })
-    const job = { id: 12, isolationMode: 'worktree' as const, branch: null }
+    const job = { id: 12, branch: null }
 
     const ctx = await manager.prepare(repo, job, 1)
     expect(ctx).toBeNull()
@@ -171,7 +165,7 @@ describe('ScheduleWorktreeManager', () => {
   it('prepare returns null for the assistant repo', async () => {
     const manager = await createManager()
     const repo = testRepo({ id: 0 })
-    const job = { id: 13, isolationMode: 'worktree' as const, branch: null }
+    const job = { id: 13, branch: null }
 
     const ctx = await manager.prepare(repo, job, 1)
     expect(ctx).toBeNull()
@@ -180,7 +174,7 @@ describe('ScheduleWorktreeManager', () => {
   it('finalize returns null commit when no changes exist and removes the worktree', async () => {
     const manager = await createManager()
     const repo = testRepo()
-    const job = { id: 10, isolationMode: 'worktree' as const, branch: null, name: 'No-change job' }
+    const job = { id: 10, branch: null, name: 'No-change job' }
     const runId = 100
 
     // Prepare a worktree first
@@ -204,7 +198,7 @@ describe('ScheduleWorktreeManager', () => {
   it('finalize commits changes and returns the commit hash, then removes the worktree', async () => {
     const manager = await createManager()
     const repo = testRepo()
-    const job = { id: 10, isolationMode: 'worktree' as const, branch: null, name: 'Change job' }
+    const job = { id: 10, branch: null, name: 'Change job' }
     const runId = 200
 
     // Prepare a worktree
@@ -254,7 +248,7 @@ describe('ScheduleWorktreeManager', () => {
   it('prepare respects the branch override', async () => {
     const manager = await createManager()
     const repo = testRepo()
-    const job = { id: 20, isolationMode: 'worktree' as const, branch: 'dev' }
+    const job = { id: 20, branch: 'dev' }
     const runId = 1
 
     const ctx = await manager.prepare(repo, job, runId)

--- a/backend/test/services/schedules.test.ts
+++ b/backend/test/services/schedules.test.ts
@@ -6,6 +6,9 @@ const mocks = vi.hoisted(() => ({
   createScheduleJob: vi.fn(),
   createScheduleRun: vi.fn(),
   deleteScheduleJob: vi.fn(),
+  deleteScheduleRunById: vi.fn(),
+  deleteScheduleRunsByIds: vi.fn(),
+  listScheduleRunArtifactsByJob: vi.fn(),
   cleanupOrphanedSchedules: vi.fn(),
   getScheduleJobById: vi.fn(),
   getRunningScheduleRunByJob: vi.fn(),
@@ -31,6 +34,7 @@ const mocks = vi.hoisted(() => ({
   stubWorktreeManager: {
     prepare: vi.fn().mockResolvedValue(null),
     finalize: vi.fn().mockResolvedValue({ commitHash: null }),
+    pruneRunArtifacts: vi.fn().mockResolvedValue(undefined),
   },
 }))
 
@@ -42,6 +46,9 @@ vi.mock('../../src/db/schedules', () => ({
   createScheduleJob: mocks.createScheduleJob,
   createScheduleRun: mocks.createScheduleRun,
   deleteScheduleJob: mocks.deleteScheduleJob,
+  deleteScheduleRunById: mocks.deleteScheduleRunById,
+  deleteScheduleRunsByIds: mocks.deleteScheduleRunsByIds,
+  listScheduleRunArtifactsByJob: mocks.listScheduleRunArtifactsByJob,
   cleanupOrphanedSchedules: mocks.cleanupOrphanedSchedules,
   getScheduleJobById: mocks.getScheduleJobById,
   getRunningScheduleRunByJob: mocks.getRunningScheduleRunByJob,
@@ -148,7 +155,6 @@ const job: ScheduleJob = {
   model: null,
   skillMetadata: null,
   branch: null,
-  isolationMode: 'worktree',
   nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
   lastRunAt: Date.UTC(2026, 2, 9, 12, 0, 0),
   createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
@@ -1407,7 +1413,6 @@ describe('ScheduleRunner', () => {
       model: null,
       skillMetadata: null,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: Date.now(),
       lastRunAt: null,
       createdAt: Date.now(),
@@ -1443,7 +1448,6 @@ describe('ScheduleRunner', () => {
       model: null,
       skillMetadata: null,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: Date.now(),
       lastRunAt: null,
       createdAt: Date.now(),
@@ -1477,7 +1481,6 @@ describe('ScheduleRunner', () => {
       model: null,
       skillMetadata: null,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: Date.now(),
       lastRunAt: null,
       createdAt: Date.now(),
@@ -1510,7 +1513,6 @@ describe('ScheduleRunner', () => {
       model: null,
       skillMetadata: null,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: Date.now(),
       lastRunAt: null,
       createdAt: Date.now(),
@@ -1543,7 +1545,6 @@ describe('ScheduleRunner', () => {
       model: null,
       skillMetadata: null,
       branch: null,
-      isolationMode: 'worktree',
       nextRunAt: Date.now(),
       lastRunAt: null,
       createdAt: Date.now(),
@@ -1563,5 +1564,68 @@ describe('ScheduleRunner', () => {
 
     expect(mockCronStop).toHaveBeenCalled()
     expect(mockCronInstances).toHaveLength(2)
+  })
+})
+
+describe('ScheduleService run history cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getRepoById.mockReturnValue(repo)
+    mocks.getScheduleJobById.mockReturnValue(job)
+    mocks.stubWorktreeManager.pruneRunArtifacts.mockResolvedValue(undefined)
+  })
+
+  function makeService() {
+    return new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+  }
+
+  it('clearRunHistory prunes finished runs and skips a running run', async () => {
+    mocks.listScheduleRunArtifactsByJob.mockReturnValue([
+      { id: 3, status: 'completed', runBranch: 'schedule/7/run-3', worktreePath: null },
+      { id: 2, status: 'running', runBranch: 'schedule/7/run-2', worktreePath: '/wt/2' },
+      { id: 1, status: 'failed', runBranch: null, worktreePath: null },
+    ])
+    mocks.deleteScheduleRunsByIds.mockReturnValue(2)
+
+    const result = await makeService().clearRunHistory(42, 7)
+
+    expect(mocks.stubWorktreeManager.pruneRunArtifacts).toHaveBeenCalledWith(repo, [
+      { id: 3, status: 'completed', runBranch: 'schedule/7/run-3', worktreePath: null },
+      { id: 1, status: 'failed', runBranch: null, worktreePath: null },
+    ])
+    expect(mocks.deleteScheduleRunsByIds).toHaveBeenCalledWith({}, 42, 7, [3, 1])
+    expect(result).toEqual({ cleared: 2 })
+  })
+
+  it('clearRunHistory is a no-op when only a running run exists', async () => {
+    mocks.listScheduleRunArtifactsByJob.mockReturnValue([
+      { id: 2, status: 'running', runBranch: 'schedule/7/run-2', worktreePath: '/wt/2' },
+    ])
+
+    const result = await makeService().clearRunHistory(42, 7)
+
+    expect(mocks.stubWorktreeManager.pruneRunArtifacts).not.toHaveBeenCalled()
+    expect(mocks.deleteScheduleRunsByIds).not.toHaveBeenCalled()
+    expect(result).toEqual({ cleared: 0 })
+  })
+
+  it('deleteRun prunes the run artifacts and deletes the row', async () => {
+    mocks.getScheduleRunById.mockReturnValue({ ...baseRun, id: 5, status: 'completed', runBranch: 'schedule/7/run-5', worktreePath: '/wt/5' })
+    mocks.deleteScheduleRunById.mockReturnValue(true)
+
+    await makeService().deleteRun(42, 7, 5)
+
+    expect(mocks.stubWorktreeManager.pruneRunArtifacts).toHaveBeenCalledWith(repo, [
+      { runBranch: 'schedule/7/run-5', worktreePath: '/wt/5' },
+    ])
+    expect(mocks.deleteScheduleRunById).toHaveBeenCalledWith({}, 42, 7, 5)
+  })
+
+  it('deleteRun refuses to delete a run in progress', async () => {
+    mocks.getScheduleRunById.mockReturnValue({ ...baseRun, id: 5, status: 'running' })
+
+    await expect(makeService().deleteRun(42, 7, 5)).rejects.toThrow('Cannot delete a run while it is in progress')
+    expect(mocks.stubWorktreeManager.pruneRunArtifacts).not.toHaveBeenCalled()
+    expect(mocks.deleteScheduleRunById).not.toHaveBeenCalled()
   })
 })

--- a/backend/test/services/schedules.test.ts
+++ b/backend/test/services/schedules.test.ts
@@ -27,6 +27,11 @@ const mocks = vi.hoisted(() => ({
   forward: vi.fn(),
   onEvent: vi.fn(),
   loggerError: vi.fn(),
+  updateScheduleRunWorktree: vi.fn(),
+  stubWorktreeManager: {
+    prepare: vi.fn().mockResolvedValue(null),
+    finalize: vi.fn().mockResolvedValue({ commitHash: null }),
+  },
 }))
 
 vi.mock('../../src/db/queries', () => ({
@@ -50,6 +55,7 @@ vi.mock('../../src/db/schedules', () => ({
   updateScheduleJobRunState: mocks.updateScheduleJobRunState,
   updateScheduleRun: mocks.updateScheduleRun,
   updateScheduleRunMetadata: mocks.updateScheduleRunMetadata,
+  updateScheduleRunWorktree: mocks.updateScheduleRunWorktree,
 }))
 
 vi.mock('../../src/services/schedule-config', () => ({
@@ -141,6 +147,8 @@ const job: ScheduleJob = {
   prompt: 'Review the repository and summarize the current state.',
   model: null,
   skillMetadata: null,
+  branch: null,
+  isolationMode: 'worktree',
   nextRunAt: Date.UTC(2026, 2, 9, 13, 0, 0),
   lastRunAt: Date.UTC(2026, 2, 9, 12, 0, 0),
   createdAt: Date.UTC(2026, 2, 8, 12, 0, 0),
@@ -161,12 +169,16 @@ const baseRun: ScheduleRun = {
   logText: null,
   responseText: null,
   errorText: null,
+  runBranch: null,
+  commitHash: null,
+  worktreePath: null,
 }
 
 describe('ScheduleService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     Reflect.get(ScheduleService, 'activeRuns').clear()
+    Reflect.get(ScheduleService, 'activeTeardowns')?.clear()
 
     mocks.getRepoById.mockReturnValue(repo)
     mocks.getScheduleJobById.mockReturnValue(job)
@@ -183,7 +195,7 @@ describe('ScheduleService', () => {
   })
 
   it('starts a run immediately and completes it after polling session messages', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runWithSession: ScheduleRun = {
       ...baseRun,
       sessionId: 'ses-run-1',
@@ -240,7 +252,7 @@ describe('ScheduleService', () => {
   })
 
   it('sends session and message JSON POSTs with Content-Type: application/json', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runWithSession: ScheduleRun = {
       ...baseRun,
       sessionId: 'ses-content-type',
@@ -280,7 +292,7 @@ describe('ScheduleService', () => {
   })
 
   it('completes a run immediately when the prompt endpoint returns JSON', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runWithSession: ScheduleRun = {
       ...baseRun,
       sessionId: 'ses-run-2',
@@ -321,7 +333,7 @@ describe('ScheduleService', () => {
   })
 
   it('rejects a new run when the job already has a running entry', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
 
     mocks.getRunningScheduleRunByJob.mockReturnValue({
       ...baseRun,
@@ -336,7 +348,7 @@ describe('ScheduleService', () => {
   })
 
   it('surfaces setup failures when the model cannot be resolved', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
 
     mocks.resolveOpenCodeModel.mockRejectedValueOnce(new Error('No configured models are available.'))
     mocks.updateScheduleRun.mockReturnValue({
@@ -364,7 +376,7 @@ describe('ScheduleService', () => {
   })
 
   it('marks the run failed when prompt submission is rejected after session creation', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runWithSession: ScheduleRun = {
       ...baseRun,
       sessionId: 'ses-run-6',
@@ -406,7 +418,7 @@ describe('ScheduleService', () => {
   })
 
   it('cancels an in-progress run by aborting the linked session', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runningRun: ScheduleRun = {
       ...baseRun,
       sessionId: 'ses-run-3',
@@ -454,7 +466,7 @@ describe('ScheduleService', () => {
   })
 
   it('rejects cancellation for runs that already finished', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
 
     mocks.getScheduleRunById.mockReturnValue({
       ...baseRun,
@@ -470,7 +482,7 @@ describe('ScheduleService', () => {
   })
 
   it('cancels a running entry without a linked session', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runningRun: ScheduleRun = {
       ...baseRun,
       sessionId: null,
@@ -493,7 +505,7 @@ describe('ScheduleService', () => {
   })
 
   it('surfaces abort failures when cancellation cannot reach OpenCode', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runningRun: ScheduleRun = {
       ...baseRun,
       sessionId: 'ses-run-7',
@@ -520,7 +532,7 @@ describe('ScheduleService', () => {
   })
 
   it('marks orphaned idle runs as failed during recovery', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const orphanedRun: ScheduleRun = {
       ...baseRun,
       triggerSource: 'schedule',
@@ -565,7 +577,7 @@ describe('ScheduleService', () => {
   })
 
   it('finalizes interrupted runs without a linked session during recovery', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
 
     mocks.listRunningScheduleRuns.mockReturnValue([
       {
@@ -590,7 +602,7 @@ describe('ScheduleService', () => {
   })
 
   it('completes recoverable runs when the assistant already finished', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const completedRun: ScheduleRun = {
       ...baseRun,
       triggerSource: 'schedule',
@@ -627,7 +639,7 @@ describe('ScheduleService', () => {
   })
 
   it('resumes recoverable runs when the session is still active', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const resumedRun: ScheduleRun = {
       ...baseRun,
       triggerSource: 'schedule',
@@ -681,7 +693,7 @@ describe('ScheduleService', () => {
   })
 
   it('lists jobs and runs through the persistence layer', () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const listedRun = { ...baseRun, status: 'completed', finishedAt: Date.UTC(2026, 2, 9, 12, 10, 0) }
 
     mocks.listScheduleJobsByRepo.mockReturnValue([job])
@@ -694,7 +706,7 @@ describe('ScheduleService', () => {
   })
 
   it('creates and updates jobs using normalized persistence input', () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const createdJob = { ...job, id: 8, name: 'Daily release summary' }
     const updatedJob = { ...job, name: 'Updated release summary' }
 
@@ -719,7 +731,7 @@ describe('ScheduleService', () => {
   })
 
   it('throws when deleting or loading missing records', () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
 
     mocks.deleteScheduleJob.mockReturnValue(false)
     mocks.getScheduleRunById.mockReturnValue(null)
@@ -728,8 +740,56 @@ describe('ScheduleService', () => {
     expect(() => service.getRun(42, 7, 5)).toThrow('Run not found')
   })
 
+  it('blocks deleteJob when a running run exists in activeRuns', () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+    Reflect.get(ScheduleService, 'activeRuns').add(7)
+
+    expect(() => service.deleteJob(42, 7)).toThrow('Cannot delete a schedule while it is running. Cancel the run first.')
+  })
+
+  it('blocks deleteJob when a running run exists in the database', () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+    mocks.getRunningScheduleRunByJob.mockReturnValue({ ...baseRun, status: 'running' })
+
+    expect(() => service.deleteJob(42, 7)).toThrow('Cannot delete a schedule while it is running. Cancel the run first.')
+  })
+
+  it('blocks prepareRepoDelete when a running run exists in activeRuns', () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+    const onJobChange = vi.fn()
+    service.setJobChangeHandler(onJobChange)
+    mocks.listScheduleJobIdsByRepo.mockReturnValue([7, 8])
+    Reflect.get(ScheduleService, 'activeRuns').add(7)
+
+    expect(() => service.prepareRepoDelete(42)).toThrow('Cannot delete a repo while a schedule run is in progress. Cancel the run first.')
+    expect(onJobChange).not.toHaveBeenCalled()
+  })
+
+  it('blocks prepareRepoDelete when a database running run exists', () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+    const onJobChange = vi.fn()
+    service.setJobChangeHandler(onJobChange)
+    mocks.listScheduleJobIdsByRepo.mockReturnValue([7, 8])
+    mocks.getRunningScheduleRunByJob.mockReturnValue({ ...baseRun, status: 'running' })
+
+    expect(() => service.prepareRepoDelete(42)).toThrow('Cannot delete a repo while a schedule run is in progress. Cancel the run first.')
+    expect(onJobChange).not.toHaveBeenCalled()
+  })
+
+  it('deleteJob succeeds when no runs are active', () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+    mocks.deleteScheduleJob.mockReturnValue(true)
+    const onJobChange = vi.fn()
+    service.setJobChangeHandler(onJobChange)
+
+    service.deleteJob(42, 7)
+
+    expect(mocks.deleteScheduleJob).toHaveBeenCalledWith(expect.anything(), 42, 7)
+    expect(onJobChange).toHaveBeenCalledWith(null, 7)
+  })
+
   it('prepares repo deletion by unregistering repo jobs without deleting records', () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const onJobChange = vi.fn()
     service.setJobChangeHandler(onJobChange)
     mocks.listScheduleJobIdsByRepo.mockReturnValue([7, 8])
@@ -743,7 +803,7 @@ describe('ScheduleService', () => {
   })
 
   it('cancels by finalizing the run when the assistant already completed', async () => {
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runningRun: ScheduleRun = {
       ...baseRun,
       sessionId: 'ses-run-5',
@@ -756,7 +816,7 @@ describe('ScheduleService', () => {
       responseText: 'Completed summary',
     }
 
-    mocks.getScheduleRunById.mockReturnValueOnce(runningRun).mockReturnValueOnce(completedRun)
+    mocks.getScheduleRunById.mockReturnValueOnce(runningRun).mockReturnValueOnce(runningRun).mockReturnValueOnce(completedRun)
     routeForward(({ path, method }) => {
       if (path === '/session/ses-run-5/message' && method === 'GET') {
         return Promise.resolve(jsonResponse([
@@ -784,7 +844,7 @@ describe('ScheduleService', () => {
 
   describe('skill injection in prompt', () => {
     it('appends skill content to the prompt when skillSlugs are set', async () => {
-      const service = new ScheduleService({} as never, createOpenCodeClientStub())
+      const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
       const jobWithSkills: ScheduleJob = {
         ...job,
         skillMetadata: { skillSlugs: ['git-release', 'code-review'], notes: undefined },
@@ -834,7 +894,7 @@ describe('ScheduleService', () => {
     })
 
     it('appends skill notes when provided', async () => {
-      const service = new ScheduleService({} as never, createOpenCodeClientStub())
+      const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
       const jobWithSkillsAndNotes: ScheduleJob = {
         ...job,
         skillMetadata: { skillSlugs: ['git-release'], notes: 'Focus on changelog' },
@@ -882,7 +942,7 @@ describe('ScheduleService', () => {
     })
 
     it('does not modify the prompt when skillSlugs is empty', async () => {
-      const service = new ScheduleService({} as never, createOpenCodeClientStub())
+      const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
       const jobWithEmptySkills: ScheduleJob = {
         ...job,
         skillMetadata: { skillSlugs: [], notes: 'some notes' },
@@ -923,7 +983,7 @@ describe('ScheduleService', () => {
     })
 
     it('falls back to name-only injection when skill endpoint fails', async () => {
-      const service = new ScheduleService({} as never, createOpenCodeClientStub())
+      const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
       const jobWithSkills: ScheduleJob = {
         ...job,
         skillMetadata: { skillSlugs: ['git-release'], notes: undefined },
@@ -967,7 +1027,7 @@ describe('ScheduleService', () => {
     })
 
     it('falls back gracefully when a skill slug is not found in the list', async () => {
-      const service = new ScheduleService({} as never, createOpenCodeClientStub())
+      const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
       const jobWithUnknownSkill: ScheduleJob = {
         ...job,
         skillMetadata: { skillSlugs: ['unknown-skill'], notes: undefined },
@@ -1012,6 +1072,318 @@ describe('ScheduleService', () => {
   })
 })
 
+describe('ScheduleService worktree isolation', () => {
+  const worktreePath = '/workspace/worktrees/job-7-run-5'
+  const runBranch = 'schedule/7/run-5'
+
+  function setupWorktreePrepare() {
+    mocks.stubWorktreeManager.prepare.mockResolvedValue({
+      directory: worktreePath,
+      worktreePath,
+      runBranch,
+    })
+  }
+
+  function setupWorktreeFinalize(commitHash: string | null = 'abc123') {
+    mocks.stubWorktreeManager.finalize.mockResolvedValue({ commitHash })
+  }
+
+  const worktreeRun: ScheduleRun = {
+    ...baseRun,
+    sessionId: 'ses-wt-1',
+    sessionTitle: 'Scheduled: Weekly engineering summary',
+    logText: 'Run started. Waiting for assistant response...',
+    worktreePath,
+    runBranch,
+  }
+
+  beforeEach(() => {
+    mocks.stubWorktreeManager.prepare.mockReset()
+    mocks.stubWorktreeManager.finalize.mockReset()
+    mocks.stubWorktreeManager.prepare.mockResolvedValue(null)
+    mocks.stubWorktreeManager.finalize.mockResolvedValue({ commitHash: null })
+    mocks.updateScheduleRunWorktree.mockClear()
+  })
+
+  it('uses worktree directory when prepare returns a context', async () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+    setupWorktreePrepare()
+
+    mocks.updateScheduleRunMetadata.mockReturnValue(worktreeRun)
+    mocks.getScheduleRunById.mockReturnValue(worktreeRun)
+    routeForward(({ path, method, directory }) => {
+      if (path === '/session' && method === 'POST') {
+        expect(directory).toBe(worktreePath)
+        return Promise.resolve(jsonResponse({ id: 'ses-wt-1' }))
+      }
+      if (path === '/session/ses-wt-1/message' && method === 'POST') {
+        expect(directory).toBe(worktreePath)
+        return Promise.resolve(textResponse(JSON.stringify({
+          parts: [{ type: 'text', text: 'Worktree run done.' }],
+        })))
+      }
+      throw new Error(`Unexpected proxy request: ${method} ${path}`)
+    })
+
+    const result = await service.runJob(42, 7, 'manual')
+
+    expect(result.sessionId).toBe('ses-wt-1')
+    expect(mocks.updateScheduleRunWorktree).toHaveBeenCalledWith(
+      expect.anything(),
+      42, 7, 5,
+      { worktreePath, runBranch },
+    )
+  })
+
+  it('calls finalize and clears worktree_path on completion', async () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+    setupWorktreePrepare()
+    setupWorktreeFinalize('def456')
+
+    // For teardownWorktree to proceed, getScheduleRunById must return a run with worktreePath
+    const runWithWorktree: ScheduleRun = {
+      ...worktreeRun,
+      commitHash: null,
+    }
+    // After finalize, the updated run should have commitHash but null worktreePath
+    mocks.updateScheduleRunMetadata.mockReturnValue(runWithWorktree)
+    // Return runWithWorktree for the initial getRun + any teardown check
+    // Return runAfterFinalize for the final check after updateScheduleRunWorktree clears it
+    mocks.getScheduleRunById.mockReturnValue(runWithWorktree)
+
+    routeForward(({ path, method }) => {
+      if (path === '/session' && method === 'POST') {
+        return Promise.resolve(jsonResponse({ id: 'ses-wt-1' }))
+      }
+      if (path === '/session/ses-wt-1/message' && method === 'POST') {
+        return Promise.resolve(textResponse(JSON.stringify({
+          parts: [{ type: 'text', text: 'Worktree run done.' }],
+        })))
+      }
+      throw new Error(`Unexpected proxy request: ${method} ${path}`)
+    })
+
+    await service.runJob(42, 7, 'manual')
+
+    await vi.waitFor(() => {
+      expect(mocks.stubWorktreeManager.finalize).toHaveBeenCalled()
+      // After submitPromptAndMonitor completes, teardownWorktree clears worktree_path
+      expect(mocks.updateScheduleRunWorktree).toHaveBeenCalledWith(
+        expect.anything(),
+        42, 7, 5,
+        expect.objectContaining({ worktreePath: null, commitHash: 'def456' }),
+      )
+    })
+  })
+
+  it('uses repo.fullPath and does not finalize when prepare returns null (inline)', async () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+    // prepare already returns null by default
+
+    const runWithSession: ScheduleRun = {
+      ...baseRun,
+      sessionId: 'ses-inline-1',
+      sessionTitle: 'Scheduled: Weekly engineering summary',
+      logText: 'Run started. Waiting for assistant response...',
+    }
+    mocks.updateScheduleRunMetadata.mockReturnValue(runWithSession)
+    mocks.getScheduleRunById.mockReturnValue(runWithSession)
+
+    let capturedDirectory: string | undefined
+    routeForward(({ path, method, directory }) => {
+      if (path === '/session' && method === 'POST') {
+        capturedDirectory = directory
+        return Promise.resolve(jsonResponse({ id: 'ses-inline-1' }))
+      }
+      if (path === '/session/ses-inline-1/message' && method === 'POST') {
+        return Promise.resolve(textResponse(JSON.stringify({
+          parts: [{ type: 'text', text: 'Inline run done.' }],
+        })))
+      }
+      throw new Error(`Unexpected proxy request: ${method} ${path}`)
+    })
+
+    await service.runJob(42, 7, 'manual')
+
+    expect(capturedDirectory).toBe(repo.fullPath)
+    expect(mocks.updateScheduleRunWorktree).not.toHaveBeenCalled()
+    expect(mocks.stubWorktreeManager.finalize).not.toHaveBeenCalled()
+  })
+
+  it('tears down worktree on cancel', async () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+
+    const runningRun: ScheduleRun = {
+      ...baseRun,
+      sessionId: 'ses-cancel-wt',
+      sessionTitle: 'Scheduled: Weekly engineering summary',
+      worktreePath,
+      runBranch,
+    }
+    const cancelledRun: ScheduleRun = {
+      ...runningRun,
+      status: 'cancelled',
+      finishedAt: Date.UTC(2026, 2, 9, 12, 10, 0),
+      errorText: 'Run cancelled by user.',
+      worktreePath,
+    }
+
+    // getScheduleRunById is called by: getRun, teardownWorktree (x2: get fresh + final clear), cancelRun's final getRun
+    mocks.getScheduleRunById.mockReturnValue(runningRun)
+    mocks.updateScheduleRun.mockReturnValue(cancelledRun)
+
+    setupWorktreeFinalize('ghi789')
+
+    routeForward(({ path, method }) => {
+      if (path === '/session/ses-cancel-wt/message' && method === 'GET') {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (path === '/session/ses-cancel-wt/abort' && method === 'POST') {
+        return Promise.resolve(textResponse(''))
+      }
+      throw new Error(`Unexpected proxy request: ${method} ${path}`)
+    })
+
+    await service.cancelRun(42, 7, 5)
+
+    // teardownWorktree fetches fresh run, finalizes, clears worktree_path
+    expect(mocks.stubWorktreeManager.finalize).toHaveBeenCalled()
+    expect(mocks.updateScheduleRunWorktree).toHaveBeenCalledWith(
+      expect.anything(),
+      42, 7, 5,
+      expect.objectContaining({ worktreePath: null, commitHash: 'ghi789' }),
+    )
+  })
+
+  it('recovery triggers teardown for orphaned runs with worktree_path', async () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+
+    const orphanedRun: ScheduleRun = {
+      ...baseRun,
+      triggerSource: 'schedule',
+      sessionId: 'ses-recover-wt',
+      sessionTitle: 'Scheduled: Weekly engineering summary',
+      worktreePath,
+      runBranch,
+    }
+
+    mocks.listRunningScheduleRuns.mockReturnValue([orphanedRun])
+    mocks.getScheduleRunById.mockReturnValue(orphanedRun)
+
+    // Session exists but has no completed message — triggers finalizeRecoveredRun
+    routeForward(({ path, method }) => {
+      if (path === '/session/ses-recover-wt/message' && method === 'GET') {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (path === '/session/status' && method === 'GET') {
+        return Promise.resolve(jsonResponse({
+          'ses-recover-wt': { type: 'idle' },
+        }))
+      }
+      throw new Error(`Unexpected proxy request: ${method} ${path}`)
+    })
+
+    await service.recoverRunningRuns()
+
+    // finalizeRecoveredRun calls teardownWorktree which calls finalize and clears worktree_path
+    expect(mocks.stubWorktreeManager.finalize).toHaveBeenCalled()
+    expect(mocks.updateScheduleRunWorktree).toHaveBeenCalledWith(
+      expect.anything(),
+      42, 7, 5,
+      expect.objectContaining({ worktreePath: null }),
+    )
+  })
+
+  it('prevents duplicate finalize when two paths race to teardown the same worktree', async () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+
+    const runningRun: ScheduleRun = {
+      ...baseRun,
+      sessionId: 'ses-race-double',
+      sessionTitle: 'Scheduled: Weekly engineering summary',
+      worktreePath,
+      runBranch,
+    }
+
+    // Assistant already completed → cancelRun goes via finalizeRecoveredRun → teardownWorktree
+    mocks.getScheduleRunById.mockReturnValue(runningRun)
+
+    // Pre-seed the guard to simulate an in-progress teardown (e.g. from monitor's finally block)
+    const activeTeardowns = Reflect.get(ScheduleService, 'activeTeardowns') as Set<string>
+    activeTeardowns.add('42:7:5')
+
+    routeForward(({ path, method }) => {
+      if (path === '/session/ses-race-double/message' && method === 'GET') {
+        return Promise.resolve(jsonResponse([
+          { info: { role: 'assistant', time: { completed: Date.now() } }, parts: [{ type: 'text', text: 'Already done' }] },
+        ]))
+      }
+      throw new Error(`Unexpected proxy request: ${method} ${path}`)
+    })
+
+    await service.cancelRun(42, 7, 5)
+
+    // Guard prevented duplicate finalize
+    expect(mocks.stubWorktreeManager.finalize).not.toHaveBeenCalled()
+    activeTeardowns.delete('42:7:5')
+  })
+
+  it('claims and releases the teardown guard around finalize', async () => {
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
+    const activeTeardowns = Reflect.get(ScheduleService, 'activeTeardowns') as Set<string>
+    activeTeardowns.clear()
+
+    const runningRun: ScheduleRun = {
+      ...baseRun,
+      sessionId: 'ses-guard-cycle',
+      sessionTitle: 'Scheduled: Weekly engineering summary',
+      worktreePath,
+      runBranch,
+    }
+
+    let resolveFinalize!: (value: { commitHash: string | null }) => void
+    const finalizeDeferred = new Promise<{ commitHash: string | null }>((resolve) => {
+      resolveFinalize = resolve
+    })
+    let finalizeCalled = false
+    mocks.stubWorktreeManager.finalize.mockImplementation(async () => {
+      finalizeCalled = true
+      return await finalizeDeferred
+    })
+
+    mocks.getScheduleRunById.mockReturnValue(runningRun)
+
+    routeForward(({ path, method }) => {
+      if (path === '/session/ses-guard-cycle/message' && method === 'GET') {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (path === '/session/ses-guard-cycle/abort' && method === 'POST') {
+        return Promise.resolve(textResponse(''))
+      }
+      throw new Error(`Unexpected proxy request: ${method} ${path}`)
+    })
+
+    const cancelledRun: ScheduleRun = {
+      ...runningRun,
+      status: 'cancelled',
+    }
+    mocks.updateScheduleRun.mockReturnValue(cancelledRun)
+
+    const cancelPromise = service.cancelRun(42, 7, 5)
+
+    // Wait until finalize is called (guard is claimed)
+    await vi.waitFor(() => expect(finalizeCalled).toBe(true))
+    expect(activeTeardowns.has('42:7:5')).toBe(true)
+
+    // Release
+    resolveFinalize!({ commitHash: 'abc123' })
+    await cancelPromise
+
+    // Guard should be released
+    expect(activeTeardowns.has('42:7:5')).toBe(false)
+  })
+})
+
 describe('ScheduleRunner', () => {
   beforeEach(() => {
     mockCronInstances.length = 0
@@ -1034,6 +1406,8 @@ describe('ScheduleRunner', () => {
       prompt: 'Test',
       model: null,
       skillMetadata: null,
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: Date.now(),
       lastRunAt: null,
       createdAt: Date.now(),
@@ -1042,7 +1416,7 @@ describe('ScheduleRunner', () => {
     mocks.listRunningScheduleRuns.mockReturnValue([])
     mocks.listEnabledScheduleJobs.mockReturnValue([mockJob])
 
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runner = new ScheduleRunner(service)
     await runner.start()
 
@@ -1068,6 +1442,8 @@ describe('ScheduleRunner', () => {
       prompt: 'Test',
       model: null,
       skillMetadata: null,
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: Date.now(),
       lastRunAt: null,
       createdAt: Date.now(),
@@ -1076,7 +1452,7 @@ describe('ScheduleRunner', () => {
     mocks.listRunningScheduleRuns.mockReturnValue([])
     mocks.listEnabledScheduleJobs.mockReturnValue([mockJob])
 
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runner = new ScheduleRunner(service)
     await runner.start()
 
@@ -1100,6 +1476,8 @@ describe('ScheduleRunner', () => {
       prompt: 'Test',
       model: null,
       skillMetadata: null,
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: Date.now(),
       lastRunAt: null,
       createdAt: Date.now(),
@@ -1108,7 +1486,7 @@ describe('ScheduleRunner', () => {
     mocks.listRunningScheduleRuns.mockReturnValue([])
     mocks.listEnabledScheduleJobs.mockReturnValue([])
 
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runner = new ScheduleRunner(service)
     await runner.start()
 
@@ -1131,6 +1509,8 @@ describe('ScheduleRunner', () => {
       prompt: 'Test',
       model: null,
       skillMetadata: null,
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: Date.now(),
       lastRunAt: null,
       createdAt: Date.now(),
@@ -1139,7 +1519,7 @@ describe('ScheduleRunner', () => {
     mocks.listRunningScheduleRuns.mockReturnValue([])
     mocks.listEnabledScheduleJobs.mockReturnValue([mockJob])
 
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runner = new ScheduleRunner(service)
     await runner.start()
 
@@ -1162,6 +1542,8 @@ describe('ScheduleRunner', () => {
       prompt: 'Test',
       model: null,
       skillMetadata: null,
+      branch: null,
+      isolationMode: 'worktree',
       nextRunAt: Date.now(),
       lastRunAt: null,
       createdAt: Date.now(),
@@ -1170,7 +1552,7 @@ describe('ScheduleRunner', () => {
     mocks.listRunningScheduleRuns.mockReturnValue([])
     mocks.listEnabledScheduleJobs.mockReturnValue([mockJob])
 
-    const service = new ScheduleService({} as never, createOpenCodeClientStub())
+    const service = new ScheduleService({} as never, createOpenCodeClientStub(), mocks.stubWorktreeManager as never)
     const runner = new ScheduleRunner(service)
     await runner.start()
 

--- a/frontend/src/api/schedules.ts
+++ b/frontend/src/api/schedules.ts
@@ -118,3 +118,15 @@ export async function cancelRepoScheduleRun(repoId: number, jobId: number, runId
     method: 'POST',
   })
 }
+
+export async function clearRepoScheduleRuns(repoId: number, jobId: number): Promise<{ cleared: number }> {
+  return fetchWrapper(`${API_BASE_URL}/api/repos/${repoId}/schedules/${jobId}/runs`, {
+    method: 'DELETE',
+  })
+}
+
+export async function deleteRepoScheduleRun(repoId: number, jobId: number, runId: number): Promise<void> {
+  return fetchWrapperVoid(`${API_BASE_URL}/api/repos/${repoId}/schedules/${jobId}/runs/${runId}`, {
+    method: 'DELETE',
+  })
+}

--- a/frontend/src/components/schedules/GeneralTab.tsx
+++ b/frontend/src/components/schedules/GeneralTab.tsx
@@ -3,6 +3,8 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { TabsContent } from '@/components/ui/tabs'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import type { ScheduleIsolationMode } from '@opencode-manager/shared/types'
 import { Info } from 'lucide-react'
 
 type GeneralTabProps = {
@@ -18,6 +20,10 @@ type GeneralTabProps = {
   modelOptions: ComboboxOption[]
   enabled: boolean
   onEnabledChange: (value: boolean) => void
+  isolationMode: ScheduleIsolationMode
+  onIsolationModeChange: (value: ScheduleIsolationMode) => void
+  branch: string
+  onBranchChange: (value: string) => void
   showRepoSelector?: boolean
   isEditing: boolean
   repoId?: number
@@ -50,6 +56,10 @@ export function GeneralTab({
   modelOptions,
   enabled,
   onEnabledChange,
+  isolationMode,
+  onIsolationModeChange,
+  branch,
+  onBranchChange,
   showRepoSelector,
   isEditing,
   repoId,
@@ -129,6 +139,38 @@ export function GeneralTab({
               <InfoHint text="Auto-run this job on its schedule while still allowing manual runs from the dashboard." />
             </div>
             <Switch checked={enabled} onCheckedChange={onEnabledChange} />
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-4">
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium">Isolation</p>
+              <InfoHint text="Run in an isolated worktree off the base branch, or inline in the main working directory." />
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
+              <div className="w-full sm:w-48">
+                <Select value={isolationMode} onValueChange={onIsolationModeChange}>
+                  <SelectTrigger id="isolation-mode">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="worktree">Worktree</SelectItem>
+                    <SelectItem value="inline">Inline</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex-1 space-y-2">
+                <Label htmlFor="schedule-branch" className={isolationMode === 'inline' ? 'text-muted-foreground' : ''}>Branch (optional)</Label>
+                <Input
+                  id="schedule-branch"
+                  value={branch}
+                  onChange={(event) => onBranchChange(event.target.value)}
+                  placeholder={isolationMode === 'inline' ? 'N/A — runs in the working directory' : 'Defaults to default branch'}
+                  disabled={isolationMode === 'inline'}
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/schedules/GeneralTab.tsx
+++ b/frontend/src/components/schedules/GeneralTab.tsx
@@ -20,6 +20,8 @@ type GeneralTabProps = {
   onEnabledChange: (value: boolean) => void
   branch: string
   onBranchChange: (value: string) => void
+  branchOptions: ComboboxOption[]
+  branchesLoading: boolean
   showRepoSelector?: boolean
   isEditing: boolean
   repoId?: number
@@ -54,6 +56,8 @@ export function GeneralTab({
   onEnabledChange,
   branch,
   onBranchChange,
+  branchOptions,
+  branchesLoading,
   showRepoSelector,
   isEditing,
   repoId,
@@ -142,11 +146,14 @@ export function GeneralTab({
               <Label htmlFor="schedule-branch">Base branch</Label>
               <InfoHint text="Scheduled runs execute in an isolated worktree branched off this base branch. Leave empty to use the repository's default branch." />
             </div>
-            <Input
-              id="schedule-branch"
+            <Combobox
               value={branch}
-              onChange={(event) => onBranchChange(event.target.value)}
-              placeholder="Defaults to default branch"
+              onChange={onBranchChange}
+              options={branchOptions}
+              placeholder={branchesLoading ? 'Loading branches…' : 'Defaults to default branch'}
+              disabled={branchesLoading}
+              allowCustomValue={false}
+              showClear
             />
           </div>
         </div>

--- a/frontend/src/components/schedules/GeneralTab.tsx
+++ b/frontend/src/components/schedules/GeneralTab.tsx
@@ -3,8 +3,6 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { TabsContent } from '@/components/ui/tabs'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import type { ScheduleIsolationMode } from '@opencode-manager/shared/types'
 import { Info } from 'lucide-react'
 
 type GeneralTabProps = {
@@ -20,8 +18,6 @@ type GeneralTabProps = {
   modelOptions: ComboboxOption[]
   enabled: boolean
   onEnabledChange: (value: boolean) => void
-  isolationMode: ScheduleIsolationMode
-  onIsolationModeChange: (value: ScheduleIsolationMode) => void
   branch: string
   onBranchChange: (value: string) => void
   showRepoSelector?: boolean
@@ -56,8 +52,6 @@ export function GeneralTab({
   modelOptions,
   enabled,
   onEnabledChange,
-  isolationMode,
-  onIsolationModeChange,
   branch,
   onBranchChange,
   showRepoSelector,
@@ -143,34 +137,17 @@ export function GeneralTab({
         </div>
 
         <div className="rounded-lg border border-border bg-card p-4">
-          <div className="space-y-4">
+          <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <p className="text-sm font-medium">Isolation</p>
-              <InfoHint text="Run in an isolated worktree off the base branch, or inline in the main working directory." />
+              <Label htmlFor="schedule-branch">Base branch</Label>
+              <InfoHint text="Scheduled runs execute in an isolated worktree branched off this base branch. Leave empty to use the repository's default branch." />
             </div>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
-              <div className="w-full sm:w-48">
-                <Select value={isolationMode} onValueChange={onIsolationModeChange}>
-                  <SelectTrigger id="isolation-mode">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="worktree">Worktree</SelectItem>
-                    <SelectItem value="inline">Inline</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="flex-1 space-y-2">
-                <Label htmlFor="schedule-branch" className={isolationMode === 'inline' ? 'text-muted-foreground' : ''}>Branch (optional)</Label>
-                <Input
-                  id="schedule-branch"
-                  value={branch}
-                  onChange={(event) => onBranchChange(event.target.value)}
-                  placeholder={isolationMode === 'inline' ? 'N/A — runs in the working directory' : 'Defaults to default branch'}
-                  disabled={isolationMode === 'inline'}
-                />
-              </div>
-            </div>
+            <Input
+              id="schedule-branch"
+              value={branch}
+              onChange={(event) => onBranchChange(event.target.value)}
+              placeholder="Defaults to default branch"
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/schedules/JobDetailTab.tsx
+++ b/frontend/src/components/schedules/JobDetailTab.tsx
@@ -134,13 +134,9 @@ export function JobDetailTab({
                   <p className="text-muted-foreground">Updated</p>
                   <p className="font-medium">{formatTimestamp(selectedJob.updatedAt)}</p>
                 </div>
-                <div>
-                  <p className="text-muted-foreground">Isolation</p>
-                  <p className="font-medium capitalize">{selectedJob.isolationMode}</p>
-                </div>
                 {selectedJob.branch && (
                   <div>
-                    <p className="text-muted-foreground">Branch</p>
+                    <p className="text-muted-foreground">Base branch</p>
                     <p className="font-medium font-mono">{selectedJob.branch}</p>
                   </div>
                 )}

--- a/frontend/src/components/schedules/JobDetailTab.tsx
+++ b/frontend/src/components/schedules/JobDetailTab.tsx
@@ -134,6 +134,16 @@ export function JobDetailTab({
                   <p className="text-muted-foreground">Updated</p>
                   <p className="font-medium">{formatTimestamp(selectedJob.updatedAt)}</p>
                 </div>
+                <div>
+                  <p className="text-muted-foreground">Isolation</p>
+                  <p className="font-medium capitalize">{selectedJob.isolationMode}</p>
+                </div>
+                {selectedJob.branch && (
+                  <div>
+                    <p className="text-muted-foreground">Branch</p>
+                    <p className="font-medium font-mono">{selectedJob.branch}</p>
+                  </div>
+                )}
               </CardContent>
             </Card>
           </div>

--- a/frontend/src/components/schedules/RunHistoryCards.tsx
+++ b/frontend/src/components/schedules/RunHistoryCards.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Badge } from '@/components/ui/badge'
-import { History, Loader2, XCircle, CheckCircle2, Ban, ChevronDown } from 'lucide-react'
+import { History, Loader2, XCircle, CheckCircle2, Ban, ChevronDown, Trash2 } from 'lucide-react'
 import type { ScheduleRun } from '@opencode-manager/shared/types'
 import { getRunTone } from '@/components/schedules/schedule-utils'
 import { RunDetailPanel } from '@/components/schedules/RunDetailPanel'
@@ -12,6 +12,8 @@ interface RunHistoryCardsProps {
   onSelectRun: (id: number) => void
   onCancelRun: () => void
   cancelRunPending: boolean
+  onDeleteRun?: (runId: number) => void
+  deleteRunPending?: boolean
 }
 
 export function RunHistoryCards({
@@ -20,6 +22,8 @@ export function RunHistoryCards({
   onSelectRun,
   onCancelRun,
   cancelRunPending,
+  onDeleteRun,
+  deleteRunPending,
 }: RunHistoryCardsProps) {
   const [expandedRunId, setExpandedRunId] = useState<number | null>(null)
   const [expandedRunRepoId, setExpandedRunRepoId] = useState<number | null>(null)
@@ -85,10 +89,11 @@ export function RunHistoryCards({
                 isExpanded ? 'border-border/70' : 'border-border/70'
               } ${index === 0 ? 'mt-0' : 'mt-2'}`}
             >
+              <div className="flex items-stretch">
               <button
                 type="button"
                 onClick={() => handleCardClick(run.id, run.repoId, run.jobId)}
-                className="w-full px-3 py-2 text-left flex items-center justify-between gap-2"
+                className="min-w-0 flex-1 px-3 py-2 text-left flex items-center justify-between gap-2"
               >
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center justify-between gap-2">
@@ -122,6 +127,19 @@ export function RunHistoryCards({
                 </div>
                 <ChevronDown className={`h-6 w-6 flex-shrink-0 text-muted-foreground transition-transform duration-200 self-start ${isExpanded ? 'rotate-180' : ''}`} />
               </button>
+              {onDeleteRun && run.status !== 'running' && (
+                <button
+                  type="button"
+                  onClick={() => onDeleteRun(run.id)}
+                  disabled={deleteRunPending}
+                  title="Delete run"
+                  aria-label="Delete run"
+                  className="flex items-center px-2.5 text-muted-foreground transition-colors hover:text-red-400 disabled:opacity-50"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+              </div>
               {isExpanded && (
                 <div className="border-t border-border/60 flex flex-col" style={{ maxHeight: 'calc(100vh - 200px)' }}>
                   <div className="flex flex-col min-h-0 flex-1 overflow-hidden">

--- a/frontend/src/components/schedules/RunHistoryCards.tsx
+++ b/frontend/src/components/schedules/RunHistoryCards.tsx
@@ -101,7 +101,21 @@ export function RunHistoryCards({
                   <p className="mt-2 truncate text-sm font-medium leading-tight">
                     {run.sessionTitle ?? 'No session recorded'}
                   </p>
-                  <p className="mt-0.5 text-xs text-muted-foreground">{new Date(run.startedAt).toLocaleString()}</p>
+                  <div className="mt-0.5 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+                    <span>{new Date(run.startedAt).toLocaleString()}</span>
+                    {run.runBranch && (
+                      <>
+                        <span aria-hidden="true">•</span>
+                        <span className="font-mono">{run.runBranch}{run.commitHash ? ` @ ${run.commitHash.slice(0, 7)}` : ''}</span>
+                      </>
+                    )}
+                    {run.runBranch && !run.commitHash && run.status !== 'running' && (
+                      <>
+                        <span aria-hidden="true">•</span>
+                        <span className="italic">No changes committed</span>
+                      </>
+                    )}
+                  </div>
                   {run.errorText && (
                     <p className="mt-0.5 truncate text-xs text-red-400/80">{run.errorText}</p>
                   )}

--- a/frontend/src/components/schedules/RunHistoryTab.tsx
+++ b/frontend/src/components/schedules/RunHistoryTab.tsx
@@ -1,6 +1,7 @@
 import type { ScheduleJob, ScheduleRun } from '@opencode-manager/shared/types'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import { History, Loader2 } from 'lucide-react'
+import { History, Loader2, Trash2 } from 'lucide-react'
 import { RunHistoryCards, RunDetailPanel } from '@/components/schedules'
 
 interface RunHistoryTabProps {
@@ -13,6 +14,10 @@ interface RunHistoryTabProps {
   onSelectRun: (id: number) => void
   onCancelRun: () => void
   cancelRunPending: boolean
+  onClearHistory: () => void
+  clearHistoryPending: boolean
+  onDeleteRun: (runId: number) => void
+  deleteRunPending: boolean
 }
 
 export function RunHistoryTab({
@@ -25,6 +30,10 @@ export function RunHistoryTab({
   selectedRunLoading,
   onCancelRun,
   cancelRunPending,
+  onClearHistory,
+  clearHistoryPending,
+  onDeleteRun,
+  deleteRunPending,
 }: RunHistoryTabProps) {
   if (!selectedJob) {
     if (selectedRunLoading) {
@@ -49,6 +58,18 @@ export function RunHistoryTab({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex items-center justify-between gap-2 pt-2">
+        <p className="text-sm font-medium text-muted-foreground">Run history</p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onClearHistory}
+          disabled={clearHistoryPending || !runs?.length}
+        >
+          {clearHistoryPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+          Clear history
+        </Button>
+      </div>
       <div className="min-h-0 flex-1 overflow-hidden pt-2 xl:gap-4 xl:grid xl:grid-cols-[320px_minmax(0,1fr)] xl:grid-rows-1">
         <RunHistoryCards
           runs={runs}
@@ -56,6 +77,8 @@ export function RunHistoryTab({
           onSelectRun={onSelectRun}
           onCancelRun={onCancelRun}
           cancelRunPending={cancelRunPending}
+          onDeleteRun={onDeleteRun}
+          deleteRunPending={deleteRunPending}
         />
 
         <div className="hidden xl:flex min-h-0 flex-col overflow-hidden rounded-xl border border-border/60 bg-background/60 p-4">

--- a/frontend/src/components/schedules/ScheduleJobDialog.assistant.test.tsx
+++ b/frontend/src/components/schedules/ScheduleJobDialog.assistant.test.tsx
@@ -38,6 +38,7 @@ vi.mock('@/api/settings', () => ({
 
 vi.mock('@/api/repos', () => ({
   listRepos: () => Promise.resolve([]),
+  listBranches: () => Promise.resolve({ branches: [], status: { ahead: 0, behind: 0 } }),
 }))
 
 function createWrapper() {

--- a/frontend/src/components/schedules/ScheduleJobDialog.tsx
+++ b/frontend/src/components/schedules/ScheduleJobDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import type { CreateScheduleJobRequest, PromptTemplate, ScheduleJob } from '@opencode-manager/shared/types'
+import type { CreateScheduleJobRequest, PromptTemplate, ScheduleJob, ScheduleIsolationMode } from '@opencode-manager/shared/types'
 import { getProvidersWithModels } from '@/api/providers'
 import { createOpenCodeClient } from '@/api/opencode'
 import { settingsApi } from '@/api/settings'
@@ -60,6 +60,8 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit,
   const [skillNotes, setSkillNotes] = useState('')
   const initialSkillSlugsRef = useRef<string[] | undefined>(undefined)
   const initialSkillNotesRef = useRef<string | undefined>(undefined)
+  const [isolationMode, setIsolationMode] = useState<ScheduleIsolationMode>('worktree')
+  const [branch, setBranch] = useState('')
   const [templateDialogOpen, setTemplateDialogOpen] = useState(false)
   const [editingTemplate, setEditingTemplate] = useState<PromptTemplate | undefined>(undefined)
   const [deletingTemplateId, setDeletingTemplateId] = useState<number | null>(null)
@@ -193,6 +195,8 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit,
     setSkillNotes(initialSkillNotes)
     initialSkillSlugsRef.current = initialSkillSlugs
     initialSkillNotesRef.current = initialSkillNotes
+    setIsolationMode(job?.isolationMode ?? 'worktree')
+    setBranch(job?.branch ?? '')
   }, [job, open, templates])
 
   const applyPromptTemplate = (template: PromptTemplate) => {
@@ -224,6 +228,8 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit,
       agentSlug: agentSlug.trim() || undefined,
       model: model.trim() || undefined,
       prompt: prompt.trim(),
+      isolationMode,
+      branch: isolationMode === 'inline' ? null : (branch.trim() || null),
       ...(shouldIncludeSkillMetadata ? {
         skillMetadata: skillSlugs.length > 0 || skillNotes.trim()
           ? {
@@ -293,6 +299,10 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit,
             modelOptions={modelOptions}
             enabled={enabled}
             onEnabledChange={setEnabled}
+            isolationMode={isolationMode}
+            onIsolationModeChange={setIsolationMode}
+            branch={branch}
+            onBranchChange={setBranch}
             showRepoSelector={showRepoSelector}
             isEditing={!!job}
             repoId={selectedRepoId}

--- a/frontend/src/components/schedules/ScheduleJobDialog.tsx
+++ b/frontend/src/components/schedules/ScheduleJobDialog.tsx
@@ -4,7 +4,7 @@ import type { CreateScheduleJobRequest, PromptTemplate, ScheduleJob } from '@ope
 import { getProvidersWithModels } from '@/api/providers'
 import { createOpenCodeClient } from '@/api/opencode'
 import { settingsApi } from '@/api/settings'
-import { listRepos } from '@/api/repos'
+import { listRepos, listBranches } from '@/api/repos'
 import type { Repo } from '@/api/types'
 import { OPENCODE_API_ENDPOINT } from '@/config'
 import { Button } from '@/components/ui/button'
@@ -108,6 +108,29 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit,
     enabled: open && !!showRepoSelector,
     staleTime: 5 * 60 * 1000,
   })
+
+  const effectiveRepoId = selectedRepoId ?? job?.repoId
+  const branchesEnabled = open && effectiveRepoId !== undefined && effectiveRepoId !== ASSISTANT_REPO_ID
+
+  const { data: branchData, isLoading: branchesLoading } = useQuery({
+    queryKey: ['branches', effectiveRepoId],
+    queryFn: () => listBranches(effectiveRepoId!),
+    enabled: branchesEnabled,
+    staleTime: 60 * 1000,
+  })
+
+  const branchOptions = useMemo<ComboboxOption[]>(() => {
+    const names = new Set<string>()
+    for (const gitBranch of branchData?.branches ?? []) {
+      const name = gitBranch.name.replace(/^remotes\/[^/]+\//, '')
+      if (name && name !== 'HEAD') {
+        names.add(name)
+      }
+    }
+    return Array.from(names)
+      .sort((a, b) => a.localeCompare(b))
+      .map((name) => ({ value: name, label: name }))
+  }, [branchData])
 
   const repoOptions = useMemo<ComboboxOption[]>(() => {
     const assistantOption: ComboboxOption = {
@@ -298,6 +321,8 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit,
             onEnabledChange={setEnabled}
             branch={branch}
             onBranchChange={setBranch}
+            branchOptions={branchOptions}
+            branchesLoading={branchesEnabled && branchesLoading}
             showRepoSelector={showRepoSelector}
             isEditing={!!job}
             repoId={selectedRepoId}

--- a/frontend/src/components/schedules/ScheduleJobDialog.tsx
+++ b/frontend/src/components/schedules/ScheduleJobDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import type { CreateScheduleJobRequest, PromptTemplate, ScheduleJob, ScheduleIsolationMode } from '@opencode-manager/shared/types'
+import type { CreateScheduleJobRequest, PromptTemplate, ScheduleJob } from '@opencode-manager/shared/types'
 import { getProvidersWithModels } from '@/api/providers'
 import { createOpenCodeClient } from '@/api/opencode'
 import { settingsApi } from '@/api/settings'
@@ -60,7 +60,6 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit,
   const [skillNotes, setSkillNotes] = useState('')
   const initialSkillSlugsRef = useRef<string[] | undefined>(undefined)
   const initialSkillNotesRef = useRef<string | undefined>(undefined)
-  const [isolationMode, setIsolationMode] = useState<ScheduleIsolationMode>('worktree')
   const [branch, setBranch] = useState('')
   const [templateDialogOpen, setTemplateDialogOpen] = useState(false)
   const [editingTemplate, setEditingTemplate] = useState<PromptTemplate | undefined>(undefined)
@@ -195,7 +194,6 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit,
     setSkillNotes(initialSkillNotes)
     initialSkillSlugsRef.current = initialSkillSlugs
     initialSkillNotesRef.current = initialSkillNotes
-    setIsolationMode(job?.isolationMode ?? 'worktree')
     setBranch(job?.branch ?? '')
   }, [job, open, templates])
 
@@ -228,8 +226,7 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit,
       agentSlug: agentSlug.trim() || undefined,
       model: model.trim() || undefined,
       prompt: prompt.trim(),
-      isolationMode,
-      branch: isolationMode === 'inline' ? null : (branch.trim() || null),
+      branch: branch.trim() || null,
       ...(shouldIncludeSkillMetadata ? {
         skillMetadata: skillSlugs.length > 0 || skillNotes.trim()
           ? {
@@ -299,8 +296,6 @@ export function ScheduleJobDialog({ open, onOpenChange, job, isSaving, onSubmit,
             modelOptions={modelOptions}
             enabled={enabled}
             onEnabledChange={setEnabled}
-            isolationMode={isolationMode}
-            onIsolationModeChange={setIsolationMode}
             branch={branch}
             onBranchChange={setBranch}
             showRepoSelector={showRepoSelector}

--- a/frontend/src/hooks/useSchedules.ts
+++ b/frontend/src/hooks/useSchedules.ts
@@ -2,8 +2,10 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type { CreateScheduleJobRequest, UpdateScheduleJobRequest } from '@opencode-manager/shared/types'
 import {
   cancelRepoScheduleRun,
+  clearRepoScheduleRuns,
   createRepoSchedule,
   deleteRepoSchedule,
+  deleteRepoScheduleRun,
   getRepoSchedule,
   getRepoScheduleRun,
   listAllScheduleRuns,
@@ -183,6 +185,42 @@ export function useCancelRepoScheduleRun() {
     },
     onError: (error) => {
       showToast.error(`Failed to cancel schedule run: ${error instanceof Error ? error.message : String(error)}`)
+    },
+  })
+}
+
+export function useClearRepoScheduleRuns() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ repoId, jobId }: { repoId: number; jobId: number }) => {
+      return clearRepoScheduleRuns(repoId, jobId)
+    },
+    onSuccess: (result, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['repo-schedule-runs', variables.repoId, variables.jobId] })
+      queryClient.invalidateQueries({ queryKey: ['all-schedule-runs'] })
+      showToast.success(result.cleared > 0 ? `Cleared ${result.cleared} run${result.cleared === 1 ? '' : 's'}` : 'No runs to clear')
+    },
+    onError: (error: unknown) => {
+      showToast.error(`Failed to clear run history: ${error instanceof Error ? error.message : String(error)}`)
+    },
+  })
+}
+
+export function useDeleteRepoScheduleRun() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ repoId, jobId, runId }: { repoId: number; jobId: number; runId: number }) => {
+      return deleteRepoScheduleRun(repoId, jobId, runId)
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['repo-schedule-runs', variables.repoId, variables.jobId] })
+      queryClient.invalidateQueries({ queryKey: ['all-schedule-runs'] })
+      showToast.success('Run deleted')
+    },
+    onError: (error: unknown) => {
+      showToast.error(`Failed to delete run: ${error instanceof Error ? error.message : String(error)}`)
     },
   })
 }

--- a/frontend/src/pages/Schedules.tsx
+++ b/frontend/src/pages/Schedules.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 import type { CreateScheduleJobRequest, ScheduleJob } from '@opencode-manager/shared/types'
 import {
   useCancelRepoScheduleRun,
+  useClearRepoScheduleRuns,
   useCreateRepoSchedule,
   useDeleteRepoSchedule,
+  useDeleteRepoScheduleRun,
   useRepoSchedule,
   useRepoScheduleRun,
   useRepoScheduleRuns,
@@ -61,6 +63,11 @@ export function Schedules() {
   const deleteMutation = useDeleteRepoSchedule()
   const runMutation = useRunRepoSchedule()
   const cancelRunMutation = useCancelRepoScheduleRun()
+  const clearRunsMutation = useClearRepoScheduleRuns()
+  const deleteRunMutation = useDeleteRepoScheduleRun()
+
+  const [clearRunsOpen, setClearRunsOpen] = useState(false)
+  const [runToDelete, setRunToDelete] = useState<number | null>(null)
 
   useEffect(() => {
     if (scheduleTab === 'prompts') {
@@ -215,6 +222,26 @@ export function Schedules() {
     })
   }
 
+  const handleClearHistory = () => {
+    if (jobId === null) {
+      return
+    }
+
+    clearRunsMutation.mutate({ repoId: repoId!, jobId }, {
+      onSuccess: () => setClearRunsOpen(false),
+    })
+  }
+
+  const handleConfirmDeleteRun = () => {
+    if (jobId === null || runToDelete === null) {
+      return
+    }
+
+    deleteRunMutation.mutate({ repoId: repoId!, jobId, runId: runToDelete }, {
+      onSuccess: () => setRunToDelete(null),
+    })
+  }
+
   const handleSelectJob = (id: number) => {
     selectJobAndView(id)
   }
@@ -292,6 +319,10 @@ export function Schedules() {
                 selectedRunLoading={selectedRunLoading}
                 onCancelRun={handleCancelRun}
                 cancelRunPending={cancelRunMutation.isPending}
+                onClearHistory={() => setClearRunsOpen(true)}
+                clearHistoryPending={clearRunsMutation.isPending}
+                onDeleteRun={(id) => setRunToDelete(id)}
+                deleteRunPending={deleteRunMutation.isPending}
               />
             )}
           </>
@@ -325,6 +356,26 @@ export function Schedules() {
         title="Delete Schedule"
         description="This removes the job definition and all recorded run history for it."
         isDeleting={deleteMutation.isPending}
+      />
+
+      <DeleteDialog
+        open={clearRunsOpen}
+        onOpenChange={(open) => !open && setClearRunsOpen(false)}
+        onConfirm={handleClearHistory}
+        onCancel={() => setClearRunsOpen(false)}
+        title="Clear run history"
+        description="This permanently deletes all finished runs for this schedule along with their git run branches and worktrees. A run in progress is kept. This cannot be undone."
+        isDeleting={clearRunsMutation.isPending}
+      />
+
+      <DeleteDialog
+        open={runToDelete !== null}
+        onOpenChange={(open) => !open && setRunToDelete(null)}
+        onConfirm={handleConfirmDeleteRun}
+        onCancel={() => setRunToDelete(null)}
+        title="Delete run"
+        description="This permanently deletes this run along with its git run branch and worktree. This cannot be undone."
+        isDeleting={deleteRunMutation.isPending}
       />
     </div>
   )

--- a/frontend/src/pages/Schedules.tsx
+++ b/frontend/src/pages/Schedules.tsx
@@ -348,6 +348,7 @@ export function Schedules() {
           if (!open) closeDialog()
         }}
         job={editingJob}
+        repoId={repoId}
         isSaving={createMutation.isPending || updateMutation.isPending}
         onSubmit={dialog === 'edit' ? handleUpdate : handleCreate}
       />

--- a/frontend/src/pages/Schedules.tsx
+++ b/frontend/src/pages/Schedules.tsx
@@ -69,6 +69,10 @@ export function Schedules() {
   const [clearRunsOpen, setClearRunsOpen] = useState(false)
   const [runToDelete, setRunToDelete] = useState<number | null>(null)
 
+  const clearableRuns = useMemo(() => (runs ?? []).filter((run) => run.status !== 'running'), [runs])
+  const clearableWorktrees = useMemo(() => clearableRuns.filter((run) => run.worktreePath).length, [clearableRuns])
+  const clearableBranches = useMemo(() => clearableRuns.filter((run) => run.runBranch).length, [clearableRuns])
+
   useEffect(() => {
     if (scheduleTab === 'prompts') {
       setScheduleTab('jobs')
@@ -364,7 +368,23 @@ export function Schedules() {
         onConfirm={handleClearHistory}
         onCancel={() => setClearRunsOpen(false)}
         title="Clear run history"
-        description="This permanently deletes all finished runs for this schedule along with their git run branches and worktrees. A run in progress is kept. This cannot be undone."
+        description={
+          <>
+            <p className="mb-2">This permanently deletes all <strong>{clearableRuns.length}</strong> finished run{clearableRuns.length === 1 ? '' : 's'} for this schedule.</p>
+            {clearableBranches > 0 && (
+              <p className="mb-1">Git artifacts that will be pruned:</p>
+            )}
+            <ul className="list-disc pl-5 space-y-0.5 text-sm text-muted-foreground">
+              {clearableWorktrees > 0 && (
+                <li><strong>{clearableWorktrees}</strong> worktree{clearableWorktrees === 1 ? '' : 's'}</li>
+              )}
+              {clearableBranches > 0 && (
+                <li><strong>{clearableBranches}</strong> run branch{clearableBranches === 1 ? '' : 'es'}</li>
+              )}
+            </ul>
+            <p className="mt-2">A run in progress is kept. This cannot be undone.</p>
+          </>
+        }
         isDeleting={clearRunsMutation.isPending}
       />
 

--- a/frontend/src/pages/__tests__/Schedules.test.tsx
+++ b/frontend/src/pages/__tests__/Schedules.test.tsx
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   useDeleteRepoSchedule: vi.fn(),
   useRunRepoSchedule: vi.fn(),
   useCancelRepoScheduleRun: vi.fn(),
+  useClearRepoScheduleRuns: vi.fn(),
+  useDeleteRepoScheduleRun: vi.fn(),
   useRepoActivity: vi.fn(),
   useScheduleUrlState: vi.fn(),
 }))
@@ -39,6 +41,8 @@ vi.mock('@/hooks/useSchedules', () => ({
   useDeleteRepoSchedule: mocks.useDeleteRepoSchedule,
   useRunRepoSchedule: mocks.useRunRepoSchedule,
   useCancelRepoScheduleRun: mocks.useCancelRepoScheduleRun,
+  useClearRepoScheduleRuns: mocks.useClearRepoScheduleRuns,
+  useDeleteRepoScheduleRun: mocks.useDeleteRepoScheduleRun,
 }))
 
 vi.mock('@/hooks/useRepoActivity', () => ({
@@ -129,6 +133,8 @@ describe('Schedules', () => {
     mocks.useDeleteRepoSchedule.mockReturnValue({ mutate: vi.fn(), isPending: false })
     mocks.useRunRepoSchedule.mockReturnValue({ mutate: vi.fn(), isPending: false })
     mocks.useCancelRepoScheduleRun.mockReturnValue({ mutate: vi.fn(), isPending: false })
+    mocks.useClearRepoScheduleRuns.mockReturnValue({ mutate: vi.fn(), isPending: false })
+    mocks.useDeleteRepoScheduleRun.mockReturnValue({ mutate: vi.fn(), isPending: false })
   })
 
   describe('assistant schedule target (repoId=0)', () => {

--- a/shared/src/config/defaults.ts
+++ b/shared/src/config/defaults.ts
@@ -26,6 +26,7 @@ export const DEFAULTS = {
   WORKSPACE: {
     BASE_PATH: './workspace',
     REPOS_DIR: 'repos',
+    SCHEDULE_WORKTREES_DIR: 'schedule-worktrees',
     CONFIG_DIR: '.config/opencode',
     AUTH_FILE: '.opencode/state/opencode/auth.json',
   },

--- a/shared/src/config/env.ts
+++ b/shared/src/config/env.ts
@@ -70,6 +70,7 @@ export const ENV = {
   WORKSPACE: {
     get BASE_PATH() { return resolveWorkspacePath() },
     REPOS_DIR: DEFAULTS.WORKSPACE.REPOS_DIR,
+    SCHEDULE_WORKTREES_DIR: DEFAULTS.WORKSPACE.SCHEDULE_WORKTREES_DIR,
     CONFIG_DIR: DEFAULTS.WORKSPACE.CONFIG_DIR,
     AUTH_FILE: DEFAULTS.WORKSPACE.AUTH_FILE,
   },
@@ -119,6 +120,7 @@ export const ENV = {
 
 export const getWorkspacePath = () => ENV.WORKSPACE.BASE_PATH
 export const getReposPath = () => path.join(ENV.WORKSPACE.BASE_PATH, ENV.WORKSPACE.REPOS_DIR)
+export const getScheduleWorktreesPath = () => path.join(ENV.WORKSPACE.BASE_PATH, ENV.WORKSPACE.SCHEDULE_WORKTREES_DIR)
 export const getConfigPath = () => path.join(ENV.WORKSPACE.BASE_PATH, ENV.WORKSPACE.CONFIG_DIR)
 export const getOpenCodeConfigFilePath = () => path.join(ENV.WORKSPACE.BASE_PATH, ENV.WORKSPACE.CONFIG_DIR, 'opencode.json')
 export const getAgentsMdPath = () => path.join(ENV.WORKSPACE.BASE_PATH, ENV.WORKSPACE.CONFIG_DIR, 'AGENTS.md')

--- a/shared/src/schemas/schedule.ts
+++ b/shared/src/schemas/schedule.ts
@@ -9,6 +9,9 @@ export type ScheduleRunStatus = z.infer<typeof ScheduleRunStatusSchema>
 export const ScheduleModeSchema = z.enum(['interval', 'cron'])
 export type ScheduleMode = z.infer<typeof ScheduleModeSchema>
 
+export const ScheduleIsolationModeSchema = z.enum(['worktree', 'inline'])
+export type ScheduleIsolationMode = z.infer<typeof ScheduleIsolationModeSchema>
+
 export const ScheduleSkillMetadataSchema = z.object({
   skillSlugs: z.array(z.string().min(1).max(100)).default([]),
   notes: z.string().max(2000).optional(),
@@ -29,6 +32,8 @@ export const ScheduleJobSchema = z.object({
   prompt: z.string(),
   model: z.string().nullable(),
   skillMetadata: ScheduleSkillMetadataSchema.nullable(),
+  branch: z.string().nullable(),
+  isolationMode: ScheduleIsolationModeSchema,
   createdAt: z.number(),
   updatedAt: z.number(),
   lastRunAt: z.number().nullable(),
@@ -50,6 +55,9 @@ export const ScheduleRunSchema = z.object({
   logText: z.string().nullable(),
   responseText: z.string().nullable(),
   errorText: z.string().nullable(),
+  runBranch: z.string().nullable(),
+  commitHash: z.string().nullable(),
+  worktreePath: z.string().nullable(),
 })
 export type ScheduleRun = z.infer<typeof ScheduleRunSchema>
 
@@ -61,6 +69,8 @@ const ScheduleJobBaseRequestSchema = z.object({
   prompt: z.string().min(1).max(20000),
   model: z.string().min(1).max(200).optional(),
   skillMetadata: ScheduleSkillMetadataSchema.nullable().optional(),
+  branch: z.string().min(1).max(200).nullable().optional(),
+  isolationMode: ScheduleIsolationModeSchema.optional(),
 })
 
 export const CreateScheduleJobRequestSchema = z.discriminatedUnion('scheduleMode', [
@@ -88,6 +98,8 @@ export const UpdateScheduleJobRequestSchema = z.object({
   prompt: z.string().min(1).max(20000).optional(),
   model: z.string().min(1).max(200).nullable().optional(),
   skillMetadata: ScheduleSkillMetadataSchema.nullable().optional(),
+  branch: z.string().min(1).max(200).nullable().optional(),
+  isolationMode: ScheduleIsolationModeSchema.optional(),
 })
 export type UpdateScheduleJobRequest = z.infer<typeof UpdateScheduleJobRequestSchema>
 

--- a/shared/src/schemas/schedule.ts
+++ b/shared/src/schemas/schedule.ts
@@ -9,9 +9,6 @@ export type ScheduleRunStatus = z.infer<typeof ScheduleRunStatusSchema>
 export const ScheduleModeSchema = z.enum(['interval', 'cron'])
 export type ScheduleMode = z.infer<typeof ScheduleModeSchema>
 
-export const ScheduleIsolationModeSchema = z.enum(['worktree', 'inline'])
-export type ScheduleIsolationMode = z.infer<typeof ScheduleIsolationModeSchema>
-
 export const ScheduleSkillMetadataSchema = z.object({
   skillSlugs: z.array(z.string().min(1).max(100)).default([]),
   notes: z.string().max(2000).optional(),
@@ -33,7 +30,6 @@ export const ScheduleJobSchema = z.object({
   model: z.string().nullable(),
   skillMetadata: ScheduleSkillMetadataSchema.nullable(),
   branch: z.string().nullable(),
-  isolationMode: ScheduleIsolationModeSchema,
   createdAt: z.number(),
   updatedAt: z.number(),
   lastRunAt: z.number().nullable(),
@@ -70,7 +66,6 @@ const ScheduleJobBaseRequestSchema = z.object({
   model: z.string().min(1).max(200).optional(),
   skillMetadata: ScheduleSkillMetadataSchema.nullable().optional(),
   branch: z.string().min(1).max(200).nullable().optional(),
-  isolationMode: ScheduleIsolationModeSchema.optional(),
 })
 
 export const CreateScheduleJobRequestSchema = z.discriminatedUnion('scheduleMode', [
@@ -99,7 +94,6 @@ export const UpdateScheduleJobRequestSchema = z.object({
   model: z.string().min(1).max(200).nullable().optional(),
   skillMetadata: ScheduleSkillMetadataSchema.nullable().optional(),
   branch: z.string().min(1).max(200).nullable().optional(),
-  isolationMode: ScheduleIsolationModeSchema.optional(),
 })
 export type UpdateScheduleJobRequest = z.infer<typeof UpdateScheduleJobRequestSchema>
 

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -110,7 +110,6 @@ export type {
 } from '../schemas/settings'
 
 export type {
-  ScheduleIsolationMode,
   ScheduleMode,
   ScheduleRunTriggerSource,
   ScheduleRunStatus,

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -110,6 +110,7 @@ export type {
 } from '../schemas/settings'
 
 export type {
+  ScheduleIsolationMode,
   ScheduleMode,
   ScheduleRunTriggerSource,
   ScheduleRunStatus,


### PR DESCRIPTION
Adds schedule worktree isolation, allowing scheduled jobs to run in isolated git worktrees instead of inline in the main working directory. Includes:

- New `isolationMode` field (worktree/inline) and optional `branch` field on schedule jobs
- ScheduleWorktreeManager service for worktree lifecycle (create, finalize, teardown)
- Migration 014-schedule-worktree-isolation adding runBranch, commitHash, and worktreePath columns to schedule_runs
- Branch/commit metadata displayed in run history cards and job detail tab
- UI controls in GeneralTab for isolation mode and branch selection
- Race-safe teardown guard to prevent duplicate finalization
- Recovery logic for orphaned runs with worktree paths

## Checks
- pnpm lint