### PR TITLE
fix: reconcile confirmed prompt on message fetch to clear stale send errors

### DIFF
--- a/frontend/src/hooks/useOpenCode.test.tsx
+++ b/frontend/src/hooks/useOpenCode.test.tsx
@@ -2,7 +2,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useDeleteSession, useSessionsAcrossDirectories } from './useOpenCode'
+import { useDeleteSession, useMessages, useSessionsAcrossDirectories } from './useOpenCode'
+import { useSendErrorStore } from '../stores/sendErrorStore'
 
 vi.mock('../lib/toast', () => ({
   showToast: {
@@ -262,5 +263,78 @@ describe('useSessionsAcrossDirectories', () => {
       'http://localhost/api/opencode/api/session?limit=25&order=desc&search=deploy&directory=%2Frepo',
       expect.objectContaining({ credentials: 'include' }),
     )
+  })
+})
+
+describe('useMessages send error reconciliation', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+    useSendErrorStore.setState({ errors: {}, queuedPrompts: {} })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('clears a stale network send error when fetched messages contain the prompt', async () => {
+    useSendErrorStore.getState().setError({
+      sessionID: 'session-1',
+      title: 'Error',
+      message: 'Load failed',
+      failedPrompt: 'sent while backgrounded',
+      kind: 'network',
+    })
+
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify([
+      {
+        info: { id: 'user-1', role: 'user', sessionID: 'session-1', time: { created: 1 } },
+        parts: [{ id: 'part-1', type: 'text', text: 'sent while backgrounded', messageID: 'user-1', sessionID: 'session-1' }],
+      },
+    ]), { headers: { 'Content-Type': 'application/json' } }))
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    renderHook(() => useMessages('/api/opencode', 'session-1', '/repo'), { wrapper })
+
+    await waitFor(() => {
+      expect(useSendErrorStore.getState().getError('session-1')).toBeNull()
+    })
+  })
+
+  it('keeps a network send error when fetched messages do not contain the prompt', async () => {
+    useSendErrorStore.getState().setError({
+      sessionID: 'session-1',
+      title: 'Error',
+      message: 'Load failed',
+      failedPrompt: 'missing prompt',
+      kind: 'network',
+    })
+
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify([
+      {
+        info: { id: 'user-1', role: 'user', sessionID: 'session-1', time: { created: 1 } },
+        parts: [{ id: 'part-1', type: 'text', text: 'different prompt', messageID: 'user-1', sessionID: 'session-1' }],
+      },
+    ]), { headers: { 'Content-Type': 'application/json' } }))
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    renderHook(() => useMessages('/api/opencode', 'session-1', '/repo'), { wrapper })
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+    expect(useSendErrorStore.getState().getError('session-1')).toEqual(expect.objectContaining({
+      failedPrompt: 'missing prompt',
+    }))
   })
 })

--- a/frontend/src/hooks/useOpenCode.ts
+++ b/frontend/src/hooks/useOpenCode.ts
@@ -143,6 +143,7 @@ export const useMessages = (opcodeUrl: string | null | undefined, sessionID: str
     queryKey: messagesQueryKey(opcodeUrl, sessionID, directory),
     queryFn: async () => {
       const response = await client!.listMessages(sessionID!)
+      reconcileConfirmedPrompt(sessionID!, response as MessageWithParts[])
       return response as MessageWithParts[]
     },
     enabled: !!client && !!sessionID,
@@ -154,6 +155,34 @@ export const useMessages = (opcodeUrl: string | null | undefined, sessionID: str
     refetchInterval: opts?.fallbackPoll ? 5000 : undefined,
   });
 };
+
+const getUserMessageText = (message: MessageWithParts) => {
+  if (message.info.role !== 'user') return ''
+  return message.parts
+    .map((part) => part.type === 'text' ? part.text || '' : '')
+    .join('')
+    .trim()
+}
+
+const hasUserMessageText = (messages: MessageWithParts[], prompt: string) => {
+  const expected = prompt.trim()
+  if (!expected) return false
+  return messages.some((message) => getUserMessageText(message) === expected)
+}
+
+const reconcileConfirmedPrompt = (sessionID: string, messages: MessageWithParts[]) => {
+  const sendErrorStore = useSendErrorStore.getState()
+  const sendError = sendErrorStore.getError(sessionID)
+  const queuedPrompt = sendErrorStore.queuedPrompts[sessionID]
+
+  if (sendError?.kind === 'network' && sendError.failedPrompt && hasUserMessageText(messages, sendError.failedPrompt)) {
+    sendErrorStore.clearNetworkError(sessionID)
+  }
+
+  if (queuedPrompt && hasUserMessageText(messages, queuedPrompt)) {
+    sendErrorStore.clearQueuedPrompt(sessionID)
+  }
+}
 
 export const useCreateSession = (
   opcodeUrl: string | null | undefined,

--- a/frontend/src/hooks/useOpenCode.ts
+++ b/frontend/src/hooks/useOpenCode.ts
@@ -14,6 +14,7 @@ import { showToast } from "../lib/toast";
 import { useSendErrorStore } from "../stores/sendErrorStore";
 import { useSessionStatus } from "../stores/sessionStatusStore";
 import { invalidateSessionListCaches, messagesQueryKey } from "../lib/queryInvalidation";
+import { reconcileConfirmedPrompt } from "../lib/sendErrorReconcile";
 
 type AssistantMessage = components["schemas"]["AssistantMessage"];
 
@@ -155,34 +156,6 @@ export const useMessages = (opcodeUrl: string | null | undefined, sessionID: str
     refetchInterval: opts?.fallbackPoll ? 5000 : undefined,
   });
 };
-
-const getUserMessageText = (message: MessageWithParts) => {
-  if (message.info.role !== 'user') return ''
-  return message.parts
-    .map((part) => part.type === 'text' ? part.text || '' : '')
-    .join('')
-    .trim()
-}
-
-const hasUserMessageText = (messages: MessageWithParts[], prompt: string) => {
-  const expected = prompt.trim()
-  if (!expected) return false
-  return messages.some((message) => getUserMessageText(message) === expected)
-}
-
-const reconcileConfirmedPrompt = (sessionID: string, messages: MessageWithParts[]) => {
-  const sendErrorStore = useSendErrorStore.getState()
-  const sendError = sendErrorStore.getError(sessionID)
-  const queuedPrompt = sendErrorStore.queuedPrompts[sessionID]
-
-  if (sendError?.kind === 'network' && sendError.failedPrompt && hasUserMessageText(messages, sendError.failedPrompt)) {
-    sendErrorStore.clearNetworkError(sessionID)
-  }
-
-  if (queuedPrompt && hasUserMessageText(messages, queuedPrompt)) {
-    sendErrorStore.clearQueuedPrompt(sessionID)
-  }
-}
 
 export const useCreateSession = (
   opcodeUrl: string | null | undefined,

--- a/frontend/src/lib/sendErrorReconcile.ts
+++ b/frontend/src/lib/sendErrorReconcile.ts
@@ -1,0 +1,39 @@
+import type { MessageWithParts } from '../api/types'
+import { useSendErrorStore } from '../stores/sendErrorStore'
+
+const getUserMessageText = (message: MessageWithParts): string => {
+  if (message.info.role !== 'user') return ''
+  return message.parts
+    .map((part) => (part.type === 'text' ? part.text || '' : ''))
+    .join('')
+    .trim()
+}
+
+const hasUserMessageText = (messages: MessageWithParts[], prompt: string): boolean => {
+  const expected = prompt.trim()
+  if (!expected) return false
+  return messages.some((message) => getUserMessageText(message) === expected)
+}
+
+/**
+ * Strict backstop for clearing stale send state when a prompt is confirmed delivered.
+ *
+ * The SSE `message.updated` handler is the realtime authority and clears send errors
+ * unconditionally because it only receives message metadata (text parts stream in
+ * separately). This helper runs against a fully fetched message list — where text parts
+ * are present — and clears only when the failed/queued prompt text actually appears,
+ * recovering sessions whose confirming SSE events were missed (e.g. backgrounded tab).
+ */
+export const reconcileConfirmedPrompt = (sessionID: string, messages: MessageWithParts[]): void => {
+  const sendErrorStore = useSendErrorStore.getState()
+  const sendError = sendErrorStore.getError(sessionID)
+  const queuedPrompt = sendErrorStore.queuedPrompts[sessionID]
+
+  if (sendError?.kind === 'network' && sendError.failedPrompt && hasUserMessageText(messages, sendError.failedPrompt)) {
+    sendErrorStore.clearNetworkError(sessionID)
+  }
+
+  if (queuedPrompt && hasUserMessageText(messages, queuedPrompt)) {
+    sendErrorStore.clearQueuedPrompt(sessionID)
+  }
+}


### PR DESCRIPTION
When the PWA is backgrounded, a queued send can fail locally with `Load failed` while OpenCode accepts the prompt. On resume, messages refetch successfully but the stale send error remains in `sendErrorStore`, causing the prompt input to restore already-sent text.

### Changes
- On `useMessages` refetch, reconcile fetched user messages against stored failed/queued prompts.
- Only clear the network error when the fetched history actually contains the failed prompt text.
- Also clear queued-prompt tracking when history confirms delivery.

### Tests
- Added 2 tests in `useOpenCode.test.tsx` covering both the clear and keep cases.
- Full frontend suite: 991 tests passed.
- `pnpm lint:frontend` — passed.