### PR TITLE
fix(mirror): reject empty commit uploads

### DIFF
--- a/backend/src/routes/internal/repo-mirror-helpers.ts
+++ b/backend/src/routes/internal/repo-mirror-helpers.ts
@@ -10,6 +10,12 @@ import { getReposPath } from '@opencode-manager/shared/config/env'
 export const MIRROR_CHUNK_SIZE = 8 * 1024 * 1024
 const STALE_UPLOAD_MS = 24 * 60 * 60 * 1000
 
+export const TOTAL_PARTS_INVALID_MESSAGE = 'totalParts must be a positive integer'
+
+export function isValidTotalParts(totalParts: number): boolean {
+  return Number.isInteger(totalParts) && totalParts >= 1
+}
+
 export interface UploadMeta {
   uploadId: string
   repoId: number
@@ -88,8 +94,8 @@ export interface ExtractResult {
 }
 
 export async function extractPartsToStaging(uploadId: string, totalParts: number, gzip: boolean): Promise<ExtractResult> {
-  if (!Number.isInteger(totalParts) || totalParts < 1) {
-    throw new Error('totalParts must be a positive integer')
+  if (!isValidTotalParts(totalParts)) {
+    throw new Error(TOTAL_PARTS_INVALID_MESSAGE)
   }
 
   const stagingParent = getStagingRoot()

--- a/backend/src/routes/internal/repo-mirror-helpers.ts
+++ b/backend/src/routes/internal/repo-mirror-helpers.ts
@@ -88,6 +88,10 @@ export interface ExtractResult {
 }
 
 export async function extractPartsToStaging(uploadId: string, totalParts: number, gzip: boolean): Promise<ExtractResult> {
+  if (!Number.isInteger(totalParts) || totalParts < 1) {
+    throw new Error('totalParts must be a positive integer')
+  }
+
   const stagingParent = getStagingRoot()
   mkdirSync(stagingParent, { recursive: true })
   const staging = mkdtempSync(join(stagingParent, 'recv-'))

--- a/backend/src/routes/internal/repo-mirror.ts
+++ b/backend/src/routes/internal/repo-mirror.ts
@@ -246,10 +246,11 @@ export function createInternalRepoMirrorRoutes(db: Database) {
 
     const { uploadId, totalParts, gzip } = body
     if (!uploadId) return c.json({ error: 'uploadId required' }, 400)
-    if (!Number.isInteger(totalParts) || totalParts < 0) return c.json({ error: 'totalParts must be a non-negative integer' }, 400)
+    if (!Number.isInteger(totalParts)) return c.json({ error: 'totalParts must be a positive integer' }, 400)
 
     const meta = await readUploadMeta(uploadId)
     if (!meta) return c.json({ error: 'upload session not found' }, 404)
+    if (totalParts < 1) return c.json({ error: 'totalParts must be a positive integer' }, 400)
 
     let backupDir: string | undefined
     let staging: string | undefined

--- a/backend/src/routes/internal/repo-mirror.ts
+++ b/backend/src/routes/internal/repo-mirror.ts
@@ -15,6 +15,8 @@ import { getErrorMessage } from '../../utils/error-utils'
 import { safeGitOut, gitOut } from './repo-sync-helpers'
 import {
   MIRROR_CHUNK_SIZE,
+  TOTAL_PARTS_INVALID_MESSAGE,
+  isValidTotalParts,
   createUploadSession,
   readUploadMeta,
   deleteUploadSession,
@@ -246,11 +248,10 @@ export function createInternalRepoMirrorRoutes(db: Database) {
 
     const { uploadId, totalParts, gzip } = body
     if (!uploadId) return c.json({ error: 'uploadId required' }, 400)
-    if (!Number.isInteger(totalParts)) return c.json({ error: 'totalParts must be a positive integer' }, 400)
+    if (!isValidTotalParts(totalParts)) return c.json({ error: TOTAL_PARTS_INVALID_MESSAGE }, 400)
 
     const meta = await readUploadMeta(uploadId)
     if (!meta) return c.json({ error: 'upload session not found' }, 404)
-    if (totalParts < 1) return c.json({ error: 'totalParts must be a positive integer' }, 400)
 
     let backupDir: string | undefined
     let staging: string | undefined

--- a/backend/test/routes/internal/repo-mirror.test.ts
+++ b/backend/test/routes/internal/repo-mirror.test.ts
@@ -755,7 +755,7 @@ describe('internal-repo-mirror routes', () => {
       expect(delRes.status).toBe(200)
       expect(mockDeleteRepo).toHaveBeenCalledWith({}, 11)
 
-      const commitRes = await commit(app, beginJson.repoId, beginJson.uploadId, 0)
+      const commitRes = await commit(app, beginJson.repoId, beginJson.uploadId, 1)
       expect(commitRes.status).toBe(404)
     })
   })

--- a/backend/test/routes/internal/repo-mirror.test.ts
+++ b/backend/test/routes/internal/repo-mirror.test.ts
@@ -621,6 +621,22 @@ describe('internal-repo-mirror routes', () => {
       expect(res.status).toBe(404)
     })
 
+    it('rejects commit requests with zero uploaded parts', async () => {
+      const targetPath = join(getTmpRoot(), 'empty-parts-repo')
+      mockEnsureMirrorTargetPath.mockReturnValue({ localPath: 'empty-parts-repo', fullPath: targetPath })
+      mockCreateRepoRow.mockImplementation((_db: any, input: any) => ({ repo: { id: 1, fullPath: input.fullPath, localPath: input.localPath }, created: true }))
+
+      const beginRes = await begin(app, 0, { create: true, name: 'empty-parts-repo' })
+      expect(beginRes.status).toBe(200)
+      const beginJson = (await beginRes.json()) as BeginResponse
+
+      const commitRes = await commit(app, beginJson.repoId, beginJson.uploadId, 0)
+      expect(commitRes.status).toBe(400)
+      const json = (await commitRes.json()) as { error: string }
+      expect(json.error).toBe('totalParts must be a positive integer')
+      expect(mockUpdateLastPulled).not.toHaveBeenCalled()
+    })
+
     it('rolls back created DB row when commit fails on invalid tarball', async () => {
       const targetPath = join(getTmpRoot(), 'test-repo')
       mockEnsureMirrorTargetPath.mockReturnValue({ localPath: 'test-repo', fullPath: targetPath })

--- a/backend/test/services/repo-mirror-helpers.test.ts
+++ b/backend/test/services/repo-mirror-helpers.test.ts
@@ -292,3 +292,22 @@ describe('isRepoInUse', () => {
     expect(result).toBe(true)
   })
 })
+
+describe('extractPartsToStaging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tmpRoot = path.join(os.tmpdir(), `mirror-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    fs.mkdirSync(tmpRoot, { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('rejects zero-part commits before creating a staging directory', async () => {
+    const { extractPartsToStaging } = await import('../../src/routes/internal/repo-mirror-helpers')
+
+    await expect(extractPartsToStaging('upload-id', 0, false)).rejects.toThrow('totalParts must be a positive integer')
+    expect(fs.existsSync(path.join(tmpRoot, '.ocm-staging'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- reject mirror commit requests with zero uploaded parts before starting extraction
- add a defensive helper guard so direct calls cannot start tar with no stdin
- cover both route-level and helper-level zero-part behavior

## Why
`POST /api/internal/repos/:repoId/mirror/commit` accepted `totalParts: 0` as a non-negative integer. For an existing upload session, that path reached `extractPartsToStaging()`, started `tar`, and then iterated over zero parts without writing or closing stdin, leaving the request stuck instead of returning a client error.

## Validation
- `cd backend && ./node_modules/.bin/vitest run test/routes/internal/repo-mirror.test.ts test/services/repo-mirror-helpers.test.ts` (46 passed)
- `cd backend && ./node_modules/.bin/tsc --noEmit`
- `cd backend && ./node_modules/.bin/eslint . --ext .ts` (0 errors; existing `backend/src/routes/repos.test.ts` no-explicit-any warnings remain)
- `git diff --check`