### PR TITLE
fix(schedules): use /api/session for session creation on OpenCode v1.16+

### DIFF
--- a/backend/src/services/schedules.ts
+++ b/backend/src/services/schedules.ts
@@ -596,7 +596,9 @@ export class ScheduleService {
       const sessionTitle = buildSessionTitle(job)
       const sessionResponse = await this.openCodeClient.forward({
         method: 'POST',
-        path: '/session',
+        // OpenCode v1.16.0+ moved the session endpoints under the /api prefix
+        // (see PR #252). The old bare /session route returns 400 on v1.17.x.
+        path: '/api/session',
         directory: runDirectory,
         body: JSON.stringify({
           title: sessionTitle,
@@ -610,7 +612,12 @@ export class ScheduleService {
         throw new ScheduleServiceError('Failed to create OpenCode session', 502)
       }
 
-      const session = await sessionResponse.json() as SessionResponse
+      // POST /api/session wraps the session in a `data` envelope (v1.16.0+).
+      // Keep a fallback for older OpenCode servers that return the flat shape.
+      const sessionRaw = await sessionResponse.json()
+      const session: SessionResponse = sessionRaw && typeof sessionRaw === 'object' && 'data' in sessionRaw && sessionRaw.data
+        ? sessionRaw.data as SessionResponse
+        : sessionRaw as SessionResponse
       const runWithSession = updateScheduleRunMetadata(this.db, repoId, jobId, run.id, {
         sessionId: session.id,
         sessionTitle,

--- a/backend/test/services/schedules.permission.test.ts
+++ b/backend/test/services/schedules.permission.test.ts
@@ -207,7 +207,7 @@ describe('ScheduleService permission ruleset in session creation', () => {
     mocks.updateScheduleRunMetadata.mockReturnValue(runWithSession)
 
     routeForward(({ path, method }) => {
-      if (path === '/session' && method === 'POST') {
+      if (path === '/api/session' && method === 'POST') {
         return jsonResponse({ id: 'ses-perm-1' })
       }
       if (path.match(/^\/session\/[\w-]+\/message$/) && method === 'POST') {
@@ -223,7 +223,7 @@ describe('ScheduleService permission ruleset in session creation', () => {
     await service.runJob(42, 7, 'manual')
 
     const sessionCall = mocks.forward.mock.calls.find(
-      ([req]) => (req as ForwardRequest).path === '/session' && (req as ForwardRequest).method === 'POST',
+      ([req]) => (req as ForwardRequest).path === '/api/session' && (req as ForwardRequest).method === 'POST',
     )
     expect(sessionCall).toBeDefined()
     const body = JSON.parse((sessionCall![0] as ForwardRequest).body!)
@@ -247,7 +247,7 @@ describe('ScheduleService permission ruleset in session creation', () => {
     mocks.updateScheduleRunMetadata.mockReturnValue(runWithSession)
 
     routeForward(({ path, method }) => {
-      if (path === '/session' && method === 'POST') {
+      if (path === '/api/session' && method === 'POST') {
         return jsonResponse({ id: 'ses-perm-2' })
       }
       if (path.match(/^\/session\/[\w-]+\/message$/) && method === 'POST') {
@@ -263,7 +263,7 @@ describe('ScheduleService permission ruleset in session creation', () => {
     await service.runJob(42, 7, 'manual')
 
     const sessionCall = mocks.forward.mock.calls.find(
-      ([req]) => (req as ForwardRequest).path === '/session' && (req as ForwardRequest).method === 'POST',
+      ([req]) => (req as ForwardRequest).path === '/api/session' && (req as ForwardRequest).method === 'POST',
     )
     expect(sessionCall).toBeDefined()
     const body = JSON.parse((sessionCall![0] as ForwardRequest).body!)
@@ -286,7 +286,7 @@ describe('ScheduleService permission ruleset in session creation', () => {
     mocks.updateScheduleRunMetadata.mockReturnValue(runWithSession)
 
     routeForward(({ path, method }) => {
-      if (path === '/session' && method === 'POST') {
+      if (path === '/api/session' && method === 'POST') {
         return jsonResponse({ id: 'ses-perm-3' })
       }
       if (path.match(/^\/session\/[\w-]+\/message$/) && method === 'POST') {
@@ -302,7 +302,7 @@ describe('ScheduleService permission ruleset in session creation', () => {
     await service.runJob(42, 7, 'manual')
 
     const sessionCall = mocks.forward.mock.calls.find(
-      ([req]) => (req as ForwardRequest).path === '/session' && (req as ForwardRequest).method === 'POST',
+      ([req]) => (req as ForwardRequest).path === '/api/session' && (req as ForwardRequest).method === 'POST',
     )
     expect(sessionCall).toBeDefined()
     const body = JSON.parse((sessionCall![0] as ForwardRequest).body!)

--- a/backend/test/services/schedules.test.ts
+++ b/backend/test/services/schedules.test.ts
@@ -213,7 +213,7 @@ describe('ScheduleService', () => {
 
     mocks.updateScheduleRunMetadata.mockReturnValue(runWithSession)
     routeForward(({ path, method }) => {
-      if (path === '/session' && method === 'POST') {
+      if (path === '/api/session' && method === 'POST') {
         return Promise.resolve(jsonResponse({ id: 'ses-run-1' }))
       }
 
@@ -270,7 +270,7 @@ describe('ScheduleService', () => {
     mocks.updateScheduleRunMetadata.mockReturnValue(runWithSession)
     mocks.getScheduleRunById.mockReturnValue(runWithSession)
     routeForward(({ path, method }) => {
-      if (path === '/session' && method === 'POST') {
+      if (path === '/api/session' && method === 'POST') {
         return jsonResponse({ id: 'ses-content-type' })
       }
       if (path === '/session/ses-content-type/message' && method === 'POST') {
@@ -285,7 +285,7 @@ describe('ScheduleService', () => {
       expect(mocks.forward).toHaveBeenCalledWith(
         expect.objectContaining({
           method: 'POST',
-          path: '/session',
+          path: '/api/session',
           headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
         }),
       )
@@ -311,7 +311,7 @@ describe('ScheduleService', () => {
     mocks.updateScheduleRunMetadata.mockReturnValue(runWithSession)
     mocks.getScheduleRunById.mockReturnValue(runWithSession)
     routeForward(({ path, method }) => {
-      if (path === '/session' && method === 'POST') {
+      if (path === '/api/session' && method === 'POST') {
         return Promise.resolve(jsonResponse({ id: 'ses-run-2' }))
       }
 
@@ -395,7 +395,7 @@ describe('ScheduleService', () => {
     mocks.updateScheduleRunMetadata.mockReturnValue(runWithSession)
     mocks.getScheduleRunById.mockReturnValue(runWithSession)
     routeForward(({ path, method }) => {
-      if (path === '/session' && method === 'POST') {
+      if (path === '/api/session' && method === 'POST') {
         return Promise.resolve(jsonResponse({ id: 'ses-run-6' }))
       }
 
@@ -876,7 +876,7 @@ describe('ScheduleService', () => {
             { name: 'code-review', description: 'Code review workflow', location: '/path/SKILL.md', content: 'Review instructions here' },
           ]))
         }
-        if (path === '/session' && method === 'POST') {
+        if (path === '/api/session' && method === 'POST') {
           return Promise.resolve(jsonResponse({ id: 'ses-skills-1' }))
         }
         if (path === '/session/ses-skills-1/message' && method === 'POST') {
@@ -925,7 +925,7 @@ describe('ScheduleService', () => {
             { name: 'git-release', description: 'Git release workflow', location: '/path/SKILL.md', content: 'Release instructions here' },
           ]))
         }
-        if (path === '/session' && method === 'POST') {
+        if (path === '/api/session' && method === 'POST') {
           return Promise.resolve(jsonResponse({ id: 'ses-skills-2' }))
         }
         if (path === '/session/ses-skills-2/message' && method === 'POST') {
@@ -968,7 +968,7 @@ describe('ScheduleService', () => {
 
       let capturedPromptBody: string | undefined
       routeForward(({ path, method, body }) => {
-        if (path === '/session' && method === 'POST') {
+        if (path === '/api/session' && method === 'POST') {
           return Promise.resolve(jsonResponse({ id: 'ses-skills-3' }))
         }
         if (path === '/session/ses-skills-3/message' && method === 'POST') {
@@ -1012,7 +1012,7 @@ describe('ScheduleService', () => {
         if (path === '/skill' && method === 'GET') {
           return Promise.resolve(new Response('error', { status: 500 }))
         }
-        if (path === '/session' && method === 'POST') {
+        if (path === '/api/session' && method === 'POST') {
           return Promise.resolve(jsonResponse({ id: 'ses-skills-4' }))
         }
         if (path === '/session/ses-skills-4/message' && method === 'POST') {
@@ -1056,7 +1056,7 @@ describe('ScheduleService', () => {
         if (path === '/skill' && method === 'GET') {
           return Promise.resolve(jsonResponse([]))
         }
-        if (path === '/session' && method === 'POST') {
+        if (path === '/api/session' && method === 'POST') {
           return Promise.resolve(jsonResponse({ id: 'ses-skills-5' }))
         }
         if (path === '/session/ses-skills-5/message' && method === 'POST') {
@@ -1120,7 +1120,7 @@ describe('ScheduleService worktree isolation', () => {
     mocks.updateScheduleRunMetadata.mockReturnValue(worktreeRun)
     mocks.getScheduleRunById.mockReturnValue(worktreeRun)
     routeForward(({ path, method, directory }) => {
-      if (path === '/session' && method === 'POST') {
+      if (path === '/api/session' && method === 'POST') {
         expect(directory).toBe(worktreePath)
         return Promise.resolve(jsonResponse({ id: 'ses-wt-1' }))
       }
@@ -1160,7 +1160,7 @@ describe('ScheduleService worktree isolation', () => {
     mocks.getScheduleRunById.mockReturnValue(runWithWorktree)
 
     routeForward(({ path, method }) => {
-      if (path === '/session' && method === 'POST') {
+      if (path === '/api/session' && method === 'POST') {
         return Promise.resolve(jsonResponse({ id: 'ses-wt-1' }))
       }
       if (path === '/session/ses-wt-1/message' && method === 'POST') {
@@ -1199,7 +1199,7 @@ describe('ScheduleService worktree isolation', () => {
 
     let capturedDirectory: string | undefined
     routeForward(({ path, method, directory }) => {
-      if (path === '/session' && method === 'POST') {
+      if (path === '/api/session' && method === 'POST') {
         capturedDirectory = directory
         return Promise.resolve(jsonResponse({ id: 'ses-inline-1' }))
       }


### PR DESCRIPTION
## Summary

Every scheduled job fails with `ScheduleServiceError: Failed to create OpenCode session` (502) on OpenCode v1.17.x because the backend `ScheduleService` still calls `POST /session`, which was moved to `POST /api/session` in OpenCode v1.16.0 (see PR #252, which migrated the frontend `listSessions` to the new `/api/session` paginated route but left the backend untouched).

Closes #307.

## Root cause

Live probe against the in-container OpenCode server (v1.17.12):

| Request | Result |
|---|---|
| `POST /session`        | `400 {"_tag":"BadRequest"}` (removed) |
| `POST /api/session`    | `200`, response wrapped in `{ data: { id, ... } }` (new) |
| `POST /session/{id}/abort`    | `200` (unchanged, still works) |
| `POST /session/{id}/message`  | `200` (unchanged, still works) |
| `GET  /session/{id}/message`  | `200` (unchanged, still works) |
| `GET  /session/status`        | `200` (unchanged, still works) |

So only the session-creation root path was actually removed — all sub-routes on existing sessions are still served on bare `/session/{id}/...` by OpenCode v1.17.x (and the frontend also still uses those paths, which is why interactive sessions keep working).

## Change

`backend/src/services/schedules.ts`:
- Create-session forward path: `'/session'` → `'/api/session'`
- Unwrap the new `POST /api/session` response envelope (`{ data: { id, ... } }`) while keeping a fallback for older OpenCode servers that still return the flat `{ id, ... }` shape.

Sub-routes (`/session/{id}/abort`, `/session/{id}/message`, `/session/status`) are deliberately left on the bare `/session/...` prefix — they are still served by OpenCode v1.17.x and the frontend uses the same paths.

## Tests

- Updated all test mocks/assertions that matched `path === '/session' && method === 'POST'` to expect `path === '/api/session'`.
- Existing flat-shape mocks (`jsonResponse({ id: 'ses-...' })`) are left as-is — they exercise the flat-shape fallback in the new unwrap code.
- `pnpm run typecheck` — clean.
- `pnpm exec vitest run test/services/schedules.test.ts test/services/schedules.permission.test.ts` — **48/48 passed**.
- `pnpm run lint` — 0 errors (25 pre-existing `no-explicit-any` warnings, unrelated).

## Notes

- The `RestartCoordinator` (`opencode-restart-coordinator.ts`) uses `/session/{id}/abort` and `/session/{id}/prompt_async` — both confirmed working on v1.17.12, so untouched here.
- The OpenCode binary pulled by `Dockerfile` is `anomalyco/opencode` (the manager bundles `OPENCODE_VERSION=latest`). The v0.14.6 image shipped with v1.17.12, which is where this regression surfaced for schedule users.