### PR TITLE
fix(schedules): use array-based permission ruleset format for OpenCode v1.16+

### DIFF
--- a/backend/test/services/schedule-permissions.test.ts
+++ b/backend/test/services/schedule-permissions.test.ts
@@ -5,26 +5,26 @@ describe('buildSchedulePermissionRuleset', () => {
   it('returns the allow-all baseline with default deny rules when given null', () => {
     const result = buildSchedulePermissionRuleset(null)
 
-    expect(result['*']).toBe('allow')
-    expect(result.external_directory).toBe('deny')
+    expect(result[0]).toEqual({ permission: '*', pattern: '*', action: 'allow' })
+    expect(result).toContainEqual({ permission: 'external_directory', pattern: '*', action: 'deny' })
     for (const pattern of DEFAULT_DESTRUCTIVE_BASH_PATTERNS) {
-      expect(result.bash?.[pattern]).toBe('deny')
+      expect(result).toContainEqual({ permission: 'bash', pattern, action: 'deny' })
     }
   })
 
   it('returns only the allow-all baseline when all permissions are granted', () => {
     const result = buildSchedulePermissionRuleset({ allowExternalDirectory: true, bashDenyPatterns: [] })
 
-    expect(result).toEqual({ '*': 'allow' })
+    expect(result).toEqual([{ permission: '*', pattern: '*', action: 'allow' }])
   })
 
   it('includes a single custom bash deny pattern alongside external_directory deny', () => {
     const result = buildSchedulePermissionRuleset({ allowExternalDirectory: false, bashDenyPatterns: ['rm -rf *'] })
 
-    expect(result).toEqual({
-      '*': 'allow',
-      external_directory: 'deny',
-      bash: { 'rm -rf *': 'deny' },
-    })
+    expect(result).toEqual([
+      { permission: '*', pattern: '*', action: 'allow' },
+      { permission: 'external_directory', pattern: '*', action: 'deny' },
+      { permission: 'bash', pattern: 'rm -rf *', action: 'deny' },
+    ])
   })
 })

--- a/backend/test/services/schedules.permission.test.ts
+++ b/backend/test/services/schedules.permission.test.ts
@@ -309,6 +309,6 @@ describe('ScheduleService permission ruleset in session creation', () => {
     expect(body.title).toBe('Scheduled: Weekly engineering summary')
     expect(body.agent).toBe('my-agent')
     expect(body.permission).toBeDefined()
-    expect(body.permission['*']).toBe('allow')
+    expect(body.permission[0]).toEqual({ permission: '*', pattern: '*', action: 'allow' })
   })
 })

--- a/shared/src/schemas/schedule.ts
+++ b/shared/src/schemas/schedule.ts
@@ -38,35 +38,39 @@ export type SchedulePermissionConfig = z.infer<typeof SchedulePermissionConfigSc
 
 export type SchedulePermissionAction = 'allow' | 'deny' | 'ask'
 
-export interface SchedulePermissionRuleset {
-  '*': SchedulePermissionAction
-  external_directory?: SchedulePermissionAction
-  bash?: Record<string, SchedulePermissionAction>
+/**
+ * A single OpenCode session permission rule. `permission` is the tool name
+ * (e.g. `bash`, `external_directory`, or `*` for all), `pattern` is the glob
+ * matched against the tool argument, and `action` is the resulting decision.
+ */
+export interface SchedulePermissionRule {
+  permission: string
+  pattern: string
+  action: SchedulePermissionAction
 }
 
+export type SchedulePermissionRuleset = SchedulePermissionRule[]
+
 /**
- * Builds an OpenCode permission config object for an unattended scheduled run.
+ * Builds the OpenCode session permission ruleset for an unattended scheduled run.
  *
- * OpenCode's config/API permission format is keyed by tool, where each value is
- * either a shorthand action or a glob-pattern -> action map (see
- * https://opencode.ai/docs/permissions). A top-level `*` sets the baseline; the
- * server merges tool entries after it and the last matching rule wins, so the
- * `bash` deny patterns override the allow-all baseline for matching commands.
+ * OpenCode's `POST /session` `permission` field expects an ordered array of
+ * `{ permission, pattern, action }` rules (`PermissionV1.Ruleset`), evaluated
+ * with last-match-wins semantics (see https://opencode.ai/docs/permissions).
+ * A leading `*`/`*` allow rule sets the allow-all baseline; the trailing
+ * `external_directory` and `bash` deny rules then override it for external
+ * directory access and matching destructive command patterns.
  */
 export function buildSchedulePermissionRuleset(
   config: SchedulePermissionConfig | null | undefined,
 ): SchedulePermissionRuleset {
   const cfg = SchedulePermissionConfigSchema.parse(config ?? {})
-  const ruleset: SchedulePermissionRuleset = { '*': 'allow' }
+  const ruleset: SchedulePermissionRuleset = [{ permission: '*', pattern: '*', action: 'allow' }]
   if (!cfg.allowExternalDirectory) {
-    ruleset.external_directory = 'deny'
+    ruleset.push({ permission: 'external_directory', pattern: '*', action: 'deny' })
   }
-  if (cfg.bashDenyPatterns.length > 0) {
-    const bash: Record<string, SchedulePermissionAction> = {}
-    for (const pattern of cfg.bashDenyPatterns) {
-      bash[pattern] = 'deny'
-    }
-    ruleset.bash = bash
+  for (const pattern of cfg.bashDenyPatterns) {
+    ruleset.push({ permission: 'bash', pattern, action: 'deny' })
   }
   return ruleset
 }


### PR DESCRIPTION
Refactor `SchedulePermissionRuleset` from object-based `{permission: action}` format to array-based `{permission, pattern, action}[]` format. Updates schema, builder, and tests to match OpenCode v1.16+ `POST /session` permission field expectations (`PermissionV1.Ruleset`).

Fixes #307