### PR TITLE
fix(frontend): add crypto.randomUUID fallback for non-secure contexts

### DIFF
--- a/frontend/src/components/message/PromptInput.tsx
+++ b/frontend/src/components/message/PromptInput.tsx
@@ -28,6 +28,7 @@ import { ModelQuickSelect } from '@/components/model/ModelQuickSelect'
 import { AgentQuickSelect } from '@/components/agent/AgentQuickSelect'
 import { VoiceStatusOverlay, type VoiceStatusOverlayState } from './VoiceStatusOverlay'
 import { detectMentionTrigger, parsePromptToParts, getFilename, filterAgentsByQuery } from '@/lib/promptParser'
+import { randomId } from '@/lib/utils'
 import { formatModelName, getProviders } from '@/api/providers'
 import { useQuery } from '@tanstack/react-query'
 
@@ -758,13 +759,6 @@ export const PromptInput = memo(forwardRef<PromptInputHandle, PromptInputProps>(
   }, [isRecording, isProcessing, transcript, interimTranscript])
 
   const addImageAttachment = (file: File) => {
-    const generateId = () => {
-      if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-        return crypto.randomUUID()
-      }
-      return `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`
-    }
-
     try {
       const reader = new FileReader()
       
@@ -777,7 +771,7 @@ export const PromptInput = memo(forwardRef<PromptInputHandle, PromptInputProps>(
           if (!dataUrl) {
             const blobUrl = URL.createObjectURL(file)
             const attachment: ImageAttachment = {
-              id: generateId(),
+              id: randomId(),
               filename: file.name,
               mime: file.type || 'image/png',
               dataUrl: blobUrl,
@@ -787,7 +781,7 @@ export const PromptInput = memo(forwardRef<PromptInputHandle, PromptInputProps>(
           }
           
           const attachment: ImageAttachment = {
-            id: generateId(),
+            id: randomId(),
             filename: file.name,
             mime: file.type || 'image/png',
             dataUrl,

--- a/frontend/src/components/settings/GitSettings.tsx
+++ b/frontend/src/components/settings/GitSettings.tsx
@@ -7,11 +7,12 @@ import { GitCredentialDialog, type GitCredentialSaveOptions } from './GitCredent
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { randomId } from '@/lib/utils'
 import type { GitCredential, GitIdentity } from '@/api/types/settings'
 import { listRepos, updateRepoGitCredential } from '@/api/repos'
 
 function ensureCredentialId(credential: GitCredential): GitCredential {
-  return credential.id ? credential : { ...credential, id: crypto.randomUUID() }
+  return credential.id ? credential : { ...credential, id: randomId() }
 }
 
 export function GitSettings() {

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { getRepoDisplayName, sanitizeForTTS } from './utils'
+import { describe, it, expect, afterEach } from 'vitest'
+import { getRepoDisplayName, sanitizeForTTS, randomId } from './utils'
 
 describe('sanitizeForTTS', () => {
   it('should handle headers', () => {
@@ -80,6 +80,41 @@ describe('sanitizeForTTS', () => {
 
   it('should handle HTML tags', () => {
     expect(sanitizeForTTS('Text with <tag>content</tag> here')).toBe('Text with content here')
+  })
+})
+
+describe('randomId', () => {
+  const originalRandomUUID = globalThis.crypto?.randomUUID
+
+  afterEach(() => {
+    if (globalThis.crypto) {
+      Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        value: originalRandomUUID,
+        configurable: true,
+        writable: true,
+      })
+    }
+  })
+
+  it('uses crypto.randomUUID when available', () => {
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+      value: () => '11111111-2222-4333-8444-555555555555',
+      configurable: true,
+      writable: true,
+    })
+    expect(randomId()).toBe('11111111-2222-4333-8444-555555555555')
+  })
+
+  it('falls back to a unique id when crypto.randomUUID is unavailable (non-secure context)', () => {
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+    const first = randomId()
+    const second = randomId()
+    expect(first).toMatch(/^[a-z0-9]+-[a-z0-9]+$/)
+    expect(first).not.toBe(second)
   })
 })
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -8,6 +8,13 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export function randomId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 11)}`
+}
+
 export const GPU_ACCELERATED_STYLE: CSSProperties = {
   transform: 'translateZ(0)',
   backfaceVisibility: 'hidden',


### PR DESCRIPTION
Introduce a shared `randomId()` helper to `frontend/src/lib/utils` that uses `crypto.randomUUID` when available and falls back to a unique id for non-secure contexts (e.g. HTTP origins where Web Crypto is unavailable). Replace the inline id generator in PromptInput and the direct `crypto.randomUUID` call in GitSettings `ensureCredentialId` with this shared helper so git credential save no longer throws in non-secure contexts.

- utils: add randomId() with crypto.randomUUID fallback
- PromptInput: replace local generateId with randomId for image attachment ids
- GitSettings: use randomId in ensureCredentialId
- Add unit tests for randomId covering both code paths