### PR TITLE
chore(frontend): make typecheck script actually check types

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",


### PR DESCRIPTION
The root tsconfig.json declares "files": [] and only project references, so tsc --noEmit resolved zero input files and always exited 0. Frontend type errors passed typecheck unnoticed; only the build script caught them via tsc -b.

Use tsc -b so the script follows the project references, matching how build already invokes it.

## Summary

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Checklist

- [ ] Code follows project style (no comments, named imports)
- [ ] TypeScript types are properly defined
- [ ] Tests added/updated (80% coverage target)
- [ ] `pnpm lint` passes locally
- [ ] `pnpm typecheck` passes locally
