### PR TITLE
fix(oauth): forward upstream error categories to clients

### DIFF
--- a/backend/src/routes/oauth.test.ts
+++ b/backend/src/routes/oauth.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Hono } from 'hono'
+import { createOAuthRoutes, classifyOAuthError } from './oauth'
+import { createStubOpenCodeClient } from '../../test/helpers/stub-opencode-client'
+
+function createTestApp(clientOverrides: Parameters<typeof createStubOpenCodeClient>[0] = {}): Hono {
+  const app = new Hono()
+  app.route('/oauth', createOAuthRoutes(createStubOpenCodeClient(clientOverrides)))
+  return app
+}
+
+describe('classifyOAuthError', () => {
+  it('returns the matched category for each known substring', () => {
+    expect(classifyOAuthError('invalid code provided', 'callback')).toBe('invalid code')
+    expect(classifyOAuthError('session has expired', 'authorize')).toBe('expired')
+    expect(classifyOAuthError('User access denied', 'authorize')).toBe('access denied')
+    expect(classifyOAuthError('upstream server error', 'callback')).toBe('server error')
+    expect(classifyOAuthError('provider not found in registry', 'authorize')).toBe('provider not found')
+    expect(classifyOAuthError('invalid method selected', 'authorize')).toBe('invalid method')
+  })
+
+  it('falls back to the phase-specific generic for unrecognized text', () => {
+    expect(classifyOAuthError('something unexpected', 'authorize')).toBe('OAuth authorization failed')
+    expect(classifyOAuthError('something unexpected', 'callback')).toBe('OAuth callback failed')
+  })
+})
+
+describe('oauth routes /auth-methods', () => {
+  it('wraps the upstream catalogue as { providers }', async () => {
+    const upstream = { anthropic: [{ type: 'oauth', label: 'Anthropic OAuth' }] }
+    const app = createTestApp({
+      forward: vi.fn(async () => new Response(JSON.stringify(upstream), { status: 200 })),
+    })
+    const res = await app.request('/oauth/auth-methods')
+    expect(res.status).toBe(200)
+    const data = (await res.json()) as { providers: typeof upstream }
+    expect(data.providers).toEqual(upstream)
+  })
+
+  it('returns 500 when upstream fails', async () => {
+    const app = createTestApp({
+      forward: vi.fn(async () => new Response('internal failure', { status: 500 })),
+    })
+    const res = await app.request('/oauth/auth-methods')
+    expect(res.status).toBe(500)
+  })
+})
+
+describe('oauth routes /:id/oauth/authorize', () => {
+  const validBody = { method: 0 }
+
+  it('forwards the validated body and returns the parsed response', async () => {
+    const upstream = {
+      url: 'https://auth.example.com',
+      method: 'auto' as const,
+      instructions: 'Open this page',
+    }
+    const forward = vi.fn(async () => new Response(JSON.stringify(upstream), { status: 200 }))
+    const app = createTestApp({ forward })
+    const res = await app.request('/oauth/openai/oauth/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual(upstream)
+    expect(forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        path: '/provider/openai/oauth/authorize',
+      }),
+    )
+  })
+
+  it('returns 400 on invalid body', async () => {
+    const app = createTestApp()
+    const res = await app.request('/oauth/openai/oauth/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('classifies known upstream error categories', async () => {
+    const cases: Array<[string, string]> = [
+      ['invalid code provided', 'invalid code'],
+      ['session expired', 'expired'],
+      ['access denied by user', 'access denied'],
+      ['server error', 'server error'],
+      ['provider not found', 'provider not found'],
+      ['invalid method index', 'invalid method'],
+    ]
+    for (const [upstreamText, expected] of cases) {
+      const app = createTestApp({
+        forward: vi.fn(async () => new Response(upstreamText, { status: 500 })),
+      })
+      const res = await app.request('/oauth/openai/oauth/authorize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validBody),
+      })
+      expect(res.status).toBe(500)
+      const body = (await res.json()) as { error: string }
+      expect(body.error).toBe(expected)
+    }
+  })
+
+  it('falls back to the generic authorize message for unknown upstream errors', async () => {
+    const app = createTestApp({
+      forward: vi.fn(async () => new Response('totally unexpected', { status: 500 })),
+    })
+    const res = await app.request('/oauth/openai/oauth/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    })
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('OAuth authorization failed')
+  })
+})
+
+describe('oauth routes /:id/oauth/callback', () => {
+  const validBody = { method: 0 }
+
+  it('forwards the validated body and returns upstream data', async () => {
+    const forward = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    const app = createTestApp({ forward })
+    const res = await app.request('/oauth/openai/oauth/callback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        path: '/provider/openai/oauth/callback',
+      }),
+    )
+  })
+
+  it('returns 400 on invalid callback body', async () => {
+    const app = createTestApp()
+    const res = await app.request('/oauth/openai/oauth/callback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ foo: 'bar' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('classifies known upstream error categories on callback failures', async () => {
+    const cases: Array<[string, string]> = [
+      ['invalid code provided', 'invalid code'],
+      ['token expired', 'expired'],
+      ['access denied', 'access denied'],
+      ['server error during exchange', 'server error'],
+      ['provider not found', 'provider not found'],
+      ['invalid method', 'invalid method'],
+    ]
+    for (const [upstreamText, expected] of cases) {
+      const app = createTestApp({
+        forward: vi.fn(async () => new Response(upstreamText, { status: 500 })),
+      })
+      const res = await app.request('/oauth/openai/oauth/callback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validBody),
+      })
+      expect(res.status).toBe(500)
+      const body = (await res.json()) as { error: string }
+      expect(body.error).toBe(expected)
+    }
+  })
+
+  it('falls back to the generic callback message for unknown upstream errors', async () => {
+    const app = createTestApp({
+      forward: vi.fn(async () => new Response('unknown boom', { status: 500 })),
+    })
+    const res = await app.request('/oauth/openai/oauth/callback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    })
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('OAuth callback failed')
+  })
+})

--- a/backend/src/routes/oauth.ts
+++ b/backend/src/routes/oauth.ts
@@ -5,10 +5,23 @@ import { logger } from '../utils/logger'
 import {
   OAuthAuthorizeRequestSchema,
   OAuthAuthorizeResponseSchema,
-  OAuthCallbackRequestSchema
+  OAuthCallbackRequestSchema,
+  OAUTH_ERROR_CATEGORIES
 } from '../../../shared/src/schemas/auth'
 import { reloadOpenCodeConfig } from '../services/opencode-restart'
 import type { OpenCodeSupervisor } from '../services/opencode-supervisor'
+
+type OAuthPhase = 'authorize' | 'callback'
+
+export function classifyOAuthError(text: string, phase: OAuthPhase): string {
+  const lower = text.toLowerCase()
+  for (const category of OAUTH_ERROR_CATEGORIES) {
+    if (lower.includes(category)) {
+      return category
+    }
+  }
+  return phase === 'authorize' ? 'OAuth authorization failed' : 'OAuth callback failed'
+}
 
 export function createOAuthRoutes(openCodeClient: OpenCodeClient, openCodeSupervisor?: OpenCodeSupervisor) {
   const app = new Hono()
@@ -29,7 +42,7 @@ export function createOAuthRoutes(openCodeClient: OpenCodeClient, openCodeSuperv
       if (!response.ok) {
         const error = await response.text()
         logger.error(`OAuth authorize failed for ${providerId}:`, error)
-        return c.json({ error: 'OAuth authorization failed' }, 500)
+        return c.json({ error: classifyOAuthError(error, 'authorize') }, 500)
       }
 
       const data = await response.json()
@@ -61,7 +74,7 @@ export function createOAuthRoutes(openCodeClient: OpenCodeClient, openCodeSuperv
       if (!response.ok) {
         const error = await response.text()
         logger.error(`OAuth callback failed for ${providerId}:`, error)
-        return c.json({ error: 'OAuth callback failed' }, 500)
+        return c.json({ error: classifyOAuthError(error, 'callback') }, 500)
       }
 
       const data = await response.json()

--- a/frontend/src/lib/oauthErrors.ts
+++ b/frontend/src/lib/oauthErrors.ts
@@ -1,4 +1,6 @@
-const ERROR_MAPPINGS: Record<string, string> = {
+import { OAUTH_ERROR_CATEGORIES, type OAuthErrorCategory } from '@opencode-manager/shared/schemas'
+
+const ERROR_MAPPINGS: Record<OAuthErrorCategory, string> = {
   'invalid code': 'Invalid authorization code. Please try the OAuth flow again.',
   'expired': 'Authorization code has expired. Please try the OAuth flow again.',
   'access denied': 'Access was denied. Please check the permissions and try again.',
@@ -14,9 +16,10 @@ export function mapOAuthError(err: unknown, context: 'authorize' | 'callback'): 
 
   if (!(err instanceof Error)) return defaultMessage
 
-  for (const [key, message] of Object.entries(ERROR_MAPPINGS)) {
-    if (err.message.toLowerCase().includes(key)) {
-      return message
+  const lower = err.message.toLowerCase()
+  for (const category of OAUTH_ERROR_CATEGORIES) {
+    if (lower.includes(category)) {
+      return ERROR_MAPPINGS[category]
     }
   }
 

--- a/shared/src/schemas/auth.ts
+++ b/shared/src/schemas/auth.ts
@@ -71,3 +71,14 @@ export const OAuthCallbackRequestSchema = z.object({
 export const ProviderAuthMethodsResponseSchema = z.object({
   providers: z.record(z.string(), z.array(ProviderAuthMethodSchema)),
 }).or(ProviderAuthMethodsSchema);
+
+export const OAUTH_ERROR_CATEGORIES = [
+  "invalid code",
+  "expired",
+  "access denied",
+  "server error",
+  "provider not found",
+  "invalid method",
+] as const;
+
+export type OAuthErrorCategory = (typeof OAUTH_ERROR_CATEGORIES)[number];


### PR DESCRIPTION
The route boundary collapsed every upstream OAuth failure into a single generic message, leaving all six mappings in the frontend's mapOAuthError unreachable. Classify the failure and forward the matched category so clients surface specific guidance.

Hoist the category list into @opencode-manager/shared as the single source of truth for both sides; the frontend map is now typed Record<OAuthErrorCategory, string> so a missing message fails typecheck.

## Summary

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Checklist

- [ ] Code follows project style (no comments, named imports)
- [ ] TypeScript types are properly defined
- [ ] Tests added/updated (80% coverage target)
- [ ] `pnpm lint` passes locally
- [ ] `pnpm typecheck` passes locally
