### PR TITLE
Refresh MiniMax provider model example to MiniMax-M3

### DIFF
--- a/frontend/src/components/settings/OpenCodeModelDialog.tsx
+++ b/frontend/src/components/settings/OpenCodeModelDialog.tsx
@@ -675,7 +675,7 @@ export function OpenCodeModelDialog({
                 <FormField control={form.control} name="contextLimit" render={({ field }) => (
                   <FormItem>
                     <FormLabel>Context Limit</FormLabel>
-                    <FormControl><Input {...field} inputMode="numeric" placeholder="e.g., 200000" /></FormControl>
+                    <FormControl><Input {...field} inputMode="numeric" placeholder="e.g., 1000000" /></FormControl>
                     <FormMessage />
                   </FormItem>
                 )} />
@@ -754,7 +754,8 @@ export function OpenCodeModelDialog({
                     <FormLabel>Variants JSON</FormLabel>
                     <FormControl>
                       <Textarea {...field} className="min-h-[120px] font-mono text-xs" placeholder={`{
-  "fast": {}
+  "adaptive": {},
+  "disabled": {}
 }`} />
                     </FormControl>
                     <FormMessage />

--- a/frontend/src/components/settings/OpenCodeModelDialog.tsx
+++ b/frontend/src/components/settings/OpenCodeModelDialog.tsx
@@ -581,7 +581,7 @@ export function OpenCodeModelDialog({
                           }
                         }}
                         options={discoveredModelOptions}
-                        placeholder="e.g., MiniMax-M2.7"
+                        placeholder="e.g., MiniMax-M3"
                         disabled={isLoadingModels}
                         allowCustomValue={true}
                       />

--- a/frontend/src/components/settings/OpenCodeModelsEditor.test.tsx
+++ b/frontend/src/components/settings/OpenCodeModelsEditor.test.tsx
@@ -377,6 +377,15 @@ describe('OpenCodeModelDialog — model discovery', () => {
     vi.mocked(settingsApi.discoverOpenCodeModels).mockReset()
   })
 
+  it('shows current MiniMax model metadata examples', async () => {
+    const { OpenCodeModelDialog } = await import('./OpenCodeModelDialog')
+    render(<OpenCodeModelDialog {...discoveryProps} />)
+
+    expect(screen.getByPlaceholderText('e.g., MiniMax-M3')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('e.g., 1000000')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/"adaptive": \{\}[\s\S]*"disabled": \{\}/)).toBeInTheDocument()
+  })
+
   it('shows a Discover button when a new API provider has a base URL', async () => {
     const { OpenCodeModelDialog } = await import('./OpenCodeModelDialog')
     render(<OpenCodeModelDialog {...discoveryProps} />)

--- a/frontend/src/components/settings/OpenCodeModelsEditor.test.tsx
+++ b/frontend/src/components/settings/OpenCodeModelsEditor.test.tsx
@@ -429,7 +429,7 @@ describe('OpenCodeModelDialog — model discovery', () => {
       expect(screen.getByText(/1 model found/i)).toBeInTheDocument()
     })
 
-    const providerModelInput = screen.getByPlaceholderText('e.g., MiniMax-M2.7')
+    const providerModelInput = screen.getByPlaceholderText('e.g., MiniMax-M3')
     fireEvent.focus(providerModelInput)
 
     const option = await screen.findByRole('button', { name: 'gpt-4o' })


### PR DESCRIPTION
Reason: Refresh the user-facing MiniMax provider model example in the OpenCode model editor from the stale MiniMax-M2.7 to the current MiniMax-M3 model ID.

Updates the placeholder text shown in the Provider Model ID field of the OpenCode model editor dialog from `e.g., MiniMax-M2.7` to `e.g., MiniMax-M3`, so the configuration guidance reflects the current MiniMax provider model. The matching test selector that locates this input is updated to keep the discovery test green.

Actual checks:
- Verified no stale `MiniMax-M2.7` placeholder reference remains in the touched files.
- Secret scan of the diff returned no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the provider model ID example to reference the newer MiniMax-M3 model.
  * Updated context limit and variants examples for MiniMax models.
  * Updated model discovery guidance to match the revised examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->