### PR TITLE
fix(session): keep cached session agent/model stable during message refetch

### DIFF
--- a/frontend/src/components/message/PromptInput.tsx
+++ b/frontend/src/components/message/PromptInput.tsx
@@ -212,6 +212,9 @@ export const PromptInput = memo(forwardRef<PromptInputHandle, PromptInputProps>(
       fileInputRef.current?.click()
     }
   }), [imageAttachments, clearSTT, isRecording, abortRecording, resetVoiceGestureState])
+  const sessionAgent = useSessionAgent(opcodeUrl, sessionID, directory)
+  const currentMode = localMode ?? sessionAgent.agent
+  const setStoredAgent = useSessionAgentStore((s) => s.setAgent)
   const sendPrompt = useSendPrompt(opcodeUrl, directory)
   const sendShell = useSendShell(opcodeUrl, directory)
   const isPromptSubmitPending = sendPrompt.isPending || sendShell.isPending
@@ -226,7 +229,7 @@ export const PromptInput = memo(forwardRef<PromptInputHandle, PromptInputProps>(
     onShowHelpDialog,
     onToggleDetails,
     onExportSession,
-    currentAgent: localMode || undefined
+    currentAgent: currentMode
   })
   
   const { files: searchResults } = useFileSearch(
@@ -1058,10 +1061,7 @@ if (isIOS && isSecureContext && navigator.clipboard && navigator.clipboard.read)
     }
   }
 
-  const sessionAgent = useSessionAgent(opcodeUrl, sessionID, directory)
-  const currentMode = localMode ?? sessionAgent.agent
-  const setStoredAgent = useSessionAgentStore((s) => s.setAgent)
-  const syncedSessionModelRef = useRef<string | undefined>(undefined)
+  const appliedSessionModelRef = useRef<string | undefined>(undefined)
 
   const client = useOpenCodeClient(opcodeUrl, directory)
   const { data: providersData } = useQuery({
@@ -1079,12 +1079,14 @@ if (isIOS && isSecureContext && navigator.clipboard && navigator.clipboard.read)
 
   useEffect(() => {
     if (!sessionModelSyncKey) return
-    if (syncedSessionModelRef.current === sessionModelSyncKey) return
     if (!sessionAgent.model) return
 
-    restoreSessionModel(sessionAgent.model)
+    const sessionSelectionKey = `${sessionModelSyncKey}|${sessionAgent.model.providerID}/${sessionAgent.model.modelID}|${sessionAgent.variant ?? ''}`
+    if (appliedSessionModelRef.current === sessionSelectionKey) return
 
-    syncedSessionModelRef.current = sessionModelSyncKey
+    appliedSessionModelRef.current = sessionSelectionKey
+
+    restoreSessionModel(sessionAgent.model)
 
     if (sessionAgent.variant) {
       setStoreVariant(sessionAgent.model, sessionAgent.variant)

--- a/frontend/src/hooks/useSessionAgent.test.tsx
+++ b/frontend/src/hooks/useSessionAgent.test.tsx
@@ -175,15 +175,15 @@ describe('useSessionAgent', () => {
     })
   })
 
-  it('does not restore model from cached messages while refetching', async () => {
+  it('keeps the cached conversation selection while messages refetch in the background', async () => {
     vi.mocked(useMessages).mockReturnValue({
       data: [
         {
           info: {
             role: 'user',
             agent: 'assistant',
-            model: { providerID: 'provider', modelID: 'stale-model' },
-            variant: 'stale-variant',
+            model: { providerID: 'provider', modelID: 'session-model' },
+            variant: 'session-variant',
           },
         },
       ],
@@ -194,7 +194,10 @@ describe('useSessionAgent', () => {
       data: { default_agent: 'code' },
     } as ReturnType<typeof useConfig>)
     vi.mocked(useAgents).mockReturnValue({
-      data: [{ name: 'code', mode: 'primary' }],
+      data: [
+        { name: 'code', mode: 'primary' },
+        { name: 'assistant', mode: 'primary' },
+      ],
       isSuccess: true,
     } as ReturnType<typeof useAgents>)
 
@@ -203,9 +206,36 @@ describe('useSessionAgent', () => {
     )
 
     await waitFor(() => {
-      expect(result.current.agent).toBe('code')
-      expect(result.current.model).toBeUndefined()
-      expect(result.current.variant).toBeUndefined()
+      expect(result.current.agent).toBe('assistant')
+      expect(result.current.model).toEqual({ providerID: 'provider', modelID: 'session-model' })
+      expect(result.current.variant).toBe('session-variant')
+    })
+  })
+
+  it('falls back to the stored session agent instead of the default while messages load', async () => {
+    useSessionAgentStore.setState({ agents: { 'session-1': 'assistant' } })
+    vi.mocked(useMessages).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+    } as ReturnType<typeof useMessages>)
+    vi.mocked(useConfig).mockReturnValue({
+      data: { default_agent: 'code' },
+    } as ReturnType<typeof useConfig>)
+    vi.mocked(useAgents).mockReturnValue({
+      data: [
+        { name: 'code', mode: 'primary' },
+        { name: 'assistant', mode: 'primary' },
+      ],
+      isSuccess: true,
+    } as ReturnType<typeof useAgents>)
+
+    const { result } = renderHook(() =>
+      useSessionAgent('http://localhost:5551', 'session-1', '/assistant')
+    )
+
+    await waitFor(() => {
+      expect(result.current.agent).toBe('assistant')
     })
   })
 

--- a/frontend/src/hooks/useSessionAgent.ts
+++ b/frontend/src/hooks/useSessionAgent.ts
@@ -62,7 +62,7 @@ export function useSessionAgent(
   sessionID: string | undefined,
   directory?: string
 ) {
-  const { data: messages, isLoading: messagesLoading, isFetching: messagesFetching } = useMessages(opcodeUrl, sessionID, directory)
+  const { data: messages } = useMessages(opcodeUrl, sessionID, directory)
   const { data: config } = useConfig(opcodeUrl, directory)
   const { data: agents, isSuccess: agentsLoaded } = useAgents(opcodeUrl, directory)
   const storedAgent = useSessionAgentStore((s) => s.agents[sessionID ?? ''] ?? null)
@@ -75,12 +75,34 @@ export function useSessionAgent(
   )
 
   const result = useMemo(() => {
-    if (messagesLoading || messagesFetching) {
-      return { agent: defaultAgent, model: undefined, variant: undefined, fromMessage: false }
+    const stabilize = (next: SessionAgentResult): SessionAgentResult => {
+      const prev = prevRef.current
+      if (
+        prev.agent === next.agent &&
+        prev.variant === next.variant &&
+        prev.fromMessage === next.fromMessage &&
+        prev.model?.providerID === next.model?.providerID &&
+        prev.model?.modelID === next.model?.modelID
+      ) {
+        return prev
+      }
+
+      prevRef.current = next
+      return next
     }
 
+    const withoutMessageAgent = (
+      model: SessionAgentResult['model'],
+      variant: string | undefined
+    ): SessionAgentResult => stabilize({
+      agent: resolveAvailableAgentName(storedAgent, agents, agentsLoaded) ?? defaultAgent,
+      model,
+      variant,
+      fromMessage: false,
+    })
+
     if (!messages || messages.length === 0) {
-      return { agent: defaultAgent, model: undefined, variant: undefined, fromMessage: false }
+      return withoutMessageAgent(undefined, undefined)
     }
 
     let latestAgent: string | undefined
@@ -101,46 +123,17 @@ export function useSessionAgent(
     }
 
     const resolvedLatestAgent = resolveAvailableAgentName(latestAgent, agents, agentsLoaded)
-    if (resolvedLatestAgent) {
-      const prev = prevRef.current
-      if (
-        prev.agent === resolvedLatestAgent &&
-        prev.variant === latestVariant &&
-        prev.model?.providerID === latestModel?.providerID &&
-        prev.model?.modelID === latestModel?.modelID
-      ) {
-        return { ...prev, fromMessage: true }
-      }
-
-      const next: SessionAgentResult = {
-        agent: resolvedLatestAgent,
-        model: latestModel,
-        variant: latestVariant,
-        fromMessage: true,
-      }
-      prevRef.current = next
-      return next
+    if (!resolvedLatestAgent) {
+      return withoutMessageAgent(latestModel, latestVariant)
     }
 
-    const resolvedStoredAgent = resolveAvailableAgentName(storedAgent, agents, agentsLoaded)
-    if (resolvedStoredAgent) {
-      const prev = prevRef.current
-      if (
-        prev.agent === resolvedStoredAgent &&
-        prev.variant === latestVariant &&
-        prev.model?.providerID === latestModel?.providerID &&
-        prev.model?.modelID === latestModel?.modelID
-      ) {
-        return { ...prev, fromMessage: false }
-      }
-
-      const next: SessionAgentResult = { agent: resolvedStoredAgent, model: latestModel, variant: latestVariant, fromMessage: false }
-      prevRef.current = next
-      return next
-    }
-
-    return { agent: defaultAgent, model: undefined, variant: undefined, fromMessage: false }
-  }, [messages, messagesLoading, messagesFetching, storedAgent, defaultAgent, agents, agentsLoaded])
+    return stabilize({
+      agent: resolvedLatestAgent,
+      model: latestModel,
+      variant: latestVariant,
+      fromMessage: true,
+    })
+  }, [messages, storedAgent, defaultAgent, agents, agentsLoaded])
 
   useEffect(() => {
     if (result.agent && sessionID && result.fromMessage) {
@@ -149,21 +142,4 @@ export function useSessionAgent(
   }, [result.agent, result.fromMessage, sessionID, setAgent])
 
   return { agent: result.agent, model: result.model, variant: result.variant }
-}
-
-export function getSessionAgentFromMessages(
-  messages: Array<{ role: string; agent?: string }> | undefined
-): string | undefined {
-  if (!messages || messages.length === 0) {
-    return undefined
-  }
-
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]
-    if (msg.role === 'user' && 'agent' in msg && msg.agent) {
-      return msg.agent
-    }
-  }
-
-  return undefined
 }


### PR DESCRIPTION
`useSessionAgent` flashed the default agent while session messages refetched in the background, and re-applied the stored session model on every session switch even when the model/variant selection had not changed. The hook now keeps the cached conversation agent/model/variant stable during refetch, falls back to the stored session agent (instead of the default) while messages are still loading, and the session-model restore guard in `PromptInput` keys on the actual agent/model/variant selection rather than the session key alone. Dead `getSessionAgentFromMessages` helper removed.

## Summary

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Checklist

- [X] Code follows project style (no comments, named imports)
- [X] TypeScript types are properly defined
- [X] Tests added/updated (80% coverage target)
- [X] `pnpm lint` passes locally
- [X] `pnpm typecheck` passes locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the selected session agent, model, and variant while messages reload.
  * Restored stored session settings instead of temporarily reverting to default configuration during loading.
  * Improved command execution to consistently use the active mode and session settings.
  * Prevented unnecessary repeated updates when session selections remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->