### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ See the [`ocm` CLI guide](docs/ocm-cli.md) for setup and commands.
 - [Development](https://chriswritescode-dev.github.io/opencode-manager/development/setup/) — Contributing and local development
 - [`ocm` CLI](docs/ocm-cli.md) — Attach local OpenCode TUI to Manager repos
 
+## ☁️ One-Click Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/opencode-manager/)
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds a RepoCloud one-click deploy button in a new "☁️ One-Click Deploy" section between the Documentation and License sections of the README.

 - New `## ☁️ One-Click Deploy` section with deploy button SVG
 - Button links to https://repocloud.io/details/opencode-manager/

## Type of Change

- [x] Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “One-Click Deploy” section to the README.
  * Included a deployment badge linking directly to the project’s deployment page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->